### PR TITLE
Add blocking file descriptor serialize/deserialize test

### DIFF
--- a/tests/test_rng.c
+++ b/tests/test_rng.c
@@ -230,6 +230,58 @@ test_rng_file_serialize(void)
 	ccs_release_object(rng);
 }
 
+static void
+test_rng_fd_serialize_blocking(void)
+{
+	ccs_rng_t           rng = NULL, rng2 = NULL;
+	ccs_result_t        err;
+	const gsl_rng_type *t, *t2;
+	unsigned long int   i = 0, i2 = 0;
+	int                 pipefd[2];
+	int                 ret;
+
+	err = ccs_create_rng(&rng);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	err = ccs_rng_get(rng, &i);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	ret = pipe(pipefd);
+	assert(ret == 0);
+
+	/* Blocking serialize to pipe write end */
+	err = ccs_object_serialize(
+		rng, CCS_SERIALIZE_FORMAT_BINARY,
+		CCS_SERIALIZE_OPERATION_FILE_DESCRIPTOR, pipefd[1],
+		CCS_SERIALIZE_OPTION_END);
+	assert(err == CCS_RESULT_SUCCESS);
+	close(pipefd[1]);
+
+	/* Blocking deserialize from pipe read end */
+	err = ccs_object_deserialize(
+		(ccs_object_t *)&rng2, CCS_SERIALIZE_FORMAT_BINARY,
+		CCS_DESERIALIZE_OPERATION_FILE_DESCRIPTOR, pipefd[0],
+		CCS_DESERIALIZE_OPTION_END);
+	assert(err == CCS_RESULT_SUCCESS);
+	close(pipefd[0]);
+
+	/* Verify roundtrip */
+	err = ccs_rng_get_type(rng, &t);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_rng_get_type(rng2, &t2);
+	assert(err == CCS_RESULT_SUCCESS);
+	assert(t == t2);
+
+	err = ccs_rng_get(rng, &i);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_rng_get(rng2, &i2);
+	assert(err == CCS_RESULT_SUCCESS);
+	assert(i == i2);
+
+	ccs_release_object(rng2);
+	ccs_release_object(rng);
+}
+
 int
 main(void)
 {
@@ -240,6 +292,7 @@ main(void)
 	test_rng_get();
 	test_rng_uniform();
 	test_rng_file_serialize();
+	test_rng_fd_serialize_blocking();
 	ccs_clear_thread_error();
 	ccs_fini();
 	return 0;


### PR DESCRIPTION
## Summary

- Add \`test_rng_fd_serialize_blocking()\` testing the FILE_DESCRIPTOR serialize/deserialize blocking paths using a pipe
- Roundtrip: serialize RNG to pipe write end, deserialize from pipe read end, verify type and next value match
- The non-blocking path was also tested during development and found to have a **pre-existing use-after-free bug**: after \`realloc\` in \`_ccs_object_deserialize_file_descriptor\` (line 809), \`pstate\` (embedded in the old allocation for non-blocking mode) becomes a dangling pointer. This will be addressed in a separate fix.

## Test plan

- [x] All 30 C tests pass
- [x] Ruby and Python binding tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)