### PR TITLE
Fix use-after-free in non-blocking fd deserialize after realloc

### DIFF
--- a/src/cconfigspace.c
+++ b/src/cconfigspace.c
@@ -800,19 +800,31 @@ _ccs_object_deserialize_file_descriptor(
 				&pstate->version),
 			err_fd_buffer);
 		/* reallocate buffer to account for whole size */
-		if (non_blocking)
-			pstate->base_size =
-				sizeof(_ccs_file_descriptor_state_t) +
-				object_size;
-		else
+		if (non_blocking) {
+			size_t new_size = sizeof(_ccs_file_descriptor_state_t) +
+					  object_size;
+			new_buffer = (char *)realloc(pstate->base, new_size);
+			CCS_REFUTE_ERR_GOTO(
+				res, !new_buffer,
+				CCS_RESULT_ERROR_OUT_OF_MEMORY, err_fd_buffer);
+			/* pstate is embedded at the start of the
+			 * allocation — update it after realloc may
+			 * have moved the block. */
+			pstate = (_ccs_file_descriptor_state_t *)new_buffer;
+			*(opts.ppfd_state) = pstate;
+			pstate->base       = new_buffer;
+			pstate->base_size  = new_size;
+		} else {
 			pstate->base_size = object_size;
-		new_buffer = (char *)realloc(pstate->base, pstate->base_size);
-		CCS_REFUTE_ERR_GOTO(
-			res, !new_buffer, CCS_RESULT_ERROR_OUT_OF_MEMORY,
-			err_fd_buffer);
-		pstate->base = new_buffer;
+			new_buffer        = (char *)realloc(
+                                pstate->base, pstate->base_size);
+			CCS_REFUTE_ERR_GOTO(
+				res, !new_buffer,
+				CCS_RESULT_ERROR_OUT_OF_MEMORY, err_fd_buffer);
+			pstate->base = new_buffer;
+		}
 		/* seek to after the header */
-		offset       = header_size;
+		offset = header_size;
 		if (non_blocking)
 			offset += sizeof(_ccs_file_descriptor_state_t);
 		pstate->buffer_size = pstate->base_size - offset;

--- a/tests/test_rng.c
+++ b/tests/test_rng.c
@@ -2,6 +2,7 @@
 #include <assert.h>
 #include <string.h>
 #include <unistd.h>
+#include <fcntl.h>
 #include <cconfigspace.h>
 #include <gsl/gsl_rng.h>
 #include "test_utils.h"
@@ -230,6 +231,75 @@ test_rng_file_serialize(void)
 	ccs_release_object(rng);
 }
 
+static void
+test_rng_fd_serialize_non_blocking(void)
+{
+	ccs_rng_t           rng = NULL, rng2 = NULL;
+	ccs_result_t        err;
+	const gsl_rng_type *t, *t2;
+	unsigned long int   i = 0, i2 = 0;
+	int                 pipefd[2];
+	int                 ret;
+	int                 flags;
+	void               *write_state = NULL;
+	void               *read_state  = NULL;
+
+	err                             = ccs_create_rng(&rng);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	err = ccs_rng_get(rng, &i);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	ret = pipe(pipefd);
+	assert(ret == 0);
+
+	/* Set both ends to non-blocking */
+	flags = fcntl(pipefd[0], F_GETFL, 0);
+	fcntl(pipefd[0], F_SETFL, flags | O_NONBLOCK);
+	flags = fcntl(pipefd[1], F_GETFL, 0);
+	fcntl(pipefd[1], F_SETFL, flags | O_NONBLOCK);
+
+	/* Non-blocking serialize — loop until done */
+	do {
+		err = ccs_object_serialize(
+			rng, CCS_SERIALIZE_FORMAT_BINARY,
+			CCS_SERIALIZE_OPERATION_FILE_DESCRIPTOR, pipefd[1],
+			CCS_SERIALIZE_OPTION_NON_BLOCKING, &write_state,
+			CCS_SERIALIZE_OPTION_END);
+	} while (err == CCS_RESULT_AGAIN);
+	assert(err == CCS_RESULT_SUCCESS);
+	assert(write_state == NULL);
+	close(pipefd[1]);
+
+	/* Non-blocking deserialize — loop until done */
+	do {
+		err = ccs_object_deserialize(
+			(ccs_object_t *)&rng2, CCS_SERIALIZE_FORMAT_BINARY,
+			CCS_DESERIALIZE_OPERATION_FILE_DESCRIPTOR, pipefd[0],
+			CCS_DESERIALIZE_OPTION_NON_BLOCKING, &read_state,
+			CCS_DESERIALIZE_OPTION_END);
+	} while (err == CCS_RESULT_AGAIN);
+	assert(err == CCS_RESULT_SUCCESS);
+	assert(read_state == NULL);
+	close(pipefd[0]);
+
+	/* Verify roundtrip */
+	err = ccs_rng_get_type(rng, &t);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_rng_get_type(rng2, &t2);
+	assert(err == CCS_RESULT_SUCCESS);
+	assert(t == t2);
+
+	err = ccs_rng_get(rng, &i);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_rng_get(rng2, &i2);
+	assert(err == CCS_RESULT_SUCCESS);
+	assert(i == i2);
+
+	ccs_release_object(rng2);
+	ccs_release_object(rng);
+}
+
 int
 main(void)
 {
@@ -240,6 +310,7 @@ main(void)
 	test_rng_get();
 	test_rng_uniform();
 	test_rng_file_serialize();
+	test_rng_fd_serialize_non_blocking();
 	ccs_clear_thread_error();
 	ccs_fini();
 	return 0;


### PR DESCRIPTION
## Summary

- Fix use-after-free in \`_ccs_object_deserialize_file_descriptor\`: in non-blocking mode, \`pstate\` is embedded at the start of the heap allocation. After \`realloc\` at line 809 (to resize from header-only to full object size), \`pstate\` became a dangling pointer if realloc moved the block. All subsequent reads/writes through \`pstate\` were use-after-free.
- Fix: update \`pstate\` and \`*(opts.ppfd_state)\` to the new allocation after realloc. Split the blocking/non-blocking realloc paths for clarity.
- Add \`test_rng_fd_serialize_non_blocking()\` exercising the non-blocking FILE_DESCRIPTOR serialize and deserialize paths via a pipe with \`O_NONBLOCK\`.
- Verified clean under valgrind (0 errors, 0 leaks).

## Test plan

- [x] All 30 C tests pass
- [x] Ruby and Python binding tests pass
- [x] Valgrind: 0 errors, 0 leaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)