### PR TITLE
Fix child object leak on ccs_tree_set_child failure

### DIFF
--- a/src/tree_space_dynamic.c
+++ b/src/tree_space_dynamic.c
@@ -152,15 +152,17 @@ _ccs_tree_space_tree_get_child(
 {
 	CCS_VALIDATE(ccs_tree_get_child(parent, index, child));
 	if (!*child) {
-		ccs_result_t err;
+		ccs_result_t err = CCS_RESULT_SUCCESS;
 		CCS_VALIDATE(child_cb(tree_space, parent, index, child));
-		err = ccs_tree_set_child(parent, index, *child);
-		if (err) {
-			ccs_release_object(*child);
-			*child = NULL;
-			return err;
-		}
+		CCS_VALIDATE_ERR_GOTO(
+			err, ccs_tree_set_child(parent, index, *child),
+			err_child);
 		CCS_VALIDATE(ccs_release_object(*child));
+		return CCS_RESULT_SUCCESS;
+	err_child:
+		ccs_release_object(*child);
+		*child = NULL;
+		return err;
 	}
 	return CCS_RESULT_SUCCESS;
 }

--- a/src/tree_space_dynamic.c
+++ b/src/tree_space_dynamic.c
@@ -152,8 +152,14 @@ _ccs_tree_space_tree_get_child(
 {
 	CCS_VALIDATE(ccs_tree_get_child(parent, index, child));
 	if (!*child) {
+		ccs_result_t err;
 		CCS_VALIDATE(child_cb(tree_space, parent, index, child));
-		CCS_VALIDATE(ccs_tree_set_child(parent, index, *child));
+		err = ccs_tree_set_child(parent, index, *child);
+		if (err) {
+			ccs_release_object(*child);
+			*child = NULL;
+			return err;
+		}
 		CCS_VALIDATE(ccs_release_object(*child));
 	}
 	return CCS_RESULT_SUCCESS;

--- a/src/tree_space_dynamic.c
+++ b/src/tree_space_dynamic.c
@@ -150,21 +150,20 @@ _ccs_tree_space_tree_get_child(
 		size_t           child_index,
 		ccs_tree_t      *child_ret))
 {
+	ccs_result_t err = CCS_RESULT_SUCCESS;
 	CCS_VALIDATE(ccs_tree_get_child(parent, index, child));
 	if (!*child) {
-		ccs_result_t err = CCS_RESULT_SUCCESS;
 		CCS_VALIDATE(child_cb(tree_space, parent, index, child));
 		CCS_VALIDATE_ERR_GOTO(
 			err, ccs_tree_set_child(parent, index, *child),
 			err_child);
 		CCS_VALIDATE(ccs_release_object(*child));
-		return CCS_RESULT_SUCCESS;
-	err_child:
-		ccs_release_object(*child);
-		*child = NULL;
-		return err;
 	}
 	return CCS_RESULT_SUCCESS;
+err_child:
+	ccs_release_object(*child);
+	*child = NULL;
+	return err;
 }
 
 static ccs_result_t


### PR DESCRIPTION
## Summary

- Fix resource leak in `_ccs_tree_space_tree_get_child`: if `child_cb` allocated a child but `ccs_tree_set_child` subsequently failed, the child was never released
- Now releases the child and clears `*child` before returning the error

## Test plan

- [x] All 30 C tests pass
- [x] Ruby and Python binding tests pass
- [x] clang-format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)