### PR TITLE
Add coverage tests: ordinal comparisons, binding extras, strided variants

### DIFF
--- a/tests/test_expression.c
+++ b/tests/test_expression.c
@@ -1393,6 +1393,89 @@ test_user_defined(void)
 	assert(err == CCS_RESULT_SUCCESS);
 }
 
+void
+test_less_ordinal(void)
+{
+	ccs_configuration_space_t configuration_space;
+	ccs_configuration_t       configuration;
+	ccs_parameter_t           parameters[2];
+	ccs_datum_t               nodes[2];
+	ccs_datum_t               values[2];
+	ccs_result_t              err;
+
+	/* Ordinal order: int(1) < float(2.0) < "toto" < none */
+	parameters[0] = create_dummy_ordinal("param1");
+	parameters[1] = create_dummy_ordinal("param2");
+	err           = ccs_create_configuration_space(
+                "my_config_space", 2, parameters, NULL, 0, NULL, NULL, NULL,
+                &configuration_space);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	/* param1 (left variable) = int(1), compare with float(2.0)
+	 * ordinal: int(1) < float(2.0), so LESS should be TRUE */
+	nodes[0]  = ccs_object(parameters[0]);
+	nodes[1]  = ccs_float(2.0);
+	values[0] = ccs_int(1);
+	values[1] = ccs_int(1);
+	err       = ccs_create_configuration(
+                configuration_space, NULL, 2, values, &configuration);
+	assert(err == CCS_RESULT_SUCCESS);
+	test_expression_wrapper(
+		CCS_EXPRESSION_TYPE_LESS, 2, nodes, configuration,
+		ccs_bool(CCS_TRUE), CCS_RESULT_SUCCESS);
+	ccs_release_object(configuration);
+
+	/* param1 = float(2.0), compare with int(1)
+	 * ordinal: float(2.0) > int(1), so LESS should be FALSE */
+	values[0] = ccs_float(2.0);
+	err       = ccs_create_configuration(
+                configuration_space, NULL, 2, values, &configuration);
+	assert(err == CCS_RESULT_SUCCESS);
+	test_expression_wrapper(
+		CCS_EXPRESSION_TYPE_LESS, 2, nodes, configuration,
+		ccs_bool(CCS_FALSE), CCS_RESULT_SUCCESS);
+	ccs_release_object(configuration);
+
+	/* GREATER: nodes = [param1, int(1)], param1 = float(2.0)
+	 * ordinal: float(2.0) > int(1) -> TRUE */
+	nodes[1]  = ccs_int(1);
+	values[0] = ccs_float(2.0);
+	err       = ccs_create_configuration(
+                configuration_space, NULL, 2, values, &configuration);
+	assert(err == CCS_RESULT_SUCCESS);
+	test_expression_wrapper(
+		CCS_EXPRESSION_TYPE_GREATER, 2, nodes, configuration,
+		ccs_bool(CCS_TRUE), CCS_RESULT_SUCCESS);
+	ccs_release_object(configuration);
+
+	/* LESS_OR_EQUAL: nodes = [param1, float(2.0)], param1 = float(2.0)
+	 * ordinal: float(2.0) <= float(2.0) -> TRUE */
+	nodes[1]  = ccs_float(2.0);
+	values[0] = ccs_float(2.0);
+	err       = ccs_create_configuration(
+                configuration_space, NULL, 2, values, &configuration);
+	assert(err == CCS_RESULT_SUCCESS);
+	test_expression_wrapper(
+		CCS_EXPRESSION_TYPE_LESS_OR_EQUAL, 2, nodes, configuration,
+		ccs_bool(CCS_TRUE), CCS_RESULT_SUCCESS);
+	ccs_release_object(configuration);
+
+	/* GREATER_OR_EQUAL: nodes = [param1, float(2.0)], param1 = int(1)
+	 * ordinal: int(1) >= float(2.0) -> FALSE */
+	values[0] = ccs_int(1);
+	err       = ccs_create_configuration(
+                configuration_space, NULL, 2, values, &configuration);
+	assert(err == CCS_RESULT_SUCCESS);
+	test_expression_wrapper(
+		CCS_EXPRESSION_TYPE_GREATER_OR_EQUAL, 2, nodes, configuration,
+		ccs_bool(CCS_FALSE), CCS_RESULT_SUCCESS);
+	ccs_release_object(configuration);
+
+	ccs_release_object(configuration_space);
+	ccs_release_object(parameters[0]);
+	ccs_release_object(parameters[1]);
+}
+
 int
 main(void)
 {
@@ -1401,6 +1484,7 @@ main(void)
 	test_equal_numerical();
 	test_equal_categorical();
 	test_equal_ordinal();
+	test_less_ordinal();
 	test_arithmetic_add();
 	test_arithmetic_substract();
 	test_arithmetic_multiply();

--- a/tests/test_expression.c
+++ b/tests/test_expression.c
@@ -1427,6 +1427,7 @@ test_less_ordinal(void)
 
 	/* param1 = float(2.0), compare with int(1)
 	 * ordinal: float(2.0) > int(1), so LESS should be FALSE */
+	nodes[1]  = ccs_int(1);
 	values[0] = ccs_float(2.0);
 	err       = ccs_create_configuration(
                 configuration_space, NULL, 2, values, &configuration);
@@ -1438,7 +1439,6 @@ test_less_ordinal(void)
 
 	/* GREATER: nodes = [param1, int(1)], param1 = float(2.0)
 	 * ordinal: float(2.0) > int(1) -> TRUE */
-	nodes[1]  = ccs_int(1);
 	values[0] = ccs_float(2.0);
 	err       = ccs_create_configuration(
                 configuration_space, NULL, 2, values, &configuration);

--- a/tests/test_feature_space.c
+++ b/tests/test_feature_space.c
@@ -2,6 +2,7 @@
 #include <assert.h>
 #include <cconfigspace.h>
 #include <string.h>
+#include "test_utils.h"
 
 double d = -2.0;
 
@@ -378,6 +379,43 @@ test_features_deserialize(void)
 	}
 }
 
