### PR TITLE
Replace alloca with malloc in user-defined expression eval

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -1417,14 +1417,14 @@ _ccs_expr_user_defined_eval(
 	_ccs_expression_data_t              *data = e->data;
 	_ccs_expression_user_defined_data_t *d =
 		(_ccs_expression_user_defined_data_t *)data;
-	ccs_datum_t  stack_values[16];
 	ccs_datum_t *values  = NULL;
 	ccs_datum_t *to_free = NULL;
 	ccs_result_t err     = CCS_RESULT_SUCCESS;
 
 	if (data->num_nodes) {
 		if (data->num_nodes <= 16) {
-			values = stack_values;
+			values = (ccs_datum_t *)alloca(
+				sizeof(ccs_datum_t) * data->num_nodes);
 		} else {
 			values = (ccs_datum_t *)malloc(
 				sizeof(ccs_datum_t) * data->num_nodes);

--- a/src/expression.c
+++ b/src/expression.c
@@ -1418,17 +1418,29 @@ _ccs_expr_user_defined_eval(
 	_ccs_expression_user_defined_data_t *d =
 		(_ccs_expression_user_defined_data_t *)data;
 	ccs_datum_t *values = NULL;
+	ccs_result_t err    = CCS_RESULT_SUCCESS;
 
-	if (data->num_nodes)
-		values = (ccs_datum_t *)alloca(
+	if (data->num_nodes) {
+		values = (ccs_datum_t *)malloc(
 			sizeof(ccs_datum_t) * data->num_nodes);
-	for (size_t i = 0; i < data->num_nodes; i++) {
-		CCS_VALIDATE(_ccs_expr_node_eval(
-			data->nodes[i], expr_ctx, values + i, NULL));
-		RETURN_IF_INACTIVE(values[i], result);
+		CCS_REFUTE(!values, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	}
-	CCS_VALIDATE(d->vector.eval(e, data->num_nodes, values, result));
-	return CCS_RESULT_SUCCESS;
+	for (size_t i = 0; i < data->num_nodes; i++) {
+		CCS_VALIDATE_ERR_GOTO(
+			err,
+			_ccs_expr_node_eval(
+				data->nodes[i], expr_ctx, values + i, NULL),
+			end);
+		if (values[i].type == CCS_DATA_TYPE_INACTIVE) {
+			*result = ccs_inactive;
+			goto end;
+		}
+	}
+	CCS_VALIDATE_ERR_GOTO(
+		err, d->vector.eval(e, data->num_nodes, values, result), end);
+end:
+	free(values);
+	return err;
 }
 
 static _ccs_expression_ops_t _ccs_expr_user_defined_ops = {

--- a/src/expression.c
+++ b/src/expression.c
@@ -1417,13 +1417,20 @@ _ccs_expr_user_defined_eval(
 	_ccs_expression_data_t              *data = e->data;
 	_ccs_expression_user_defined_data_t *d =
 		(_ccs_expression_user_defined_data_t *)data;
-	ccs_datum_t *values = NULL;
-	ccs_result_t err    = CCS_RESULT_SUCCESS;
+	ccs_datum_t  stack_values[16];
+	ccs_datum_t *values  = NULL;
+	ccs_datum_t *to_free = NULL;
+	ccs_result_t err     = CCS_RESULT_SUCCESS;
 
 	if (data->num_nodes) {
-		values = (ccs_datum_t *)malloc(
-			sizeof(ccs_datum_t) * data->num_nodes);
-		CCS_REFUTE(!values, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		if (data->num_nodes <= 16) {
+			values = stack_values;
+		} else {
+			values = (ccs_datum_t *)malloc(
+				sizeof(ccs_datum_t) * data->num_nodes);
+			CCS_REFUTE(!values, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+			to_free = values;
+		}
 	}
 	for (size_t i = 0; i < data->num_nodes; i++) {
 		CCS_VALIDATE_ERR_GOTO(
@@ -1439,7 +1446,7 @@ _ccs_expr_user_defined_eval(
 	CCS_VALIDATE_ERR_GOTO(
 		err, d->vector.eval(e, data->num_nodes, values, result), end);
 end:
-	free(values);
+	free(to_free);
 	return err;
 }
 


### PR DESCRIPTION
## Summary

- Replace `alloca` with `malloc`/`free` in `_ccs_expr_user_defined_eval` to prevent stack overflow when `num_nodes` is large
- User-defined expressions have unbounded arity (-1), so `num_nodes` has no upper limit
- Route all exit paths through a cleanup label to ensure the buffer is freed

## Test plan

- [x] All 30 C tests pass
- [x] Ruby and Python binding tests pass
- [x] clang-format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)