### PR TITLE
Fix node leak in expression literal and variable deserialize paths

### DIFF
--- a/src/expression_deserialize.h
+++ b/src/expression_deserialize.h
@@ -66,18 +66,11 @@ _ccs_deserialize_bin_ccs_expression_literal_data(
 	size_t                              *buffer_size,
 	const char                         **buffer)
 {
-	ccs_result_t err = CCS_RESULT_SUCCESS;
 	CCS_VALIDATE(_ccs_deserialize_bin_ccs_expression_data(
 		&data->expr, version, buffer_size, buffer, NULL));
-	CCS_VALIDATE_ERR_GOTO(
-		err,
-		_ccs_deserialize_bin_ccs_datum(
-			&data->value, buffer_size, buffer),
-		err_nodes);
+	CCS_VALIDATE(_ccs_deserialize_bin_ccs_datum(
+		&data->value, buffer_size, buffer));
 	return CCS_RESULT_SUCCESS;
-err_nodes:
-	_ccs_expression_data_mock_free(&data->expr);
-	return err;
 }
 
 static inline ccs_result_t
@@ -89,8 +82,11 @@ _ccs_deserialize_bin_expression_literal(
 {
 	ccs_result_t                        err = CCS_RESULT_SUCCESS;
 	_ccs_expression_literal_data_mock_t data;
-	CCS_VALIDATE(_ccs_deserialize_bin_ccs_expression_literal_data(
-		&data, version, buffer_size, buffer));
+	CCS_VALIDATE_ERR_GOTO(
+		err,
+		_ccs_deserialize_bin_ccs_expression_literal_data(
+			&data, version, buffer_size, buffer),
+		end);
 	CCS_VALIDATE_ERR_GOTO(
 		err, ccs_create_literal(data.value, expression_ret), end);
 end:
@@ -112,18 +108,11 @@ _ccs_deserialize_bin_ccs_expression_variable_data(
 	size_t                               *buffer_size,
 	const char                          **buffer)
 {
-	ccs_result_t err = CCS_RESULT_SUCCESS;
 	CCS_VALIDATE(_ccs_deserialize_bin_ccs_expression_data(
 		&data->expr, version, buffer_size, buffer, NULL));
-	CCS_VALIDATE_ERR_GOTO(
-		err,
-		_ccs_deserialize_bin_ccs_object(
-			(ccs_object_t *)&data->parameter, buffer_size, buffer),
-		err_nodes);
+	CCS_VALIDATE(_ccs_deserialize_bin_ccs_object(
+		(ccs_object_t *)&data->parameter, buffer_size, buffer));
 	return CCS_RESULT_SUCCESS;
-err_nodes:
-	_ccs_expression_data_mock_free(&data->expr);
-	return err;
 }
 
 static inline ccs_result_t
@@ -137,8 +126,11 @@ _ccs_deserialize_bin_expression_variable(
 	CCS_CHECK_OBJ(opts->handle_map, CCS_OBJECT_TYPE_MAP);
 	ccs_result_t                         err = CCS_RESULT_SUCCESS;
 	_ccs_expression_variable_data_mock_t data;
-	CCS_VALIDATE(_ccs_deserialize_bin_ccs_expression_variable_data(
-		&data, version, buffer_size, buffer));
+	CCS_VALIDATE_ERR_GOTO(
+		err,
+		_ccs_deserialize_bin_ccs_expression_variable_data(
+			&data, version, buffer_size, buffer),
+		end);
 	ccs_datum_t     d;
 	ccs_parameter_t h;
 	CCS_VALIDATE_ERR_GOTO(

--- a/src/expression_deserialize.h
+++ b/src/expression_deserialize.h
@@ -41,6 +41,17 @@ _ccs_deserialize_bin_ccs_expression_data(
 	return CCS_RESULT_SUCCESS;
 }
 
+static inline void
+_ccs_expression_data_mock_free(_ccs_expression_data_mock_t *data)
+{
+	if (data->nodes) {
+		for (size_t i = 0; i < data->num_nodes; i++)
+			if (data->nodes[i].type == CCS_DATA_TYPE_OBJECT)
+				ccs_release_object(data->nodes[i].value.o);
+		free(data->nodes);
+	}
+}
+
 struct _ccs_expression_literal_data_mock_s {
 	_ccs_expression_data_mock_t expr;
 	ccs_datum_t                 value;
@@ -55,11 +66,18 @@ _ccs_deserialize_bin_ccs_expression_literal_data(
 	size_t                              *buffer_size,
 	const char                         **buffer)
 {
+	ccs_result_t err = CCS_RESULT_SUCCESS;
 	CCS_VALIDATE(_ccs_deserialize_bin_ccs_expression_data(
 		&data->expr, version, buffer_size, buffer, NULL));
-	CCS_VALIDATE(_ccs_deserialize_bin_ccs_datum(
-		&data->value, buffer_size, buffer));
+	CCS_VALIDATE_ERR_GOTO(
+		err,
+		_ccs_deserialize_bin_ccs_datum(
+			&data->value, buffer_size, buffer),
+		err_nodes);
 	return CCS_RESULT_SUCCESS;
+err_nodes:
+	_ccs_expression_data_mock_free(&data->expr);
+	return err;
 }
 
 static inline ccs_result_t
@@ -69,11 +87,15 @@ _ccs_deserialize_bin_expression_literal(
 	size_t           *buffer_size,
 	const char      **buffer)
 {
+	ccs_result_t                        err = CCS_RESULT_SUCCESS;
 	_ccs_expression_literal_data_mock_t data;
 	CCS_VALIDATE(_ccs_deserialize_bin_ccs_expression_literal_data(
 		&data, version, buffer_size, buffer));
-	CCS_VALIDATE(ccs_create_literal(data.value, expression_ret));
-	return CCS_RESULT_SUCCESS;
+	CCS_VALIDATE_ERR_GOTO(
+		err, ccs_create_literal(data.value, expression_ret), end);
+end:
+	_ccs_expression_data_mock_free(&data.expr);
+	return err;
 }
 
 struct _ccs_expression_variable_data_mock_s {
@@ -90,11 +112,18 @@ _ccs_deserialize_bin_ccs_expression_variable_data(
 	size_t                               *buffer_size,
 	const char                          **buffer)
 {
+	ccs_result_t err = CCS_RESULT_SUCCESS;
 	CCS_VALIDATE(_ccs_deserialize_bin_ccs_expression_data(
 		&data->expr, version, buffer_size, buffer, NULL));
-	CCS_VALIDATE(_ccs_deserialize_bin_ccs_object(
-		(ccs_object_t *)&data->parameter, buffer_size, buffer));
+	CCS_VALIDATE_ERR_GOTO(
+		err,
+		_ccs_deserialize_bin_ccs_object(
+			(ccs_object_t *)&data->parameter, buffer_size, buffer),
+		err_nodes);
 	return CCS_RESULT_SUCCESS;
+err_nodes:
+	_ccs_expression_data_mock_free(&data->expr);
+	return err;
 }
 
 static inline ccs_result_t
@@ -106,19 +135,24 @@ _ccs_deserialize_bin_expression_variable(
 	_ccs_object_deserialize_options_t *opts)
 {
 	CCS_CHECK_OBJ(opts->handle_map, CCS_OBJECT_TYPE_MAP);
+	ccs_result_t                         err = CCS_RESULT_SUCCESS;
 	_ccs_expression_variable_data_mock_t data;
 	CCS_VALIDATE(_ccs_deserialize_bin_ccs_expression_variable_data(
 		&data, version, buffer_size, buffer));
 	ccs_datum_t     d;
 	ccs_parameter_t h;
-	CCS_VALIDATE(
-		ccs_map_get(opts->handle_map, ccs_object(data.parameter), &d));
-	CCS_REFUTE(
-		d.type != CCS_DATA_TYPE_OBJECT,
-		CCS_RESULT_ERROR_INVALID_HANDLE);
+	CCS_VALIDATE_ERR_GOTO(
+		err,
+		ccs_map_get(opts->handle_map, ccs_object(data.parameter), &d),
+		end);
+	CCS_REFUTE_ERR_GOTO(
+		err, d.type != CCS_DATA_TYPE_OBJECT,
+		CCS_RESULT_ERROR_INVALID_HANDLE, end);
 	h = (ccs_parameter_t)(d.value.o);
-	CCS_VALIDATE(ccs_create_variable(h, expression_ret));
-	return CCS_RESULT_SUCCESS;
+	CCS_VALIDATE_ERR_GOTO(err, ccs_create_variable(h, expression_ret), end);
+end:
+	_ccs_expression_data_mock_free(&data.expr);
+	return err;
 }
 
 static inline ccs_result_t
@@ -142,12 +176,7 @@ _ccs_deserialize_bin_expression_general(
 			data.type, data.num_nodes, data.nodes, expression_ret),
 		end);
 end:
-	if (data.nodes) {
-		for (size_t i = 0; i < data.num_nodes; i++)
-			if (data.nodes[i].type == CCS_DATA_TYPE_OBJECT)
-				ccs_release_object(data.nodes[i].value.o);
-		free(data.nodes);
-	}
+	_ccs_expression_data_mock_free(&data);
 	return res;
 }
 
@@ -215,12 +244,7 @@ _ccs_deserialize_bin_expression_user_defined(
 		end);
 
 end:
-	if (data.expr.nodes) {
-		for (size_t i = 0; i < data.expr.num_nodes; i++)
-			if (data.expr.nodes[i].type == CCS_DATA_TYPE_OBJECT)
-				ccs_release_object(data.expr.nodes[i].value.o);
-		free(data.expr.nodes);
-	}
+	_ccs_expression_data_mock_free(&data.expr);
 	return res;
 }
 

--- a/src/expression_deserialize.h
+++ b/src/expression_deserialize.h
@@ -126,13 +126,13 @@ _ccs_deserialize_bin_expression_variable(
 	CCS_CHECK_OBJ(opts->handle_map, CCS_OBJECT_TYPE_MAP);
 	ccs_result_t                         err = CCS_RESULT_SUCCESS;
 	_ccs_expression_variable_data_mock_t data;
+	ccs_datum_t                          d;
+	ccs_parameter_t                      h;
 	CCS_VALIDATE_ERR_GOTO(
 		err,
 		_ccs_deserialize_bin_ccs_expression_variable_data(
 			&data, version, buffer_size, buffer),
 		end);
-	ccs_datum_t     d;
-	ccs_parameter_t h;
 	CCS_VALIDATE_ERR_GOTO(
 		err,
 		ccs_map_get(opts->handle_map, ccs_object(data.parameter), &d),


### PR DESCRIPTION
## Summary

- Add `_ccs_expression_data_mock_free` helper to release and free deserialized expression nodes
- Fix leak in literal and variable deserialize paths: if the expression data was deserialized but a subsequent step failed, `data.expr.nodes` and any child expressions were leaked
- Deduplicate the same cleanup pattern in the general and user-defined paths

## Test plan

- [x] All 30 C tests pass
- [x] Ruby and Python binding tests pass
- [x] clang-format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)