+void
+test_binding_extras(void)
+{
+	ccs_result_t        err;
+	ccs_parameter_t     parameter;
+	ccs_feature_space_t fspace;
+	ccs_features_t      features;
+	ccs_datum_t         values[3];
+	ccs_datum_t         value;
+	ccs_bool_t          found;
+
+	parameter = create_numerical("x", -5.0, 5.0);
+	err       = ccs_create_feature_space("fspace", 1, &parameter, &fspace);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	ccs_datum_t fval = ccs_float(1.0);
+	err              = ccs_create_features(fspace, 1, &fval, &features);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	/* get_values with oversized buffer — tail should be zeroed */
+	err = ccs_binding_get_values((ccs_binding_t)features, 3, values, NULL);
+	assert(err == CCS_RESULT_SUCCESS);
+	assert(values[0].value.f == 1.0);
+	assert(values[1].type == CCS_DATA_TYPE_NONE);
+	assert(values[2].type == CCS_DATA_TYPE_NONE);
+
+	/* get_value_by_name with nonexistent name */
+	err = ccs_binding_get_value_by_name(
+		(ccs_binding_t)features, "nonexistent", &found, &value);
+	assert(err == CCS_RESULT_SUCCESS);
+	assert(found == CCS_FALSE);
+
+	ccs_release_object(features);
+	ccs_release_object(fspace);
+	ccs_release_object(parameter);
+}
+
 int
 main(void)
 {
@@ -386,6 +424,7 @@ main(void)
 	test_features();
 	test_deserialize();
 	test_features_deserialize();
+	test_binding_extras();
 	ccs_clear_thread_error();
 	ccs_fini();
 	return 0;

--- a/tests/test_roulette_distribution.c
+++ b/tests/test_roulette_distribution.c
@@ -358,6 +358,34 @@ test_roulette_distribution_soa_samples(void)
 	assert(err == CCS_RESULT_SUCCESS);
 }
 
+void
+test_roulette_distribution_get_areas_oversized(void)
+{
+	ccs_distribution_t distrib = NULL;
+	ccs_result_t       err;
+	ccs_float_t        areas[] = {1.0, 2.0, 3.0};
+	ccs_float_t        areas_ret[5];
+	size_t             num_areas_ret;
+
+	err = ccs_create_roulette_distribution(3, areas, &distrib);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	/* Oversized buffer — extra slots should be zeroed */
+	err = ccs_roulette_distribution_get_areas(
+		distrib, 5, areas_ret, &num_areas_ret);
+	assert(err == CCS_RESULT_SUCCESS);
+	assert(num_areas_ret == 3);
+	assert(areas_ret[3] == 0.0);
+	assert(areas_ret[4] == 0.0);
+
+	/* Undersized buffer */
+	err = ccs_roulette_distribution_get_areas(distrib, 2, areas_ret, NULL);
+	assert(err == CCS_RESULT_ERROR_INVALID_VALUE);
+	ccs_clear_thread_error();
+
+	ccs_release_object(distrib);
+}
+
 int
 main(void)
 {
@@ -368,6 +396,7 @@ main(void)
 	test_roulette_distribution_zero();
 	test_roulette_distribution_strided_samples();
 	test_roulette_distribution_soa_samples();
+	test_roulette_distribution_get_areas_oversized();
 	ccs_clear_thread_error();
 	ccs_fini();
 	return 0;

--- a/tests/test_uniform_distribution.c
+++ b/tests/test_uniform_distribution.c
@@ -538,6 +538,123 @@ test_uniform_distribution_float_strided_samples(void)
 	assert(err == CCS_RESULT_SUCCESS);
 }
 
