### PR TITLE
Fix memory leak in oversampling retry loop

### DIFF
--- a/src/parameter_categorical.c
+++ b/src/parameter_categorical.c
@@ -172,9 +172,9 @@ _ccs_parameter_categorical_samples(
 		vs           = NULL;
 		size_t coeff = 2;
 		while (found < num_values) {
-			CCS_REFUTE(
-				coeff > 32,
-				CCS_RESULT_ERROR_SAMPLING_UNSUCCESSFUL);
+			CCS_REFUTE_ERR_GOTO(
+				err, coeff > 32,
+				CCS_RESULT_ERROR_SAMPLING_UNSUCCESSFUL, errmem);
 			size_t     buff_sz = (num_values - found) * coeff;
 			ccs_int_t *oldvs   = vs;
 			vs                 = (ccs_int_t *)realloc(

--- a/src/parameter_numerical.c
+++ b/src/parameter_numerical.c
@@ -154,9 +154,9 @@ _ccs_parameter_numerical_samples(
 		vs           = NULL;
 		size_t coeff = 2;
 		while (found < num_values) {
-			CCS_REFUTE(
-				coeff > 32,
-				CCS_RESULT_ERROR_SAMPLING_UNSUCCESSFUL);
+			CCS_REFUTE_ERR_GOTO(
+				err, coeff > 32,
+				CCS_RESULT_ERROR_SAMPLING_UNSUCCESSFUL, errmem);
 			size_t         buff_sz = (num_values - found) * coeff;
 			ccs_numeric_t *oldvs   = vs;
 			vs                     = (ccs_numeric_t *)realloc(


### PR DESCRIPTION
## Summary

- `CCS_REFUTE` in the oversampling retry loop of `_ccs_parameter_categorical_samples` and `_ccs_parameter_numerical_samples` performs a direct `return` without cleanup, leaking the dynamically allocated `vs` buffer when the retry coefficient exceeds 32.
- Replaced with `CCS_REFUTE_ERR_GOTO` to jump to the `errmem` label and properly free the buffer, consistent with the same pattern in `ccs_distribution_parameters_samples` (`distribution.c:273-275`) which already uses the correct approach.

## Test plan

- [x] Build with `--enable-strict` (`-Wall -Wextra -Wpedantic -Werror`)
- [x] All tests pass (`make check`)
- [x] `clang-format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)