### PR TITLE
Guard against uint64_t to size_t truncation on 32-bit platforms

### DIFF
--- a/src/cconfigspace.c
+++ b/src/cconfigspace.c
@@ -247,6 +247,7 @@ _ccs_deserialize_header(
 			CCS_RESULT_ERROR_INVALID_VALUE);
 		CCS_VALIDATE(_ccs_deserialize_bin_uncompressed_uint64(
 			&sz, buffer_size, buffer));
+		CCS_REFUTE(sz > SIZE_MAX, CCS_RESULT_ERROR_INVALID_VALUE);
 		*size = sz;
 		CCS_VALIDATE(CCS_SERIALIZATION_API_VERSION_DESERIALIZE_BIN(
 			version, buffer_size, buffer));

--- a/src/cconfigspace_internal.h
+++ b/src/cconfigspace_internal.h
@@ -938,6 +938,7 @@ _ccs_deserialize_bin_size(size_t *sz, size_t *buffer_size, const char **buffer)
 {
 	uint64_t tmp;
 	CCS_VALIDATE(_ccs_deserialize_bin_uint64(&tmp, buffer_size, buffer));
+	CCS_REFUTE(tmp > SIZE_MAX, CCS_RESULT_ERROR_INVALID_VALUE);
 	*sz = tmp;
 	return CCS_RESULT_SUCCESS;
 }


### PR DESCRIPTION
## Summary

- Add `CCS_REFUTE(value > SIZE_MAX, CCS_RESULT_ERROR_INVALID_VALUE)` in `_ccs_deserialize_bin_size` and `_ccs_deserialize_header` before assigning `uint64_t` to `size_t`
- On 32-bit platforms, values exceeding `SIZE_MAX` would silently truncate, leading to undersized allocations and potential buffer overflows
- On 64-bit platforms the check is optimized away (no runtime cost)

## Test plan

- [x] All 30 C tests pass (gcc and g++)
- [x] Ruby and Python binding tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)