### PR TITLE
Add missing NULL check for vector callback in expression deserialize

### DIFF
--- a/src/expression_deserialize.h
+++ b/src/expression_deserialize.h
@@ -249,6 +249,7 @@ _ccs_deserialize_bin_expression(
 			&new_opts));
 		break;
 	case CCS_EXPRESSION_TYPE_USER_DEFINED:
+		CCS_CHECK_PTR(opts->deserialize_vector_callback);
 		CCS_VALIDATE(_ccs_deserialize_bin_expression_user_defined(
 			expression_ret, version, buffer_size, buffer,
 			&new_opts));


### PR DESCRIPTION
## Summary

- Add `CCS_CHECK_PTR(opts->deserialize_vector_callback)` before calling `_ccs_deserialize_bin_expression_user_defined`, matching the guards already present in the tuner (`tuner_deserialize.h:237`) and tree space (`tree_space_deserialize.h:171`) deserializers
- Without this check, deserializing a user-defined expression without providing `CCS_DESERIALIZE_OPTION_VECTOR_CALLBACK` caused a NULL function pointer dereference

## Test plan

- [x] All 30 C tests pass
- [x] Ruby and Python binding tests pass
- [x] clang-format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)