### PR TITLE
Rename CCS_EXPRESSION_FORCE_32BIT to CCS_EXPRESSION_TYPE_FORCE_32BIT

### DIFF
--- a/include/cconfigspace/expression.h
+++ b/include/cconfigspace/expression.h
@@ -62,7 +62,7 @@ enum ccs_expression_type_e {
 	/** Guard */
 	CCS_EXPRESSION_TYPE_MAX,
 	/** Try forcing 32 bits value for bindings */
-	CCS_EXPRESSION_FORCE_32BIT = INT32_MAX
+	CCS_EXPRESSION_TYPE_FORCE_32BIT = INT32_MAX
 };
 
 /**


### PR DESCRIPTION
## Summary

- Rename `CCS_EXPRESSION_FORCE_32BIT` → `CCS_EXPRESSION_TYPE_FORCE_32BIT` to match the naming convention used by every other FORCE_32BIT sentinel in the codebase

## Test plan

- [x] All 30 C tests pass
- [x] Ruby and Python binding tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)