### PR TITLE
Remove stray semicolons in expression equal/not_equal eval

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -453,7 +453,6 @@ _ccs_expr_equal_eval(
 			CCS_RESULT_ERROR_INVALID_VALUE,
 			"Types %d and %d are not comparable", left.type,
 			right.type);
-	;
 	*result = (equal ? ccs_true : ccs_false);
 	return CCS_RESULT_SUCCESS;
 }
@@ -487,7 +486,6 @@ _ccs_expr_not_equal_eval(
 			CCS_RESULT_ERROR_INVALID_VALUE,
 			"Types %d and %d are not comparable", left.type,
 			right.type);
-	;
 	*result = (equal ? ccs_false : ccs_true);
 	return CCS_RESULT_SUCCESS;
 }


### PR DESCRIPTION
## Summary

- Remove stray `;` null statements after `CCS_RAISE` in `_ccs_expr_equal_eval` (line 456) and `_ccs_expr_not_equal_eval` (line 490)
- These null statements made the code structure misleading and left the result assignment visually separated from its guard

## Test plan

- [x] All 30 C tests pass
- [x] Ruby and Python binding tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)