### PR TITLE
Fix default features reference leak in random tuner suggest

### DIFF
--- a/src/tuner_random.c
+++ b/src/tuner_random.c
@@ -577,7 +577,6 @@ _ccs_tuner_random_suggest(
 				configuration),
 			err_feat);
 	}
-	return CCS_RESULT_SUCCESS;
 err_feat:
 	if (feat)
 		ccs_release_object(feat);


### PR DESCRIPTION
## Summary

- Fix reference leak in `_ccs_tuner_random_suggest`: the default features object obtained via `ccs_feature_space_get_default_features` was only released on the error path, not on the success path
- Leaked on every successful `suggest` call when the caller did not provide explicit features
- Fix: route the success path through the same `err_feat:` cleanup label

## Test plan

- [x] All 30 C tests pass
- [x] Ruby and Python binding tests pass
- [x] clang-format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)