### PR TITLE
Add configuration-with-features and float strided distribution tests

### DIFF
--- a/tests/test_configuration_space.c
+++ b/tests/test_configuration_space.c
@@ -480,6 +480,70 @@ test_deserialize_errors(void)
 	ccs_release_object(rng);
 }
 
+void
+test_configuration_with_features(void)
+{
+	ccs_result_t              err;
+	ccs_parameter_t           parameter;
+	ccs_configuration_space_t cspace;
+	ccs_configuration_t       config1, config2;
+	ccs_feature_space_t       fspace;
+	ccs_features_t            features_on, features_off;
+	ccs_features_t            features_ret;
+	ccs_hash_t                hash1, hash2;
+	int                       cmp;
+
+	parameter = create_numerical("x", -5.0, 5.0);
+
+	fspace    = create_knobs(&features_on, &features_off);
+
+	err       = ccs_create_configuration_space(
+                "space_with_features", 1, &parameter, NULL, 0, NULL, fspace,
+                NULL, &cspace);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	/* Sample a configuration with features */
+	err = ccs_configuration_space_sample(
+		cspace, NULL, features_on, NULL, &config1);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	/* Verify get_features */
+	err = ccs_configuration_get_features(config1, &features_ret);
+	assert(err == CCS_RESULT_SUCCESS);
+	assert(features_ret == features_on);
+
+	/* Sample with different features */
+	err = ccs_configuration_space_sample(
+		cspace, NULL, features_off, NULL, &config2);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	/* Hash should work with features */
+	err = ccs_binding_hash((ccs_binding_t)config1, &hash1);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_binding_hash((ccs_binding_t)config2, &hash2);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	/* Compare configurations with different features */
+	err = ccs_binding_cmp(
+		(ccs_binding_t)config1, (ccs_binding_t)config2, &cmp);
+	assert(err == CCS_RESULT_SUCCESS);
+	assert(cmp != 0);
+
+	/* Compare configuration with itself */
+	err = ccs_binding_cmp(
+		(ccs_binding_t)config1, (ccs_binding_t)config1, &cmp);
+	assert(err == CCS_RESULT_SUCCESS);
+	assert(cmp == 0);
+
+	ccs_release_object(config2);
+	ccs_release_object(config1);
+	ccs_release_object(cspace);
+	ccs_release_object(features_off);
+	ccs_release_object(features_on);
+	ccs_release_object(fspace);
+	ccs_release_object(parameter);
+}
+
 int
 main(void)
 {
@@ -490,6 +554,7 @@ main(void)
 	test_deserialize();
 	test_configuration_deserialize();
 	test_deserialize_errors();
+	test_configuration_with_features();
 	ccs_clear_thread_error();
 	ccs_fini();
 	return 0;

--- a/tests/test_uniform_distribution.c
+++ b/tests/test_uniform_distribution.c
@@ -487,6 +487,57 @@ test_uniform_distribution_soa_samples(void)
 	assert(err == CCS_RESULT_SUCCESS);
 }
 
+static void
+test_uniform_distribution_float_strided_samples(void)
+{
+	ccs_distribution_t distrib1    = NULL;
+	ccs_distribution_t distrib2    = NULL;
+	ccs_rng_t          rng         = NULL;
+	ccs_result_t       err         = CCS_RESULT_SUCCESS;
+	const size_t       num_samples = NUM_SAMPLES;
+	ccs_float_t        lower1      = -10.0;
+	ccs_float_t        upper1      = 11.0;
+	ccs_float_t        lower2      = 12.0;
+	ccs_float_t        upper2      = 20.0;
+	ccs_numeric_t      samples[NUM_SAMPLES * 2];
+
+	err = ccs_create_rng(&rng);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_create_uniform_distribution(
+		CCS_NUMERIC_TYPE_FLOAT, CCSF(lower1), CCSF(upper1),
+		CCS_SCALE_TYPE_LINEAR, CCSF(0.0), &distrib1);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	err = ccs_create_uniform_distribution(
+		CCS_NUMERIC_TYPE_FLOAT, CCSF(lower2), CCSF(upper2),
+		CCS_SCALE_TYPE_LINEAR, CCSF(0.0), &distrib2);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	err = ccs_distribution_strided_samples(
+		distrib1, rng, num_samples, 2, samples);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_distribution_strided_samples(
+		distrib2, rng, num_samples, 2, &(samples[0]) + 1);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	for (size_t i = 0; i < num_samples; i++) {
+		assert(samples[i * 2].f >= lower1);
+		assert(samples[i * 2].f < upper1);
+	}
+
+	for (size_t i = 0; i < num_samples; i++) {
+		assert(samples[i * 2 + 1].f >= lower2);
+		assert(samples[i * 2 + 1].f < upper2);
+	}
+
+	err = ccs_release_object(distrib1);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_release_object(distrib2);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_release_object(rng);
+	assert(err == CCS_RESULT_SUCCESS);
+}
+
 int
 main(void)
 {
@@ -502,6 +553,7 @@ main(void)
 	test_uniform_distribution_float_quantize();
 	test_uniform_distribution_float_log_quantize();
 	test_uniform_distribution_strided_samples();
+	test_uniform_distribution_float_strided_samples();
 	test_uniform_distribution_soa_samples();
 	ccs_clear_thread_error();
 	ccs_fini();


### PR DESCRIPTION
## Summary

- Add \`test_configuration_with_features()\`: creates a configuration space with a feature space, samples with features, verifies \`ccs_configuration_get_features\`, and exercises \`ccs_binding_hash\`/\`ccs_binding_cmp\` on configurations with features — covering the hash/cmp paths from PR #43
- Add \`test_uniform_distribution_float_strided_samples()\`: exercises the float strided sampling path (\`_ccs_distribution_uniform_strided_samples_float\`) which was previously untested

## Test plan

- [x] All 30 C tests pass
- [x] Ruby and Python binding tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)