+static void
+test_uniform_distribution_int_log_strided_samples(void)
+{
+	ccs_distribution_t distrib     = NULL;
+	ccs_rng_t          rng         = NULL;
+	ccs_result_t       err         = CCS_RESULT_SUCCESS;
+	const size_t       num_samples = NUM_SAMPLES;
+	ccs_numeric_t      samples[NUM_SAMPLES * 2];
+
+	err = ccs_create_rng(&rng);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_create_uniform_distribution(
+		CCS_NUMERIC_TYPE_INT, CCSI(1), CCSI(100),
+		CCS_SCALE_TYPE_LOGARITHMIC, CCSI(0), &distrib);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	err = ccs_distribution_strided_samples(
+		distrib, rng, num_samples, 2, samples);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	for (size_t i = 0; i < num_samples; i++) {
+		assert(samples[i * 2].i >= 1);
+		assert(samples[i * 2].i < 100);
+	}
+
+	ccs_release_object(distrib);
+	ccs_release_object(rng);
+}
+
+static void
+test_uniform_distribution_float_log_strided_samples(void)
+{
+	ccs_distribution_t distrib     = NULL;
+	ccs_rng_t          rng         = NULL;
+	ccs_result_t       err         = CCS_RESULT_SUCCESS;
+	const size_t       num_samples = NUM_SAMPLES;
+	ccs_numeric_t      samples[NUM_SAMPLES * 2];
+
+	err = ccs_create_rng(&rng);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_create_uniform_distribution(
+		CCS_NUMERIC_TYPE_FLOAT, CCSF(1.0), CCSF(100.0),
+		CCS_SCALE_TYPE_LOGARITHMIC, CCSF(0.0), &distrib);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	err = ccs_distribution_strided_samples(
+		distrib, rng, num_samples, 2, samples);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	for (size_t i = 0; i < num_samples; i++) {
+		assert(samples[i * 2].f >= 1.0);
+		assert(samples[i * 2].f < 100.0);
+	}
+
+	ccs_release_object(distrib);
+	ccs_release_object(rng);
+}
+
+static void
+test_uniform_distribution_int_quantize_strided_samples(void)
+{
+	ccs_distribution_t distrib     = NULL;
+	ccs_rng_t          rng         = NULL;
+	ccs_result_t       err         = CCS_RESULT_SUCCESS;
+	const size_t       num_samples = NUM_SAMPLES;
+	ccs_numeric_t      samples[NUM_SAMPLES * 2];
+
+	err = ccs_create_rng(&rng);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_create_uniform_distribution(
+		CCS_NUMERIC_TYPE_INT, CCSI(0), CCSI(100), CCS_SCALE_TYPE_LINEAR,
+		CCSI(5), &distrib);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	err = ccs_distribution_strided_samples(
+		distrib, rng, num_samples, 2, samples);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	for (size_t i = 0; i < num_samples; i++) {
+		assert(samples[i * 2].i >= 0);
+		assert(samples[i * 2].i < 100);
+		assert(samples[i * 2].i % 5 == 0);
+	}
+
+	ccs_release_object(distrib);
+	ccs_release_object(rng);
+}
+
+static void
+test_uniform_distribution_float_quantize_strided_samples(void)
+{
+	ccs_distribution_t distrib     = NULL;
+	ccs_rng_t          rng         = NULL;
+	ccs_result_t       err         = CCS_RESULT_SUCCESS;
+	const size_t       num_samples = NUM_SAMPLES;
+	ccs_numeric_t      samples[NUM_SAMPLES * 2];
+
+	err = ccs_create_rng(&rng);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_create_uniform_distribution(
+		CCS_NUMERIC_TYPE_FLOAT, CCSF(0.0), CCSF(10.0),
+		CCS_SCALE_TYPE_LINEAR, CCSF(0.5), &distrib);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	err = ccs_distribution_strided_samples(
+		distrib, rng, num_samples, 2, samples);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	for (size_t i = 0; i < num_samples; i++) {
+		assert(samples[i * 2].f >= 0.0);
+		assert(samples[i * 2].f < 10.0);
+	}
+
+	ccs_release_object(distrib);
+	ccs_release_object(rng);
+}
+
 int
 main(void)
 {
@@ -554,6 +671,10 @@ main(void)
 	test_uniform_distribution_float_log_quantize();
 	test_uniform_distribution_strided_samples();
 	test_uniform_distribution_float_strided_samples();
+	test_uniform_distribution_int_log_strided_samples();
+	test_uniform_distribution_float_log_strided_samples();
+	test_uniform_distribution_int_quantize_strided_samples();
+	test_uniform_distribution_float_quantize_strided_samples();
 	test_uniform_distribution_soa_samples();
 	ccs_clear_thread_error();
 	ccs_fini();


### PR DESCRIPTION
## Summary

- **\`test_less_ordinal()\`** in test_expression.c: exercises ordinal parameter comparison branches in LESS, GREATER, LESS_OR_EQUAL, GREATER_OR_EQUAL expression evaluators (~40 uncovered lines across 4 functions)
- **\`test_binding_extras()\`** in test_feature_space.c: oversized buffer tail-zeroing in \`ccs_binding_get_values\`, and name-not-found early return in \`ccs_binding_get_value_by_name\`
- **\`test_roulette_distribution_get_areas_oversized()\`**: oversized buffer (tail zeroing) and undersized buffer (error) tests for \`ccs_roulette_distribution_get_areas\`
- **4 new uniform distribution strided tests**: int log, float log, int quantize, float quantize — covering all previously untested strided sampling branches in \`distribution_uniform.c\`

## Test plan

- [x] All 30 C tests pass
- [x] Ruby and Python binding tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)