### PR TITLE
Fix use of released feature_space in tree space deserialize

### DIFF
--- a/src/tree_space_deserialize.h
+++ b/src/tree_space_deserialize.h
@@ -69,6 +69,17 @@ _ccs_deserialize_bin_tree_space_static(
 			data->name, data->tree, data->feature_space, data->rng,
 			tree_space_ret),
 		end);
+	if (opts->map_values && data->feature_space_handle)
+		CCS_VALIDATE_ERR_GOTO(
+			res,
+			_ccs_object_handle_check_add(
+				opts->handle_map, data->feature_space_handle,
+				(ccs_object_t)data->feature_space),
+			err_tree_space);
+	goto end;
+err_tree_space:
+	ccs_release_object(*tree_space_ret);
+	*tree_space_ret = NULL;
 end:
 	if (data->feature_space)
 		ccs_release_object(data->feature_space);
@@ -124,6 +135,17 @@ _ccs_deserialize_bin_tree_space_dynamic(
 			data->name, data->tree, data->feature_space, data->rng,
 			vector, tree_space_data, tree_space_ret),
 		end);
+	if (opts->map_values && data->feature_space_handle)
+		CCS_VALIDATE_ERR_GOTO(
+			res,
+			_ccs_object_handle_check_add(
+				opts->handle_map, data->feature_space_handle,
+				(ccs_object_t)data->feature_space),
+			err_tree_space);
+	goto end;
+err_tree_space:
+	ccs_release_object(*tree_space_ret);
+	*tree_space_ret = NULL;
 end:
 	if (data->feature_space)
 		ccs_release_object(data->feature_space);
@@ -142,8 +164,6 @@ _ccs_deserialize_bin_tree_space(
 	const char                       **buffer,
 	_ccs_object_deserialize_options_t *opts)
 {
-	ccs_result_t          res = CCS_RESULT_SUCCESS;
-
 	ccs_tree_space_type_t stype;
 	CCS_VALIDATE(
 		_ccs_peek_bin_ccs_tree_space_type(&stype, buffer_size, buffer));
@@ -169,21 +189,7 @@ _ccs_deserialize_bin_tree_space(
 			CCS_RESULT_ERROR_UNSUPPORTED_OPERATION,
 			"Unsupported tree space type: %d", stype);
 	}
-	if (opts->map_values) {
-		if (data.feature_space_handle)
-			CCS_VALIDATE_ERR_GOTO(
-				res,
-				_ccs_object_handle_check_add(
-					opts->handle_map,
-					data.feature_space_handle,
-					(ccs_object_t)data.feature_space),
-				err_tree_space);
-	}
 	return CCS_RESULT_SUCCESS;
-err_tree_space:
-	ccs_release_object(*tree_space_ret);
-	*tree_space_ret = NULL;
-	return res;
 }
 
 static ccs_result_t


### PR DESCRIPTION
## Summary

- Move `_ccs_object_handle_check_add` for `feature_space` into the static and dynamic tree space deserialize helpers, before `ccs_release_object` is called
- Previously, the outer function used `data.feature_space` after the inner function had released it — a logically surrendered reference
- Also adds proper rollback (release the created tree_space) if handle map insertion fails
- Remove dead handle map code from the outer `_ccs_deserialize_bin_tree_space` function

## Test plan

- [x] All 30 C tests pass
- [x] Ruby and Python binding tests pass
- [x] clang-format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)