### PR TITLE
Add bounds check on deserialized condition index

### DIFF
--- a/src/configuration_space_deserialize.h
+++ b/src/configuration_space_deserialize.h
@@ -74,6 +74,9 @@ _ccs_deserialize_bin_ccs_configuration_space_data(
 		size_t index;
 		CCS_VALIDATE(
 			_ccs_deserialize_bin_size(&index, buffer_size, buffer));
+		CCS_REFUTE(
+			index >= data->num_parameters,
+			CCS_RESULT_ERROR_INVALID_VALUE);
 		CCS_VALIDATE(_ccs_object_deserialize_with_opts_check(
 			(ccs_object_t *)data->conditions + index,
 			CCS_OBJECT_TYPE_EXPRESSION, CCS_SERIALIZE_FORMAT_BINARY,


### PR DESCRIPTION
## Summary

- In `_ccs_deserialize_bin_ccs_configuration_space_data`, the condition parameter index is deserialized from the input buffer and used directly to index into the `conditions` array (which has `num_parameters` slots) without bounds validation.
- A malformed or corrupted input with `index >= num_parameters` would cause an out-of-bounds array access.
- Added a `CCS_REFUTE(index >= data->num_parameters, CCS_RESULT_ERROR_INVALID_VALUE)` check before the array access.

## Test plan

- [x] Build with `--enable-strict` (`-Wall -Wextra -Wpedantic -Werror`)
- [x] All tests pass (`make check`)
- [x] `clang-format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)