### PR TITLE
Fix ccs_map_get_keys returning values instead of keys

### DIFF
--- a/src/map.c
+++ b/src/map.c
@@ -315,7 +315,7 @@ ccs_map_get_keys(
 		size_t            i = 0;
 		HASH_ITER(hh, map->data->map, current, tmp)
 		{
-			keys[i++] = current->value;
+			keys[i++] = current->key;
 		}
 		for (i = num_entries; i < num_keys; i++)
 			keys[i] = ccs_none;

--- a/tests/test_map.c
+++ b/tests/test_map.c
@@ -119,6 +119,23 @@ test_map(void)
 	err = ccs_map_get_pairs(map, 0, NULL, NULL, &d_count);
 	assert(err == CCS_RESULT_SUCCESS);
 	assert(d_count == 5);
+	{
+		ccs_datum_t *pair_keys =
+			(ccs_datum_t *)calloc(d_count, sizeof(ccs_datum_t));
+		ccs_datum_t *pair_values =
+			(ccs_datum_t *)calloc(d_count, sizeof(ccs_datum_t));
+		assert(pair_keys);
+		assert(pair_values);
+		err = ccs_map_get_pairs(
+			map, d_count, pair_keys, pair_values, NULL);
+		assert(err == CCS_RESULT_SUCCESS);
+		for (size_t i = 0; i < d_count; i++) {
+			assert(!ccs_datum_cmp(keys[i], pair_keys[i]));
+			assert(!ccs_datum_cmp(values[i], pair_values[i]));
+		}
+		free(pair_keys);
+		free(pair_values);
+	}
 	err = ccs_map_get_pairs(map, d_count, keys, values, NULL);
 	assert(err == CCS_RESULT_SUCCESS);
 


### PR DESCRIPTION
## Summary

- Fix `ccs_map_get_keys()` copying `current->value` instead of `current->key`, which made it return identical data to `ccs_map_get_values()`
- Add test assertions that cross-check `ccs_map_get_keys`/`ccs_map_get_values` results against `ccs_map_get_pairs` to prevent regression

## Test plan

- [x] All 30 C tests pass (including strengthened `test_map`)
- [x] Ruby and Python binding tests pass
- [x] clang-format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)