### PR TITLE
Add missing bounds check in user data deserialization

### DIFF
--- a/src/cconfigspace_internal.h
+++ b/src/cconfigspace_internal.h
@@ -1449,6 +1449,9 @@ _ccs_object_deserialize_user_data(
 		CCS_VALIDATE(_ccs_deserialize_bin_size(
 			&serialize_data_size, buffer_size, buffer));
 		if (serialize_data_size) {
+			CCS_REFUTE(
+				*buffer_size < serialize_data_size,
+				CCS_RESULT_ERROR_NOT_ENOUGH_DATA);
 			if (opts->deserialize_data_callback)
 				CCS_VALIDATE(opts->deserialize_data_callback(
 					object, serialize_data_size, *buffer,


### PR DESCRIPTION
## Summary

- Add a `CCS_REFUTE(*buffer_size < serialize_data_size, CCS_RESULT_ERROR_NOT_ENOUGH_DATA)` guard in `_ccs_object_deserialize_user_data` before advancing the buffer
- Without this check, a malformed input stream with a large `serialize_data_size` causes an unsigned underflow of `buffer_size` and an out-of-bounds read
- The serialize counterpart (`_ccs_object_serialize_user_data`) already has this check, as do all other deserialize paths in the codebase

## Test plan

- [x] All 30 C tests pass
- [x] Ruby and Python binding tests pass
- [x] clang-format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)