### PR TITLE
Handle OOM in ccs_object_set_destroy_callback instead of exit

### DIFF
--- a/src/cconfigspace.c
+++ b/src/cconfigspace.c
@@ -132,6 +132,13 @@ ccs_object_get_refcount(ccs_object_t object, int32_t *refcount_ret)
 static const UT_icd _object_callback_icd = {
 	sizeof(_ccs_object_callback_t), NULL, NULL, NULL};
 
+#undef utarray_oom
+#define utarray_oom()                                                          \
+	{                                                                      \
+		CCS_RAISE_ERR_GOTO(                                            \
+			err, CCS_RESULT_ERROR_OUT_OF_MEMORY, end,              \
+			"Not enough memory to allocate array");                \
+	}
 ccs_result_t
 ccs_object_set_destroy_callback(
 	ccs_object_t                  object,
@@ -140,15 +147,19 @@ ccs_object_set_destroy_callback(
 {
 	CCS_CHECK_BASE_OBJ(object);
 	CCS_CHECK_PTR(callback);
+	ccs_result_t            err = CCS_RESULT_SUCCESS;
 	_ccs_object_internal_t *obj = (_ccs_object_internal_t *)object;
+	_ccs_object_callback_t  cb  = {callback, user_data};
 	CCS_MUTEX_LOCK(obj->mutex);
 	if (!obj->callbacks)
 		utarray_new(obj->callbacks, &_object_callback_icd);
-	_ccs_object_callback_t cb = {callback, user_data};
 	utarray_push_back(obj->callbacks, &cb);
+end:
 	CCS_MUTEX_UNLOCK(obj->mutex);
-	return CCS_RESULT_SUCCESS;
+	return err;
 }
+#undef utarray_oom
+#define utarray_oom() exit(-1)
 
 ccs_result_t
 ccs_object_set_user_data(ccs_object_t object, void *user_data)


### PR DESCRIPTION
## Summary

- Override \`utarray_oom\` in \`ccs_object_set_destroy_callback\` to return \`CCS_RESULT_ERROR_OUT_OF_MEMORY\` instead of calling \`exit(-1)\`
- This was the only remaining call site using utarray operations under the default OOM handler — all other sites in the codebase already override it

## Test plan

- [x] All 30 C tests pass (gcc and g++)
- [x] Ruby and Python binding tests pass
- [x] clang-format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)