### PR TITLE
Use CONCEPTS.md as the Doxygen main page

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -324,11 +324,11 @@ A **tuner** (`ccs_tuner_t`) drives the optimization loop. The core workflow:
 ```
 
 1. **Create** a tuner with an objective space.
-2. **`ccs_tuner_ask()`** — request one or more candidate configurations.
+2. `ccs_tuner_ask()` — request one or more candidate configurations.
 3. **Evaluate** each configuration externally (run your experiment/benchmark).
-4. **`ccs_create_evaluation()`** — wrap the results in an evaluation object.
-5. **`ccs_tuner_tell()`** — report evaluations back to the tuner.
-6. **`ccs_tuner_get_optima()`** — retrieve the best evaluation(s) found so far.
+4. `ccs_create_evaluation()` — wrap the results in an evaluation object.
+5. `ccs_tuner_tell()` — report evaluations back to the tuner.
+6. `ccs_tuner_get_optima()` — retrieve the best evaluation(s) found so far.
 
 Repeat steps 2-6 as many times as needed.
 

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -21,7 +21,7 @@ example see [README.md](README.md).
 
 ---
 
-## Overview
+## Overview {#overview}
 
 CCS is a C library for describing autotuning problems and autotuners. It was
 inspired by Python's [ConfigSpace](https://github.com/automl/ConfigSpace) and
@@ -44,7 +44,7 @@ through the same C interface.
 
 ---
 
-## Object Model
+## Object Model {#object-model}
 
 ### Reference Counting
 
@@ -116,7 +116,7 @@ function).
 
 ---
 
-## Parameters
+## Parameters {#parameters}
 
 A **parameter** defines one dimension of a search space. CCS provides five
 parameter types (`ccs_parameter_type_e`):
@@ -168,7 +168,7 @@ All parameter types support:
 
 ---
 
-## Distributions
+## Distributions {#distributions}
 
 A **distribution** governs how parameter values are sampled. CCS provides five
 distribution types (`ccs_distribution_type_e`):
@@ -221,7 +221,7 @@ distribution space (see [Distribution Spaces](#distribution-spaces)).
 
 ---
 
-## Configuration Spaces
+## Configuration Spaces {#configuration-spaces}
 
 A **configuration space** (`ccs_configuration_space_t`) groups parameters into a
 search space and adds optional constraints. Create one with
@@ -271,7 +271,7 @@ that associate each parameter with a concrete value. Use
 
 ---
 
-## Objective Spaces
+## Objective Spaces {#objective-spaces}
 
 An **objective space** (`ccs_objective_space_t`) defines what to optimize.
 Create one with `ccs_create_objective_space()`.
@@ -304,7 +304,7 @@ Evaluations support multi-objective comparison through
 
 ---
 
-## Tuners and the Ask/Tell Pattern
+## Tuners and the Ask/Tell Pattern {#tuners-and-the-asktell-pattern}
 
 A **tuner** (`ccs_tuner_t`) drives the optimization loop. The core workflow:
 
@@ -354,7 +354,7 @@ vector with `ask`, `tell`, `get_optima`, and other operations.
 
 ---
 
-## Feature Spaces and Contextual Tuning
+## Feature Spaces and Contextual Tuning {#feature-spaces-and-contextual-tuning}
 
 A **feature space** (`ccs_feature_space_t`) defines contextual parameters that
 describe the environment in which optimization takes place. Create one with
@@ -388,7 +388,7 @@ hardware, datasets, or other environmental factors.
 
 ---
 
-## Tree Spaces
+## Tree Spaces {#tree-spaces}
 
 A **tree space** (`ccs_tree_space_t`) defines a search space over
 tree-structured decisions, as opposed to the flat parameter vectors of a
@@ -423,7 +423,7 @@ Tree spaces can also have an attached feature space for contextual tree tuning.
 
 ---
 
-## Expressions
+## Expressions {#expressions}
 
 The **expression system** provides an AST (abstract syntax tree) for building
 conditions, forbidden clauses, and objective formulas.
@@ -460,7 +460,7 @@ using `ccs_expression_eval()`.
 
 ---
 
-## Serialization
+## Serialization {#serialization}
 
 CCS supports **binary serialization** (`CCS_SERIALIZE_FORMAT_BINARY`) for all
 object types. This lets you save and restore tuner state, configuration spaces,
@@ -480,7 +480,7 @@ callbacks can be registered with `ccs_object_set_serialize_callback()`.
 
 ---
 
-## Distribution Spaces
+## Distribution Spaces {#distribution-spaces}
 
 A **distribution space** (`ccs_distribution_space_t`) customizes how
 parameters are sampled within a configuration space. Create one with

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -1,9 +1,8 @@
 # CCS Conceptual Guide
 
 This guide explains the architecture, object model, and workflow of CCS (C
-Configuration Space and Tuning Library). For API details see the
-[Doxygen reference](https://argonne-lcf.github.io/CCS/index.html); for build
-instructions and a quick example see [README.md](README.md).
+Configuration Space and Tuning Library). For build instructions and a quick
+example see [README.md](README.md).
 
 ## Table of Contents
 

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -21,7 +21,8 @@ example see [README.md](README.md).
 
 ---
 
-## Overview {#overview}
+<a id="overview"></a>
+## Overview
 
 CCS is a C library for describing autotuning problems and autotuners. It was
 inspired by Python's [ConfigSpace](https://github.com/automl/ConfigSpace) and
@@ -44,7 +45,8 @@ through the same C interface.
 
 ---
 
-## Object Model {#object-model}
+<a id="object-model"></a>
+## Object Model
 
 ### Reference Counting
 
@@ -116,7 +118,8 @@ function).
 
 ---
 
-## Parameters {#parameters}
+<a id="parameters"></a>
+## Parameters
 
 A **parameter** defines one dimension of a search space. CCS provides five
 parameter types (`ccs_parameter_type_e`):
@@ -168,7 +171,8 @@ All parameter types support:
 
 ---
 
-## Distributions {#distributions}
+<a id="distributions"></a>
+## Distributions
 
 A **distribution** governs how parameter values are sampled. CCS provides five
 distribution types (`ccs_distribution_type_e`):
@@ -221,7 +225,8 @@ distribution space (see [Distribution Spaces](#distribution-spaces)).
 
 ---
 
-## Configuration Spaces {#configuration-spaces}
+<a id="configuration-spaces"></a>
+## Configuration Spaces
 
 A **configuration space** (`ccs_configuration_space_t`) groups parameters into a
 search space and adds optional constraints. Create one with
@@ -271,7 +276,8 @@ that associate each parameter with a concrete value. Use
 
 ---
 
-## Objective Spaces {#objective-spaces}
+<a id="objective-spaces"></a>
+## Objective Spaces
 
 An **objective space** (`ccs_objective_space_t`) defines what to optimize.
 Create one with `ccs_create_objective_space()`.
@@ -304,7 +310,8 @@ Evaluations support multi-objective comparison through
 
 ---
 
-## Tuners and the Ask/Tell Pattern {#tuners-and-the-asktell-pattern}
+<a id="tuners-and-the-asktell-pattern"></a>
+## Tuners and the Ask/Tell Pattern
 
 A **tuner** (`ccs_tuner_t`) drives the optimization loop. The core workflow:
 
@@ -354,7 +361,8 @@ vector with `ask`, `tell`, `get_optima`, and other operations.
 
 ---
 
-## Feature Spaces and Contextual Tuning {#feature-spaces-and-contextual-tuning}
+<a id="feature-spaces-and-contextual-tuning"></a>
+## Feature Spaces and Contextual Tuning
 
 A **feature space** (`ccs_feature_space_t`) defines contextual parameters that
 describe the environment in which optimization takes place. Create one with
@@ -388,7 +396,8 @@ hardware, datasets, or other environmental factors.
 
 ---
 
-## Tree Spaces {#tree-spaces}
+<a id="tree-spaces"></a>
+## Tree Spaces
 
 A **tree space** (`ccs_tree_space_t`) defines a search space over
 tree-structured decisions, as opposed to the flat parameter vectors of a
@@ -423,7 +432,8 @@ Tree spaces can also have an attached feature space for contextual tree tuning.
 
 ---
 
-## Expressions {#expressions}
+<a id="expressions"></a>
+## Expressions
 
 The **expression system** provides an AST (abstract syntax tree) for building
 conditions, forbidden clauses, and objective formulas.
@@ -460,7 +470,8 @@ using `ccs_expression_eval()`.
 
 ---
 
-## Serialization {#serialization}
+<a id="serialization"></a>
+## Serialization
 
 CCS supports **binary serialization** (`CCS_SERIALIZE_FORMAT_BINARY`) for all
 object types. This lets you save and restore tuner state, configuration spaces,
@@ -480,7 +491,8 @@ callbacks can be registered with `ccs_object_set_serialize_callback()`.
 
 ---
 
-## Distribution Spaces {#distribution-spaces}
+<a id="distribution-spaces"></a>
+## Distribution Spaces
 
 A **distribution space** (`ccs_distribution_space_t`) customizes how
 parameters are sampled within a configuration space. Create one with

--- a/Doxyfile
+++ b/Doxyfile
@@ -341,7 +341,7 @@ OPTIMIZE_OUTPUT_SLICE  = NO
 #
 # Note see also the list of default file extension mappings.
 
-EXTENSION_MAPPING      =
+EXTENSION_MAPPING      = no_extension=md
 
 # If the MARKDOWN_SUPPORT tag is enabled then doxygen pre-processes all comments
 # according to the Markdown format, which allows for more readable
@@ -909,7 +909,8 @@ WARN_LOGFILE           =
 INPUT                  = include \
                          include/cconfigspace \
                          README.md \
-                         CONCEPTS.md
+                         CONCEPTS.md \
+                         LICENSE
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/Doxyfile
+++ b/Doxyfile
@@ -908,7 +908,8 @@ WARN_LOGFILE           =
 
 INPUT                  = include \
                          include/cconfigspace \
-                         README.md
+                         README.md \
+                         CONCEPTS.md
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -1105,7 +1106,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE = README.md
+USE_MDFILE_AS_MAINPAGE = CONCEPTS.md
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing


### PR DESCRIPTION
## Summary
- Set `CONCEPTS.md` as the Doxygen main page (`USE_MDFILE_AS_MAINPAGE`) instead of `README.md`
- Add `CONCEPTS.md` to the Doxygen `INPUT` list
- Remove the self-referential Doxygen link from `CONCEPTS.md` since it is now the Doxygen landing page itself

The generated API documentation now opens with the conceptual guide covering the architecture, object model, and workflow, giving users a high-level understanding before they dive into the API reference.

## Test plan
- [x] `doxygen Doxyfile` generates without warnings
- [x] Main page (`index.html`) renders CONCEPTS.md content with all sections
- [x] `make check` passes (no functional changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)