### PR TITLE
Fix inverted loop bounds in categorical parameter get_values

### DIFF
--- a/src/parameter_categorical.c
+++ b/src/parameter_categorical.c
@@ -399,7 +399,7 @@ _ccs_categorical_parameter_get_values(
 			CCS_RESULT_ERROR_INVALID_VALUE);
 		for (size_t i = 0; i < d->num_possible_values; i++)
 			possible_values[i] = d->possible_values[i].d;
-		for (size_t i = num_possible_values; i < d->num_possible_values;
+		for (size_t i = d->num_possible_values; i < num_possible_values;
 		     i++)
 			possible_values[i] = ccs_none;
 	}


### PR DESCRIPTION
## Summary

- Fix swapped loop bounds in `_ccs_categorical_parameter_get_values` that left the tail of the caller's buffer uninitialized
- The loop iterated `for (i = num_possible_values; i < d->num_possible_values; ...)` which is always empty since the preceding guard ensures `num_possible_values >= d->num_possible_values`
- Correct bounds: `for (i = d->num_possible_values; i < num_possible_values; ...)`

## Test plan

- [x] All 30 C tests pass
- [x] Ruby and Python binding tests pass
- [x] clang-format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)