### PR TITLE
Add checked-overflow allocation helpers and harden deserialize sites

### DIFF
--- a/src/cconfigspace_internal.h
+++ b/src/cconfigspace_internal.h
@@ -958,12 +958,7 @@ _ccs_size_add(size_t a, size_t b, size_t *result)
 }
 
 static inline ccs_bool_t
-_ccs_size_sum2(
-	size_t n1,
-	size_t s1,
-	size_t n2,
-	size_t s2,
-	size_t *result)
+_ccs_size_sum2(size_t n1, size_t s1, size_t n2, size_t s2, size_t *result)
 {
 	size_t p1, p2;
 	if (_ccs_size_mul(n1, s1, &p1))
@@ -975,12 +970,12 @@ _ccs_size_sum2(
 
 static inline ccs_bool_t
 _ccs_size_sum3(
-	size_t n1,
-	size_t s1,
-	size_t n2,
-	size_t s2,
-	size_t n3,
-	size_t s3,
+	size_t  n1,
+	size_t  s1,
+	size_t  n2,
+	size_t  s2,
+	size_t  n3,
+	size_t  s3,
 	size_t *result)
 {
 	size_t p;

--- a/src/cconfigspace_internal.h
+++ b/src/cconfigspace_internal.h
@@ -943,6 +943,55 @@ _ccs_deserialize_bin_size(size_t *sz, size_t *buffer_size, const char **buffer)
 	return CCS_RESULT_SUCCESS;
 }
 
+/* Checked-overflow size arithmetic for safe allocation.
+ * All return CCS_TRUE on overflow. */
+static inline ccs_bool_t
+_ccs_size_mul(size_t a, size_t b, size_t *result)
+{
+	return __builtin_mul_overflow(a, b, result) ? CCS_TRUE : CCS_FALSE;
+}
+
+static inline ccs_bool_t
+_ccs_size_add(size_t a, size_t b, size_t *result)
+{
+	return __builtin_add_overflow(a, b, result) ? CCS_TRUE : CCS_FALSE;
+}
+
+static inline ccs_bool_t
+_ccs_size_sum2(
+	size_t n1,
+	size_t s1,
+	size_t n2,
+	size_t s2,
+	size_t *result)
+{
+	size_t p1, p2;
+	if (_ccs_size_mul(n1, s1, &p1))
+		return CCS_TRUE;
+	if (_ccs_size_mul(n2, s2, &p2))
+		return CCS_TRUE;
+	return _ccs_size_add(p1, p2, result);
+}
+
+static inline ccs_bool_t
+_ccs_size_sum3(
+	size_t n1,
+	size_t s1,
+	size_t n2,
+	size_t s2,
+	size_t n3,
+	size_t s3,
+	size_t *result)
+{
+	size_t p;
+	if (_ccs_size_sum2(n1, s1, n2, s2, &p))
+		return CCS_TRUE;
+	size_t p3;
+	if (_ccs_size_mul(n3, s3, &p3))
+		return CCS_TRUE;
+	return _ccs_size_add(p, p3, result);
+}
+
 static inline size_t
 _ccs_serialize_bin_size_string(const char *str)
 {

--- a/src/configuration_space_deserialize.h
+++ b/src/configuration_space_deserialize.h
@@ -51,12 +51,18 @@ _ccs_deserialize_bin_ccs_configuration_space_data(
 	if (!(data->num_parameters + data->num_conditions +
 	      data->num_forbidden_clauses))
 		return CCS_RESULT_SUCCESS;
-	mem = (uintptr_t)calloc(
-		1,
-		data->num_parameters * sizeof(ccs_parameter_t) +
-			data->num_parameters * sizeof(ccs_expression_t) +
-			data->num_forbidden_clauses * sizeof(ccs_expression_t));
-	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	{
+		size_t _sz;
+		CCS_REFUTE(
+			_ccs_size_sum3(
+				data->num_parameters, sizeof(ccs_parameter_t),
+				data->num_parameters, sizeof(ccs_expression_t),
+				data->num_forbidden_clauses,
+				sizeof(ccs_expression_t), &_sz),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		mem = (uintptr_t)calloc(1, _sz);
+		CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	}
 
 	data->parameters = (ccs_parameter_t *)mem;
 	mem += data->num_parameters * sizeof(ccs_parameter_t);

--- a/src/distribution_deserialize.h
+++ b/src/distribution_deserialize.h
@@ -131,9 +131,15 @@ _ccs_deserialize_bin_ccs_distribution_roulette_data(
 		&data->common_data, buffer_size, buffer));
 	CCS_VALIDATE(_ccs_deserialize_bin_size(
 		&data->num_areas, buffer_size, buffer));
-	data->areas =
-		(ccs_float_t *)malloc(data->num_areas * sizeof(ccs_float_t));
-	CCS_REFUTE(!data->areas, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	{
+		size_t _sz;
+		CCS_REFUTE(
+			_ccs_size_mul(
+				data->num_areas, sizeof(ccs_float_t), &_sz),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		data->areas = (ccs_float_t *)malloc(_sz);
+		CCS_REFUTE(!data->areas, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	}
 	for (size_t i = 0; i < data->num_areas; i++)
 		CCS_VALIDATE(_ccs_deserialize_bin_ccs_float(
 			data->areas + i, buffer_size, buffer));
@@ -193,9 +199,16 @@ _ccs_deserialize_bin_ccs_distribution_mixture_data(
 	data->distributions = (ccs_distribution_t *)calloc(
 		data->num_distributions, sizeof(ccs_distribution_t));
 	CCS_REFUTE(!data->distributions, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-	data->weights = (ccs_float_t *)malloc(
-		sizeof(ccs_float_t) * data->num_distributions);
-	CCS_REFUTE(!data->weights, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	{
+		size_t _sz;
+		CCS_REFUTE(
+			_ccs_size_mul(
+				data->num_distributions, sizeof(ccs_float_t),
+				&_sz),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		data->weights = (ccs_float_t *)malloc(_sz);
+		CCS_REFUTE(!data->weights, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	}
 	for (size_t i = 0; i < data->num_distributions; i++) {
 		CCS_VALIDATE(_ccs_deserialize_bin_ccs_float(
 			data->weights + i, buffer_size, buffer));

--- a/src/distribution_space_deserialize.h
+++ b/src/distribution_space_deserialize.h
@@ -34,11 +34,17 @@ _ccs_deserialize_bin_ccs_distribution_space_data(
 
 	if (!(data->num_distributions))
 		return CCS_RESULT_SUCCESS;
-	mem = (uintptr_t)calloc(
-		1, data->num_distributions * (sizeof(ccs_distribution_t) +
-					      sizeof(size_t)) +
-			   data->num_parameters * sizeof(size_t));
-	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	{
+		size_t _sz;
+		CCS_REFUTE(
+			_ccs_size_sum2(
+				data->num_distributions,
+				sizeof(ccs_distribution_t) + sizeof(size_t),
+				data->num_parameters, sizeof(size_t), &_sz),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		mem = (uintptr_t)calloc(1, _sz);
+		CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	}
 
 	data->distributions = (ccs_distribution_t *)mem;
 	mem += data->num_distributions * sizeof(ccs_distribution_t);

--- a/src/map_deserialize.h
+++ b/src/map_deserialize.h
@@ -22,9 +22,15 @@ _ccs_deserialize_bin_ccs_map_data(
 {
 	CCS_VALIDATE(_ccs_deserialize_bin_size(
 		&data->num_pairs, buffer_size, buffer));
-	data->pairs = (_ccs_map_pair_t *)malloc(
-		data->num_pairs * sizeof(_ccs_map_pair_t));
-	CCS_REFUTE(!data->pairs, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	{
+		size_t _sz;
+		CCS_REFUTE(
+			_ccs_size_mul(
+				data->num_pairs, sizeof(_ccs_map_pair_t), &_sz),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		data->pairs = (_ccs_map_pair_t *)malloc(_sz);
+		CCS_REFUTE(!data->pairs, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	}
 	for (size_t i = 0; i < data->num_pairs; i++) {
 		CCS_VALIDATE(_ccs_deserialize_bin_ccs_datum(
 			&data->pairs[i].key, buffer_size, buffer));

--- a/src/objective_space_deserialize.h
+++ b/src/objective_space_deserialize.h
@@ -43,12 +43,19 @@ _ccs_deserialize_bin_ccs_objective_space_data(
 
 	if (!(data->num_parameters + data->num_objectives))
 		return CCS_RESULT_SUCCESS;
-	mem = (uintptr_t)calloc(
-		1,
-		data->num_parameters * sizeof(ccs_parameter_t) +
-			data->num_objectives * (sizeof(ccs_expression_t) +
-						sizeof(ccs_objective_type_t)));
-	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	{
+		size_t _sz;
+		CCS_REFUTE(
+			_ccs_size_sum2(
+				data->num_parameters, sizeof(ccs_parameter_t),
+				data->num_objectives,
+				sizeof(ccs_expression_t) +
+					sizeof(ccs_objective_type_t),
+				&_sz),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		mem = (uintptr_t)calloc(1, _sz);
+		CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	}
 	data->parameters = (ccs_parameter_t *)mem;
 	mem += data->num_parameters * sizeof(ccs_parameter_t);
 	data->objectives = (ccs_expression_t *)mem;

--- a/src/parameter_deserialize.h
+++ b/src/parameter_deserialize.h
@@ -50,9 +50,17 @@ _ccs_deserialize_bin_ccs_parameter_categorical_data(
 		&data->common_data, buffer_size, buffer));
 	CCS_VALIDATE(_ccs_deserialize_bin_size(
 		&data->num_possible_values, buffer_size, buffer));
-	data->possible_values = (ccs_datum_t *)malloc(
-		data->num_possible_values * sizeof(ccs_datum_t));
-	CCS_REFUTE(!data->possible_values, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	{
+		size_t _sz;
+		CCS_REFUTE(
+			_ccs_size_mul(
+				data->num_possible_values, sizeof(ccs_datum_t),
+				&_sz),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		data->possible_values = (ccs_datum_t *)malloc(_sz);
+		CCS_REFUTE(
+			!data->possible_values, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	}
 	for (size_t i = 0; i < data->num_possible_values; i++)
 		CCS_VALIDATE(_ccs_deserialize_bin_ccs_datum(
 			data->possible_values + i, buffer_size, buffer));

--- a/src/tree_configuration_deserialize.h
+++ b/src/tree_configuration_deserialize.h
@@ -26,8 +26,11 @@ _ccs_deserialize_bin_tree_configuration_data(
 	CCS_VALIDATE(_ccs_deserialize_bin_size(
 		&data->position_size, buffer_size, buffer));
 	if (data->position_size) {
-		data->position =
-			(size_t *)malloc(data->position_size * sizeof(size_t));
+		size_t _sz;
+		CCS_REFUTE(
+			_ccs_size_mul(data->position_size, sizeof(size_t), &_sz),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		data->position = (size_t *)malloc(_sz);
 		CCS_REFUTE(!data->position, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 		for (size_t i = 0; i < data->position_size; i++)
 			CCS_VALIDATE(_ccs_deserialize_bin_size(


### PR DESCRIPTION
## Summary

- Add \`_ccs_size_mul\`, \`_ccs_size_add\`, \`_ccs_size_sum2\`, \`_ccs_size_sum3\` inline helpers in \`cconfigspace_internal.h\` using \`__builtin_mul_overflow\`/\`__builtin_add_overflow\` for safe allocation size computation
- Harden 8 HIGH-risk deserialize allocation sites where untrusted counts from the binary stream are multiplied by sizeof types before malloc/calloc — on overflow, these would allocate a truncated buffer causing heap overflow
- Sites fixed: \`distribution_deserialize.h\` (2), \`configuration_space_deserialize.h\` (1), \`distribution_space_deserialize.h\` (1), \`objective_space_deserialize.h\` (1), \`tree_configuration_deserialize.h\` (1), \`map_deserialize.h\` (1), \`parameter_deserialize.h\` (1)

## Test plan

- [x] All 30 C tests pass (gcc, g++)
- [x] Ruby and Python binding tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)