### PR TITLE
Fix Doxygen errors and INT_MAX inconsistency in headers

### DIFF
--- a/include/cconfigspace/base.h
+++ b/include/cconfigspace/base.h
@@ -233,7 +233,7 @@ enum ccs_result_e {
 	CCS_RESULT_ERROR_INVALID_TREE               = -27,
 	/** The provided tree space is invalid */
 	CCS_RESULT_ERROR_INVALID_TREE_SPACE         = -28,
-	/** The provided tree tuner is invalid */
+	/** The provided distribution space is invalid */
 	CCS_RESULT_ERROR_INVALID_DISTRIBUTION_SPACE = -29,
 	/** Guard */
 	CCS_RESULT_MIN                              = -30,

--- a/include/cconfigspace/parameter.h
+++ b/include/cconfigspace/parameter.h
@@ -42,7 +42,7 @@ enum ccs_parameter_type_e {
 	/** Guard */
 	CCS_PARAMETER_TYPE_MAX,
 	/** Try forcing 32 bits value for bindings */
-	CCS_PARAMETER_TYPE_FORCE_32BIT = INT_MAX
+	CCS_PARAMETER_TYPE_FORCE_32BIT = INT32_MAX
 };
 
 /**
@@ -418,7 +418,7 @@ ccs_parameter_get_type(
  *                       value of the parameter
  * @return #CCS_RESULT_SUCCESS on success
  * @return #CCS_RESULT_ERROR_INVALID_VALUE if \p value_ret is NULL
- * @return #CCS_RESULT_ERROR_INVALID_OBJECT if \p distribution is not a valid
+ * @return #CCS_RESULT_ERROR_INVALID_OBJECT if \p parameter is not a valid
  * CCS parameter
  * @remarks
  *   This function is thread-safe
@@ -435,7 +435,7 @@ ccs_parameter_get_default_value(
  *                      the name of the parameter
  * @return #CCS_RESULT_SUCCESS on success
  * @return #CCS_RESULT_ERROR_INVALID_VALUE if \p name_ret is NULL
- * @return #CCS_RESULT_ERROR_INVALID_OBJECT if \p distribution is not a valid
+ * @return #CCS_RESULT_ERROR_INVALID_OBJECT if \p parameter is not a valid
  * CCS parameter
  * @remarks
  *   This function is thread-safe


### PR DESCRIPTION
## Summary

- Fix copy-paste error in `CCS_RESULT_ERROR_INVALID_DISTRIBUTION_SPACE` comment: "tree tuner" → "distribution space"
- Fix `\p distribution` → `\p parameter` in Doxygen for `ccs_parameter_get_default_value` and `ccs_parameter_get_name`
- Fix `CCS_PARAMETER_TYPE_FORCE_32BIT = INT_MAX` → `INT32_MAX` for consistency with all other FORCE_32BIT sentinels

## Test plan

- [x] All 30 C tests pass
- [x] Ruby and Python binding tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)