### PR TITLE
Fix mixture strided/SOA tests and add int oversampling test

### DIFF
--- a/tests/test_mixture_distribution.c
+++ b/tests/test_mixture_distribution.c
@@ -233,7 +233,7 @@ test_mixture_distribution_strided_samples(void)
 	assert(err == CCS_RESULT_SUCCESS);
 
 	err = ccs_distribution_strided_samples(
-		distrib, rng, num_samples, NUM_DISTRIBS + 1, samples);
+		t_distrib, rng, num_samples, NUM_DISTRIBS + 1, samples);
 	assert(err == CCS_RESULT_SUCCESS);
 
 	for (size_t i = 0; i < num_samples; i++) {
@@ -298,7 +298,8 @@ test_mixture_distribution_soa_samples(void)
                 num_t_distribs, t_distribs, weights, &t_distrib);
 	assert(err == CCS_RESULT_SUCCESS);
 
-	err = ccs_distribution_soa_samples(distrib, rng, num_samples, samples);
+	err = ccs_distribution_soa_samples(
+		t_distrib, rng, num_samples, samples);
 	assert(err == CCS_RESULT_SUCCESS);
 
 	for (size_t i = 0; i < num_samples; i++) {

--- a/tests/test_numerical_parameter.c
+++ b/tests/test_numerical_parameter.c
@@ -181,6 +181,42 @@ test_oversampling(void)
 	assert(err == CCS_RESULT_SUCCESS);
 }
 
+void
+test_oversampling_int(void)
+{
+	ccs_rng_t          rng;
+	ccs_parameter_t    parameter;
+	ccs_distribution_t distribution;
+	const size_t       num_samples = NUM_SAMPLES;
+	ccs_datum_t        samples[NUM_SAMPLES];
+	ccs_result_t       err;
+
+	err = ccs_create_rng(&rng);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	err = ccs_create_normal_int_distribution(
+		0, 5, CCS_SCALE_TYPE_LINEAR, 0, &distribution);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	err = ccs_create_numerical_parameter(
+		"my_param", CCS_NUMERIC_TYPE_INT, CCSI(-3), CCSI(4), CCSI(0),
+		CCSI(0), &parameter);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	err = ccs_parameter_samples(
+		parameter, distribution, rng, num_samples, samples);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	for (size_t i = 0; i < num_samples; i++) {
+		assert(samples[i].type == CCS_DATA_TYPE_INT);
+		assert(samples[i].value.i >= -3 && samples[i].value.i < 4);
+	}
+
+	ccs_release_object(distribution);
+	ccs_release_object(parameter);
+	ccs_release_object(rng);
+}
+
 int
 main(void)
 {
@@ -188,6 +224,7 @@ main(void)
 	test_create();
 	test_samples();
 	test_oversampling();
+	test_oversampling_int();
 	ccs_clear_thread_error();
 	ccs_fini();
 	return 0;


### PR DESCRIPTION
## Summary

- Fix \`test_mixture_distribution_strided_samples\`: was calling \`ccs_distribution_strided_samples\` on \`distrib\` (multivariate) instead of \`t_distrib\` (mixture) — the mixture's strided path was entirely untested
- Fix \`test_mixture_distribution_soa_samples\`: same issue — was testing multivariate SOA instead of mixture SOA
- Add \`test_oversampling_int\`: exercises the integer oversampling branch in \`_ccs_parameter_numerical_convert_samples\` (lines 150-152, 185-190) — only float oversampling was previously covered

## Test plan

- [x] All 30 C tests pass
- [x] Ruby and Python binding tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)