### PR TITLE
Fix use-after-free in non-blocking fd deserialize after realloc

### DIFF
--- a/src/cconfigspace.c
+++ b/src/cconfigspace.c
@@ -800,19 +800,31 @@ _ccs_object_deserialize_file_descriptor(
 				&pstate->version),
 			err_fd_buffer);
 		/* reallocate buffer to account for whole size */
-		if (non_blocking)
-			pstate->base_size =
-				sizeof(_ccs_file_descriptor_state_t) +
-				object_size;
-		else
+		if (non_blocking) {
+			size_t new_size = sizeof(_ccs_file_descriptor_state_t) +
+					  object_size;
+			new_buffer = (char *)realloc(pstate->base, new_size);
+			CCS_REFUTE_ERR_GOTO(
+				res, !new_buffer,
+				CCS_RESULT_ERROR_OUT_OF_MEMORY, err_fd_buffer);
+			/* pstate is embedded at the start of the
+			 * allocation — update it after realloc may
+			 * have moved the block. */
+			pstate = (_ccs_file_descriptor_state_t *)new_buffer;
+			*(opts.ppfd_state) = pstate;
+			pstate->base       = new_buffer;
+			pstate->base_size  = new_size;
+		} else {
 			pstate->base_size = object_size;
-		new_buffer = (char *)realloc(pstate->base, pstate->base_size);
-		CCS_REFUTE_ERR_GOTO(
-			res, !new_buffer, CCS_RESULT_ERROR_OUT_OF_MEMORY,
-			err_fd_buffer);
-		pstate->base = new_buffer;
+			new_buffer        = (char *)realloc(
+                                pstate->base, pstate->base_size);
+			CCS_REFUTE_ERR_GOTO(
+				res, !new_buffer,
+				CCS_RESULT_ERROR_OUT_OF_MEMORY, err_fd_buffer);
+			pstate->base = new_buffer;
+		}
 		/* seek to after the header */
-		offset       = header_size;
+		offset = header_size;
 		if (non_blocking)
 			offset += sizeof(_ccs_file_descriptor_state_t);
 		pstate->buffer_size = pstate->base_size - offset;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -46,6 +46,7 @@ CCONFIGSPACE_TESTS = \
 	test_user_defined_tree_tuner \
 	test_atomics
 
+test_rng_LDFLAGS = -lpthread $(AM_LDFLAGS)
 test_atomics_LDFLAGS = -lpthread $(AM_LDFLAGS)
 
 # unit tests

--- a/tests/test_rng.c
+++ b/tests/test_rng.c
@@ -2,6 +2,8 @@
 #include <assert.h>
 #include <string.h>
 #include <unistd.h>
+#include <fcntl.h>
+#include <pthread.h>
 #include <cconfigspace.h>
 #include <gsl/gsl_rng.h>
 #include "test_utils.h"
@@ -282,6 +284,98 @@ test_rng_fd_serialize_blocking(void)
 	ccs_release_object(rng);
 }
 
+struct _nb_write_args {
+	ccs_rng_t rng;
+	int       fd;
+};
+
+static void *
+_nb_write_thread(void *arg)
+{
+	struct _nb_write_args *wa          = (struct _nb_write_args *)arg;
+	void                  *write_state = NULL;
+	ccs_result_t           err;
+	do {
+		err = ccs_object_serialize(
+			wa->rng, CCS_SERIALIZE_FORMAT_BINARY,
+			CCS_SERIALIZE_OPERATION_FILE_DESCRIPTOR, wa->fd,
+			CCS_SERIALIZE_OPTION_NON_BLOCKING, &write_state,
+			CCS_SERIALIZE_OPTION_END);
+	} while (err == CCS_RESULT_AGAIN);
+	assert(err == CCS_RESULT_SUCCESS);
+	assert(write_state == NULL);
+	close(wa->fd);
+	return NULL;
+}
+
+static void
+test_rng_fd_serialize_non_blocking(void)
+{
+	ccs_rng_t             rng = NULL, rng2 = NULL;
+	ccs_result_t          err;
+	const gsl_rng_type   *t, *t2;
+	unsigned long int     i = 0, i2 = 0;
+	int                   pipefd[2];
+	int                   ret;
+	int                   flags;
+	void                 *read_state = NULL;
+	pthread_t             writer;
+	struct _nb_write_args wa;
+
+	err = ccs_create_rng(&rng);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	err = ccs_rng_get(rng, &i);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	ret = pipe(pipefd);
+	assert(ret == 0);
+
+	/* Set both ends to non-blocking */
+	flags = fcntl(pipefd[0], F_GETFL, 0);
+	fcntl(pipefd[0], F_SETFL, flags | O_NONBLOCK);
+	flags = fcntl(pipefd[1], F_GETFL, 0);
+	fcntl(pipefd[1], F_SETFL, flags | O_NONBLOCK);
+
+	/* Write in a separate thread so that if the pipe buffer fills,
+	 * the read thread can drain it. */
+	wa.rng = rng;
+	wa.fd  = pipefd[1];
+	ret    = pthread_create(&writer, NULL, _nb_write_thread, &wa);
+	assert(ret == 0);
+
+	/* Non-blocking deserialize in the main thread */
+	do {
+		err = ccs_object_deserialize(
+			(ccs_object_t *)&rng2, CCS_SERIALIZE_FORMAT_BINARY,
+			CCS_DESERIALIZE_OPERATION_FILE_DESCRIPTOR, pipefd[0],
+			CCS_DESERIALIZE_OPTION_NON_BLOCKING, &read_state,
+			CCS_DESERIALIZE_OPTION_END);
+	} while (err == CCS_RESULT_AGAIN);
+	assert(err == CCS_RESULT_SUCCESS);
+	assert(read_state == NULL);
+	close(pipefd[0]);
+
+	ret = pthread_join(writer, NULL);
+	assert(ret == 0);
+
+	/* Verify roundtrip */
+	err = ccs_rng_get_type(rng, &t);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_rng_get_type(rng2, &t2);
+	assert(err == CCS_RESULT_SUCCESS);
+	assert(t == t2);
+
+	err = ccs_rng_get(rng, &i);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_rng_get(rng2, &i2);
+	assert(err == CCS_RESULT_SUCCESS);
+	assert(i == i2);
+
+	ccs_release_object(rng2);
+	ccs_release_object(rng);
+}
+
 int
 main(void)
 {
@@ -293,6 +387,7 @@ main(void)
 	test_rng_uniform();
 	test_rng_file_serialize();
 	test_rng_fd_serialize_blocking();
+	test_rng_fd_serialize_non_blocking();
 	ccs_clear_thread_error();
 	ccs_fini();
 	return 0;


### PR DESCRIPTION
## Summary

- Fix use-after-free in `_ccs_object_deserialize_file_descriptor`: in non-blocking mode, `pstate` is embedded at the start of the heap allocation. After `realloc` (to resize from header-only to full object size), `pstate` became a dangling pointer if realloc moved the block.
- Fix: update `pstate` and `*(opts.ppfd_state)` to the new allocation after realloc. Split the blocking/non-blocking realloc paths for clarity.
- Add `test_rng_fd_serialize_non_blocking()` exercising the non-blocking FILE_DESCRIPTOR serialize and deserialize paths via a pipe with `O_NONBLOCK`.
- Verified clean under valgrind (0 errors, 0 leaks).

Supersedes #67 (rebased on devel after #66 merged).

## Test plan

- [x] All 30 C tests pass
- [x] Ruby and Python binding tests pass
- [x] Valgrind: 0 errors, 0 leaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)