### PR TITLE
Fix Doxygen typos and grammar across header files

### DIFF
--- a/include/cconfigspace/base.h
+++ b/include/cconfigspace/base.h
@@ -8,7 +8,7 @@
  * @file base.h
  * Base definition of CCS objects and types.
  * @remarks
- *   A note on thread safety: many objects in CCS are aither immutable or their
+ *   A note on thread safety: many objects in CCS are either immutable or their
  *   inner state is protected, so many calls to the API are thread safe as long
  *   as the thread holds a valid reference to a CCS object. Some CCS objects
  *   (tree APIs) are not immutable and functions modifying their inner state

--- a/include/cconfigspace/binding.h
+++ b/include/cconfigspace/binding.h
@@ -79,7 +79,7 @@ ccs_binding_get_values(
  * @param[in] binding
  * @param[in] name the name of the parameter whose value to retrieve
  * @param[out] found_ret a pointer to the an optional variable that will
- *                       hold wether a parameter named \p name was found in
+ *                       hold whether a parameter named \p name was found in
  *                       \p binding
  * @param[out] value_ret a pointer to the variable that will hold the value
  * @return #CCS_RESULT_SUCCESS on success
@@ -103,7 +103,7 @@ ccs_binding_get_value_by_name(
  * @param[in] binding
  * @param[in] parameter parameter whose value to retrieve
  * @param[out] found_ret a pointer to the an optional variable that will
- *                       hold wether the parameter was found in the \p
+ *                       hold whether the parameter was found in the \p
  *                       binding context
  * @param[out] value_ret a pointer to the variable that will hold the value
  * @return #CCS_RESULT_SUCCESS on success

--- a/include/cconfigspace/configuration.h
+++ b/include/cconfigspace/configuration.h
@@ -18,7 +18,7 @@ extern "C" {
  * @param[in] configuration_space
  * @param[in] features an optional features to use. If NULL and a feature space
  *                     was provided at \p configuration_space creation, the
- *                     deafult features of the feature space will be used.
+ *                     default features of the feature space will be used.
  * @param[in] num_values the number of provided values to initialize the
  *            configuration
  * @param[in] values an optional array of values to initialize the configuration
@@ -55,7 +55,7 @@ ccs_create_configuration(
  * @return #CCS_RESULT_SUCCESS on success
  * @return #CCS_RESULT_ERROR_INVALID_OBJECT if \p configuration is not a valid
  * CCS configuration
- * @return #CCS_RESULT_ERROR_INVALID_VALUE if \p configuration_space_ret is NULL
+ * @return #CCS_RESULT_ERROR_INVALID_VALUE if \p configuration_ret is NULL
  * @remarks
  *   This function is thread-safe
  */

--- a/include/cconfigspace/configuration_space.h
+++ b/include/cconfigspace/configuration_space.h
@@ -25,7 +25,7 @@ extern "C" {
  *                       a NULL entry in the array means no condition is
  *                       attached to the corresponding parameter.
  * @param[in] num_forbidden_clauses the number of provided forbidden clauses
- * @param[in] forbidden_clauses an array o \p num_forbidden_clauses expressions
+ * @param[in] forbidden_clauses an array of \p num_forbidden_clauses expressions
  *                              to add as forbidden clauses to the
  *                              configuration space
  * @param[in] feature_space an optional CCS feature space object
@@ -44,7 +44,7 @@ extern "C" {
  * @return #CCS_RESULT_ERROR_INVALID_PARAMETER if a parameter's type is
  * CCS_PARAMETER_TYPE_STRING; or if a parameter appears more than once in \p
  * parameters; or if two or more parameters share the same name; or if a
- * paramater is already part of another context; or if an expression references
+ * parameter is already part of another context; or if an expression references
  * a parameter that is not in \p parameters or in \p feature_space
  * @return #CCS_RESULT_ERROR_INVALID_CONFIGURATION if adding one of the
  * provided forbidden clause would render the default configuration invalid
@@ -142,7 +142,7 @@ ccs_configuration_space_get_condition(
  * valid CCS configuration space
  * @return #CCS_RESULT_ERROR_INVALID_VALUE if \p expressions is NULL and \p
  * num_expressions is greater than 0; or if \p expressions is NULL and
- * num_expressions_ret is NULL; or if num_expressions is is less than the number
+ * num_expressions_ret is NULL; or if num_expressions is less than the number
  * of parameters contained by configuration_space
  * @remarks
  *   This function is thread-safe
@@ -191,8 +191,8 @@ ccs_configuration_space_get_forbidden_clause(
  * @return #CCS_RESULT_ERROR_INVALID_OBJECT if \p configuration_space is not a
  * valid CCS configuration space
  * @return #CCS_RESULT_ERROR_INVALID_VALUE if \p expressions is NULL and \p
- * num_expressions is greater than 0; or if or if \p expressions is NULL and \p
- * num_expressions_ret is NULL; or if \p num_expressions is less than then
+ * num_expressions is greater than 0; or if \p expressions is NULL and \p
+ * num_expressions_ret is NULL; or if \p num_expressions is less than the
  * number of expressions that would be returned
  * @remarks
  *   This function is thread-safe
@@ -209,7 +209,7 @@ ccs_configuration_space_get_forbidden_clauses(
  * @param[in] configuration_space
  * @param[in] features an optional features to use. If NULL and a feature space
  *                     was provided at \p configuration_space creation, the
- *                     deafult features of the feature space will be used.
+ *                     default features of the feature space will be used.
  * @param[out] configuration_ret a pointer to the variable that will contain the
  *                               returned default configuration
  * @return #CCS_RESULT_SUCCESS on success
@@ -239,7 +239,7 @@ ccs_configuration_space_get_default_configuration(
  * @param[in] distribution_space an optional distribution space to use
  * @param[in] features an optional features to use. If NULL and a feature space
  *                     was provided at \p configuration_space creation, the
- *                     deafult features of the feature space will be used.
+ *                     default features of the feature space will be used.
  * @param[in] rng an optional rng to use
  * @param[out] configuration_ret a pointer to the variable that will contain the
  *                               returned configuration

--- a/include/cconfigspace/context.h
+++ b/include/cconfigspace/context.h
@@ -106,7 +106,7 @@ ccs_context_get_parameter_by_name(
  * @param[in] context
  * @param[in] name the name of the parameter to retrieve the index of
  * @param[out] found_ret a pointer to the an optional variable that will
- *                       hold wether a parameter named \p name was found in
+ *                       hold whether a parameter named \p name was found in
  *                       \p context
  * @param[out] index_ret a pointer to the variable that will contain the index
  *                       of parameter in the \p context
@@ -131,7 +131,7 @@ ccs_context_get_parameter_index_by_name(
  * @param[in] context
  * @param[in] parameter
  * @param[out] found_ret a pointer to the an optional variable that will
- *                       hold wether the parameter was found in the \p
+ *                       hold whether the parameter was found in the \p
  *                       context
  * @param[out] index_ret a pointer to the variable which will contain the index
  *                       of the parameter
@@ -158,7 +158,7 @@ ccs_context_get_parameter_index(
  * @param[in] parameters an array of \p num_parameters parameters to query the
  *                       index for
  * @param[out] found an optional array of \p num_parameters variables that
-		     will hold wether the parameter was found in \p context
+		     will hold whether the parameter was found in \p context
  * @param[out] indexes an array of \p num_parameters indices that will
  *                     contain the values of the parameter indices
  * @return #CCS_RESULT_SUCCESS on success

--- a/include/cconfigspace/distribution.h
+++ b/include/cconfigspace/distribution.h
@@ -127,7 +127,7 @@ ccs_create_normal_int_distribution(
  * distributions are unidimensional.
  * @param[in] mu mean of the distribution
  * @param[in] sigma standard deviation of the distribution
- * @param[in] scale an be either #CCS_SCALE_TYPE_LINEAR or
+ * @param[in] scale can be either #CCS_SCALE_TYPE_LINEAR or
  *                  #CCS_SCALE_TYPE_LOGARITHMIC
  * @param[in] quantization quantization of the results, 0 means no quantization.
  * @param[out] distribution_ret a pointer to the variable that will contain the
@@ -161,7 +161,7 @@ ccs_create_normal_float_distribution(
  * @param[in] upper the upper bound of the distribution, excluded. Must be a
  *                  ccs_int_t if \p data_type is #CCS_NUMERIC_TYPE_INT or a
  *                  ccs_float_t if \p data_type is #CCS_NUMERIC_TYPE_FLOAT
- * @param[in] scale an be either #CCS_SCALE_TYPE_LINEAR or
+ * @param[in] scale can be either #CCS_SCALE_TYPE_LINEAR or
  *                  #CCS_SCALE_TYPE_LOGARITHMIC
  * @param[in] quantization quantization of the results, 0 means no quantization.
  *                         Must be a ccs_int_t if \p data_type is
@@ -197,7 +197,7 @@ ccs_create_uniform_distribution(
  * distributions are unidimensional.
  * @param[in] lower the lower bound of the distribution, included.
  * @param[in] upper the upper bound of the distribution, excluded.
- * @param[in] scale an be either #CCS_SCALE_TYPE_LINEAR or
+ * @param[in] scale can be either #CCS_SCALE_TYPE_LINEAR or
  *                  #CCS_SCALE_TYPE_LOGARITHMIC
  * @param[in] quantization quantization of the results, 0 means no quantization.
  * @param[out] distribution_ret a pointer to the variable that will contain the
@@ -227,7 +227,7 @@ ccs_create_uniform_int_distribution(
  * distributions are unidimensional.
  * @param[in] lower the lower bound of the distribution, included.
  * @param[in] upper the upper bound of the distribution, excluded.
- * @param[in] scale an be either #CCS_SCALE_TYPE_LINEAR or
+ * @param[in] scale can be either #CCS_SCALE_TYPE_LINEAR or
  *                  #CCS_SCALE_TYPE_LOGARITHMIC
  * @param[in] quantization quantization of the results, 0 means no quantization.
  * @param[out] distribution_ret a pointer to the variable that will contain the
@@ -713,7 +713,7 @@ ccs_distribution_soa_samples(
  * @param[in] distribution
  * @param[in,out] rng the random number generator to use
  * @param[in] parameters an array of parameters. The dimension of the array
- *                       must be qual to the dimension of the distribution
+ *                       must be equal to the dimension of the distribution
  * @param[in] num_samples the number of samples to get
  * @param[out] values an array of datum values. The dimension of the array
  *                    should be the dimension of the distribution times \p
@@ -743,7 +743,7 @@ ccs_distribution_parameters_samples(
  * @param[in] distribution
  * @param[in,out] rng the random number generator to use
  * @param[in] parameters an array of parameters. The dimension of the array
- *                       must be qual to the dimension of the distribution
+ *                       must be equal to the dimension of the distribution
  * @param[out] values an array of datum of the same dimension as the
  *                    distribution. Will contain the sampled values.
  * @return #CCS_RESULT_SUCCESS on success

--- a/include/cconfigspace/distribution_space.h
+++ b/include/cconfigspace/distribution_space.h
@@ -39,7 +39,7 @@ ccs_create_distribution_space(
  * @return #CCS_RESULT_SUCCESS on success
  * @return #CCS_RESULT_ERROR_INVALID_OBJECT if \p distribution_space is not a
  * valid CCS distribution space
- * @return #CCS_RESULT_ERROR_INVALID_VALUE if \p configuration_space_ret is NULL
+ * @return #CCS_RESULT_ERROR_INVALID_VALUE if \p distribution_space_ret is NULL
  * @remarks
  *   This function is thread-safe
  */

--- a/include/cconfigspace/evaluation.h
+++ b/include/cconfigspace/evaluation.h
@@ -209,7 +209,7 @@ ccs_evaluation_get_objective_values(
  * other_evaluation are not valid CCS evaluations; or if \p evaluation and \p
  * other_evaluation do not share the same objective space; or if any of the
  * the evaluation is associated a result code different than
- * #CCS_RESULT_SUCCESS; or if both evaluations are not ot the same type
+ * #CCS_RESULT_SUCCESS; or if both evaluations are not of the same type
  * @return #CCS_RESULT_ERROR_INVALID_VALUE if \p result_ret is NULL; or if there
  * was an issue evaluating any of the objectives
  * @remarks

--- a/include/cconfigspace/expression.h
+++ b/include/cconfigspace/expression.h
@@ -651,7 +651,7 @@ ccs_expression_get_parameters(
  * @param[in] contexts an array of \p num_contexts contexts
  * @return #CCS_RESULT_SUCCESS on success
  * @return #CCS_RESULT_ERROR_INVALID_OBJECT if \p expression is not a valid CCS
- * expression; or if one of the provided ocntexts in \p contexts is not a
+ * expression; or if one of the provided contexts in \p contexts is not a
  * valid CCS context
  * @return #CCS_RESULT_ERROR_INVALID_VALUE if the expression depends on a
  * parameter and \p contexts is NULL

--- a/include/cconfigspace/feature_space.h
+++ b/include/cconfigspace/feature_space.h
@@ -27,7 +27,7 @@ extern "C" {
  * parameter
  * @return #CCS_RESULT_ERROR_INVALID_PARAMETER if a parameter appears more than
  * once in \p parameters; or if two or more parameters share the same name; or
- * if a paramater is already part of another context
+ * if a parameter is already part of another context
  * @return #CCS_RESULT_ERROR_OUT_OF_MEMORY if there was a lack of memory to
  * allocate the new feature space
  * @remarks

--- a/include/cconfigspace/features.h
+++ b/include/cconfigspace/features.h
@@ -25,7 +25,7 @@ extern "C" {
  * feature space
  * @return #CCS_RESULT_ERROR_INVALID_VALUE if \p features_ret is NULL; or if \p
  * values is NULL and \p num_values is greater than 0; or if the number of
- * values provided is not to the number of parameters in the feature space
+ * values provided is not equal to the number of parameters in the feature space
  * @return #CCS_RESULT_ERROR_OUT_OF_MEMORY if there was a lack of memory to
  * allocate the new features
  * @remarks

--- a/include/cconfigspace/interval.h
+++ b/include/cconfigspace/interval.h
@@ -22,7 +22,7 @@ struct ccs_interval_s {
 	ccs_numeric_t      upper;
 	/** Is the lower bound included in the interval */
 	ccs_bool_t         lower_included;
-	/** Is the upper boud included in the interval */
+	/** Is the upper bound included in the interval */
 	ccs_bool_t         upper_included;
 };
 
@@ -110,7 +110,7 @@ ccs_interval_equal(
  * numeric of the same type as the interval, else results are undefined.
  * @param[in] interval a pointer to the interval
  * @param[in] value the value to check for inclusion in the interval
- * @return #CCS_TRUE if the interval include the value
+ * @return #CCS_TRUE if the interval includes the value
  * @return #CCS_FALSE if the interval does not include the value; or if \p
  * interval is NULL
  * @remarks

--- a/include/cconfigspace/objective_space.h
+++ b/include/cconfigspace/objective_space.h
@@ -40,9 +40,9 @@ typedef enum ccs_objective_type_e ccs_objective_type_t;
  * @param[in] parameters an array of \p num_parameters parameters
  *                       to add to the objective space
  * @param[in] num_objectives the number of provided expressions
- * @param[in] objectives an array o \p num_objectives expressions to add as
+ * @param[in] objectives an array of \p num_objectives expressions to add as
  *                       objectives to the objective space
- * @param[in] types an array o \p num_objectives types of objectives
+ * @param[in] types an array of \p num_objectives types of objectives
  * @param[out] objective_space_ret a pointer to the variable that will hold
  *                                 the newly created objective space
  * @return #CCS_RESULT_SUCCESS on success
@@ -56,7 +56,7 @@ typedef enum ccs_objective_type_e ccs_objective_type_t;
  * expressions is not a valid CCS expression
  * @return #CCS_RESULT_ERROR_INVALID_PARAMETER if a parameter appears more than
  * once in \p parameters; or if two or more parameters share the same name; or
- * if a paramater is already part of another context; or if an expression
+ * if a parameter is already part of another context; or if an expression
  * references a parameter that is not in \p parameters or in \p search_space or
  * in \p search_space feature space if it exists
  * @return #CCS_RESULT_ERROR_OUT_OF_MEMORY if there was a lack of memory to
@@ -136,7 +136,7 @@ ccs_objective_space_get_objective(
  * CCS objective space
  * @return #CCS_RESULT_ERROR_INVALID_VALUE if \p expressions is NULL and \p
  * num_objectives is greater than 0; if \p types is NULL and \p num_objectives
- * is greater than 0; or if or if \p expressions is NULL and \p
+ * is greater than 0; or if \p expressions is NULL and \p
  * num_objectives_ret is NULL; or if \p num_objectives is less than then number
  * of expressions that would be returned
  * @remarks

--- a/include/cconfigspace/parameter.h
+++ b/include/cconfigspace/parameter.h
@@ -7,7 +7,7 @@ extern "C" {
 
 /**
  * @file parameter.h
- * Parameters are parameters the when grouped together define a tuning
+ * Parameters, when grouped together, define a tuning
  * context (see context.h). Most parameters can be sampled according to a
  * distribution's dimension (see distribution.h). Hyperparamters are immutable,
  * except from a reference counting and callback management point of view.

--- a/include/cconfigspace/tree.h
+++ b/include/cconfigspace/tree.h
@@ -38,7 +38,7 @@ ccs_create_tree(size_t arity, ccs_datum_t value, ccs_tree_t *tree_ret);
  *                       the value associated with the node.
  * @return #CCS_RESULT_SUCCESS on success
  * @return #CCS_RESULT_ERROR_INVALID_OBJECT if \p tree is not a valid CCS tree
- * @return #CCS_RESULT_ERROR_INVALID_VALUE if \p tree_ret is NULL
+ * @return #CCS_RESULT_ERROR_INVALID_VALUE if \p value_ret is NULL
  * @remarks
  *   This function is thread-safe
  */

--- a/include/cconfigspace/tree_configuration.h
+++ b/include/cconfigspace/tree_configuration.h
@@ -17,7 +17,7 @@ extern "C" {
  * @param[in] tree_space
  * @param[in] features an optional features to use. If NULL and a feature space
  *                     was provided at \p configuration_space creation, the
- *                     deafult features of the feature space will be used.
+ *                     default features of the feature space will be used.
  * @param[in] position_size the number of entries in the \p position array
  * @param[in] position an array of indexes defining a location in the tree.
  *                     can be NULL if \p position_size is 0
@@ -52,7 +52,7 @@ ccs_create_tree_configuration(
  * @return #CCS_RESULT_SUCCESS on success
  * @return #CCS_RESULT_ERROR_INVALID_OBJECT if \p configuration is not a valid
  * CCS configuration
- * @return #CCS_RESULT_ERROR_INVALID_VALUE if \p configuration_space_ret is NULL
+ * @return #CCS_RESULT_ERROR_INVALID_VALUE if \p tree_space_ret is NULL
  * @remarks
  *   This function is thread-safe
  */
@@ -141,7 +141,7 @@ ccs_tree_configuration_get_values(
  * @return #CCS_RESULT_SUCCESS on success
  * @return #CCS_RESULT_ERROR_INVALID_OBJECT if \p configuration is not a valid
  * CCS tree configuration
- * @return #CCS_RESULT_ERROR_INVALID_VALUE \p node_ret is NULL
+ * @return #CCS_RESULT_ERROR_INVALID_VALUE if \p node_ret is NULL
  * @remarks
  *   This function is thread-safe
  */

--- a/include/cconfigspace/tree_space.h
+++ b/include/cconfigspace/tree_space.h
@@ -77,7 +77,7 @@ struct ccs_dynamic_tree_space_vector_s {
 	ccs_result_t (*del)(ccs_tree_space_t tree_space);
 
 	/**
-	 * The all back that will be called when querying a missing children in
+	 * The callback that will be called when querying a missing children in
 	 * a dynamic tree space.
 	 * @param[in] tree_space the dynamic tree space
 	 * @param[in] parent the parent of the node being queried
@@ -101,7 +101,7 @@ struct ccs_dynamic_tree_space_vector_s {
 	 */
 	ccs_result_t (*serialize_user_state)(
 		ccs_tree_space_t tree_space,
-		size_t           sate_size,
+		size_t           state_size,
 		void            *state,
 		size_t          *state_size_ret);
 
@@ -251,7 +251,7 @@ ccs_tree_space_get_tree(ccs_tree_space_t tree_space, ccs_tree_t *tree_ret);
  * position is undefined and \p tree_space is a static tree space
  * @remarks
  *   This function is NOT thread-safe for dynamic tree spaces as it can
- *   instanciate new children
+ *   instantiate new children
  */
 extern ccs_result_t
 ccs_tree_space_get_node_at_position(
@@ -282,7 +282,7 @@ ccs_tree_space_get_node_at_position(
  * \p position_size is greater than 0
  * @remarks
  *   This function is NOT thread-safe for dynamic tree spaces as it can
- *   instanciate new children
+ *   instantiate new children
  */
 extern ccs_result_t
 ccs_tree_space_get_values_at_position(

--- a/include/cconfigspace/tuner.h
+++ b/include/cconfigspace/tuner.h
@@ -340,7 +340,7 @@ struct ccs_user_defined_tuner_vector_s {
 	 */
 	ccs_result_t (*serialize_user_state)(
 		ccs_tuner_t tuner,
-		size_t      sate_size,
+		size_t      state_size,
 		void       *state,
 		size_t     *state_size_ret);
 


### PR DESCRIPTION
## Summary
- Fix spelling errors, grammar issues, and incorrect parameter references in Doxygen comments across 18 public header files
- Fixes include: misspelled words (e.g., "paramater" → "parameter", "deafult" → "default", "wether" → "whether"), duplicate words ("or if or if" → "or if", "is is less" → "is less"), incorrect `\p` parameter references (e.g., `\p configuration_space_ret` → `\p configuration_ret`), and minor grammar corrections

### Files changed
`base.h`, `binding.h`, `configuration.h`, `configuration_space.h`, `context.h`, `distribution.h`, `distribution_space.h`, `evaluation.h`, `expression.h`, `feature_space.h`, `features.h`, `interval.h`, `objective_space.h`, `parameter.h`, `tree.h`, `tree_configuration.h`, `tree_space.h`, `tuner.h`

## Test plan
- [x] Build with `--enable-strict` (no warnings/errors)
- [x] All tests pass (`make check`)
- [ ] Verify generated Doxygen output renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)