### PR TITLE
Fix inverted bounds check in ccs_evaluation_get_objective_values

### DIFF
--- a/src/evaluation.c
+++ b/src/evaluation.c
@@ -416,7 +416,7 @@ ccs_evaluation_get_objective_values(
 	CCS_REFUTE(!values && !num_values_ret, CCS_RESULT_ERROR_INVALID_VALUE);
 	size_t count = evaluation->data->num_objectives;
 	if (values) {
-		CCS_REFUTE(count < num_values, CCS_RESULT_ERROR_INVALID_VALUE);
+		CCS_REFUTE(num_values < count, CCS_RESULT_ERROR_INVALID_VALUE);
 		for (size_t i = 0; i < count; i++)
 			values[i] = evaluation->data->objective_values[i];
 		for (size_t i = count; i < num_values; i++)


### PR DESCRIPTION
## Summary

- Fix `CCS_REFUTE(count < num_values, ...)` → `CCS_REFUTE(num_values < count, ...)` in `ccs_evaluation_get_objective_values`
- The original guard rejected callers with oversized buffers and accepted undersized ones, inverting the intended behavior
- Matches the pattern used by `ccs_binding_get_values` and `ccs_expression_get_nodes`

## Test plan

- [x] All 30 C tests pass
- [x] Ruby and Python binding tests pass
- [x] clang-format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)