### PR TITLE
Initialize pstate->base in non-blocking serialize file descriptor

### DIFF
--- a/src/cconfigspace.c
+++ b/src/cconfigspace.c
@@ -482,6 +482,7 @@ _ccs_object_serialize_file_descriptor(
 			CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 			*(opts.ppfd_state) = pstate =
 				(_ccs_file_descriptor_state_t *)mem;
+			pstate->base = mem;
 			pstate->base_size =
 				sizeof(_ccs_file_descriptor_state_t) +
 				object_size;


### PR DESCRIPTION
## Summary

- Initialize `pstate->base = mem` in the non-blocking first-call branch of `_ccs_object_serialize_file_descriptor`
- Without this, `pstate->base` contained uninitialized garbage from `malloc`, and the error path `free(pstate->base)` would free an arbitrary pointer
- Matches the pattern used by the deserialize counterpart `_ccs_object_deserialize_file_descriptor`

## Test plan

- [x] All 30 C tests pass
- [x] Ruby and Python binding tests pass
- [x] clang-format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)