### PR TITLE
Add shift overflow guard in LEB128 deserializer

### DIFF
--- a/src/cconfigspace_internal.h
+++ b/src/cconfigspace_internal.h
@@ -695,6 +695,9 @@ ccs_zigzag_decode_int64(uint64_t x)
 				buff_size < 1,                                 \
 				CCS_RESULT_ERROR_NOT_ENOUGH_DATA);             \
 			y = *buff;                                             \
+			CCS_REFUTE(                                            \
+				shift >= sizeof(MAPPED_TYPE) * 8,              \
+				CCS_RESULT_ERROR_INVALID_VALUE);               \
 			v |= (y & 0x7f) << shift;                              \
 			buff_size -= 1;                                        \
 			buff += 1;                                             \


### PR DESCRIPTION
## Summary

- Add a bounds check on the shift accumulator in the `CCS_COMPRESSED_DESERIALIZER` LEB128 decoding loop
- Without this check, a malformed stream with continuous 0x80 bytes causes `shift` to exceed the target type width, invoking undefined behavior via `(y & 0x7f) << shift`
- The guard rejects the stream with `CCS_RESULT_ERROR_INVALID_VALUE` when `shift >= sizeof(MAPPED_TYPE) * 8`

## Test plan

- [x] All 30 C tests pass
- [x] Ruby and Python binding tests pass
- [x] clang-format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)