### PR TITLE
Handle return values of munmap and close in cleanup paths

### DIFF
--- a/src/cconfigspace.c
+++ b/src/cconfigspace.c
@@ -431,14 +431,15 @@ _ccs_object_serialize_file(
 		res, msync(buffer, buffer_size, MS_SYNC) == -1,
 		CCS_RESULT_ERROR_SYSTEM, err_file_map);
 err_file_map:
-	munmap(buffer, buffer_size);
+	if (munmap(buffer, buffer_size) == -1) { /* best-effort */
+	}
 err_file_truncated:
 	if (CCS_UNLIKELY(res < CCS_RESULT_SUCCESS))
-		if (ftruncate(fd, 0) == -1) { /* best-effort: ignore failure in
-						 error path */
+		if (ftruncate(fd, 0) == -1) { /* best-effort */
 		}
 err_file_fd:
-	close(fd);
+	if (close(fd) == -1) { /* best-effort */
+	}
 	return res;
 }
 
@@ -675,9 +676,11 @@ _ccs_object_deserialize_file(
 			err_file_map);
 	}
 err_file_map:
-	munmap((void *)buffer, buffer_size);
+	if (munmap((void *)buffer, buffer_size) == -1) { /* best-effort */
+	}
 err_file_fd:
-	close(fd);
+	if (close(fd) == -1) { /* best-effort */
+	}
 	return res;
 }
 


### PR DESCRIPTION
## Summary

- `munmap` and `close` were called without checking their return values in the cleanup labels of `_ccs_object_serialize_file` and `_ccs_object_deserialize_file`.
- While no meaningful recovery is possible in these cleanup paths, explicitly handling the return value with a best-effort `if`-check makes the intent clear and is consistent with the existing `ftruncate(fd, 0)` cleanup pattern introduced in the same functions (PR #24).

## Test plan

- [x] Builds cleanly with `--enable-strict` (`-Wall -Wextra -Wpedantic -Werror`)
- [x] `clang-format-17 --dry-run --Werror` passes on modified file
- [x] All 30 C tests pass (`make check`)
- [x] All 99 Ruby binding tests pass
- [x] All 17 Python binding tests pass
- [x] Interop samples (`test_ruby`, `test_python`) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)