### PR TITLE
Harden MEDIUM-risk allocation sites with overflow checks

### DIFF
--- a/src/configuration_space.c
+++ b/src/configuration_space.c
@@ -550,17 +550,25 @@ ccs_create_configuration_space(
 		CCS_CHECK_OBJ(rng, CCS_OBJECT_TYPE_RNG);
 
 	ccs_result_t err;
-	uintptr_t    mem = (uintptr_t)calloc(
-                1,
-                sizeof(struct _ccs_configuration_space_s) +
-                        sizeof(struct _ccs_configuration_space_data_s) +
-                        sizeof(ccs_parameter_t) * num_parameters +
-                        sizeof(_ccs_parameter_index_hash_t) * num_parameters +
-                        sizeof(ccs_expression_t) * num_parameters +
-                        sizeof(UT_array *) * num_parameters * 2 +
-                        sizeof(size_t) * num_parameters +
-                        sizeof(ccs_expression_t) * num_forbidden_clauses +
-                        strlen(name) + 1);
+	size_t       _sz;
+	CCS_REFUTE(
+		_ccs_size_sum2(
+			num_parameters,
+			sizeof(ccs_parameter_t) +
+				sizeof(_ccs_parameter_index_hash_t) +
+				sizeof(ccs_expression_t) +
+				sizeof(UT_array *) * 2 + sizeof(size_t),
+			num_forbidden_clauses, sizeof(ccs_expression_t), &_sz),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	CCS_REFUTE(
+		_ccs_size_add(
+			_sz,
+			sizeof(struct _ccs_configuration_space_s) +
+				sizeof(struct _ccs_configuration_space_data_s) +
+				strlen(name) + 1,
+			&_sz),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	uintptr_t mem = (uintptr_t)calloc(1, _sz);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	uintptr_t                 mem_orig = mem;
 

--- a/src/distribution_mixture.c
+++ b/src/distribution_mixture.c
@@ -256,8 +256,8 @@ ccs_create_mixture_distribution(
 	}
 	bounds_tmp = (ccs_interval_t *)tmp_mem;
 	data_types_tmp =
-		(ccs_numeric_type_t *)(tmp_mem + sizeof(ccs_interval_t) *
-							 num_distributions);
+		(ccs_numeric_type_t
+			 *)(tmp_mem + sizeof(ccs_interval_t) * num_distributions);
 
 	distrib = (ccs_distribution_t)cur_mem;
 	cur_mem += sizeof(struct _ccs_distribution_s);

--- a/src/distribution_mixture.c
+++ b/src/distribution_mixture.c
@@ -219,22 +219,24 @@ ccs_create_mixture_distribution(
 	_ccs_distribution_mixture_data_t *distrib_data;
 	{
 		size_t _sz;
-		CCS_REFUTE(_ccs_size_sum2(
-				   num_distributions,
-				   sizeof(ccs_distribution_t) +
-					   sizeof(ccs_float_t),
-				   dimension,
-				   sizeof(ccs_interval_t) +
-					   sizeof(ccs_numeric_type_t),
-				   &_sz),
-			   CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		CCS_REFUTE(_ccs_size_add(
-				   _sz,
-				   sizeof(struct _ccs_distribution_s) +
-					   sizeof(_ccs_distribution_mixture_data_t) +
-					   sizeof(ccs_float_t),
-				   &_sz),
-			   CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		CCS_REFUTE(
+			_ccs_size_sum2(
+				num_distributions,
+				sizeof(ccs_distribution_t) +
+					sizeof(ccs_float_t),
+				dimension,
+				sizeof(ccs_interval_t) +
+					sizeof(ccs_numeric_type_t),
+				&_sz),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		CCS_REFUTE(
+			_ccs_size_add(
+				_sz,
+				sizeof(struct _ccs_distribution_s) +
+					sizeof(_ccs_distribution_mixture_data_t) +
+					sizeof(ccs_float_t),
+				&_sz),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY);
 		mem = (uintptr_t)calloc(1, _sz);
 		CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	}
@@ -250,13 +252,12 @@ ccs_create_mixture_distribution(
 			CCS_RESULT_ERROR_OUT_OF_MEMORY, memory);
 		tmp_mem = (uintptr_t)calloc(1, _sz);
 		CCS_REFUTE_ERR_GOTO(
-			err, !tmp_mem, CCS_RESULT_ERROR_OUT_OF_MEMORY,
-			memory);
+			err, !tmp_mem, CCS_RESULT_ERROR_OUT_OF_MEMORY, memory);
 	}
 	bounds_tmp = (ccs_interval_t *)tmp_mem;
 	data_types_tmp =
-		(ccs_numeric_type_t
-			 *)(tmp_mem + sizeof(ccs_interval_t) * num_distributions);
+		(ccs_numeric_type_t *)(tmp_mem + sizeof(ccs_interval_t) *
+							 num_distributions);
 
 	distrib = (ccs_distribution_t)cur_mem;
 	cur_mem += sizeof(struct _ccs_distribution_s);

--- a/src/distribution_mixture.c
+++ b/src/distribution_mixture.c
@@ -217,22 +217,42 @@ ccs_create_mixture_distribution(
 	ccs_numeric_type_t               *data_types_tmp;
 	ccs_distribution_t                distrib;
 	_ccs_distribution_mixture_data_t *distrib_data;
-	mem = (uintptr_t)calloc(
-		1, sizeof(struct _ccs_distribution_s) +
-			   sizeof(_ccs_distribution_mixture_data_t) +
-			   sizeof(ccs_distribution_t) * num_distributions +
-			   sizeof(ccs_interval_t) * dimension +
-			   sizeof(ccs_float_t) * (num_distributions + 1) +
-			   sizeof(ccs_numeric_type_t) * dimension);
-
-	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	{
+		size_t _sz;
+		CCS_REFUTE(_ccs_size_sum2(
+				   num_distributions,
+				   sizeof(ccs_distribution_t) +
+					   sizeof(ccs_float_t),
+				   dimension,
+				   sizeof(ccs_interval_t) +
+					   sizeof(ccs_numeric_type_t),
+				   &_sz),
+			   CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		CCS_REFUTE(_ccs_size_add(
+				   _sz,
+				   sizeof(struct _ccs_distribution_s) +
+					   sizeof(_ccs_distribution_mixture_data_t) +
+					   sizeof(ccs_float_t),
+				   &_sz),
+			   CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		mem = (uintptr_t)calloc(1, _sz);
+		CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	}
 	cur_mem = mem;
 
-	tmp_mem = (uintptr_t)calloc(
-		1, sizeof(ccs_interval_t) * num_distributions +
-			   sizeof(ccs_numeric_type_t) * dimension);
-	CCS_REFUTE_ERR_GOTO(
-		err, !tmp_mem, CCS_RESULT_ERROR_OUT_OF_MEMORY, memory);
+	{
+		size_t _sz;
+		CCS_REFUTE_ERR_GOTO(
+			err,
+			_ccs_size_sum2(
+				num_distributions, sizeof(ccs_interval_t),
+				dimension, sizeof(ccs_numeric_type_t), &_sz),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY, memory);
+		tmp_mem = (uintptr_t)calloc(1, _sz);
+		CCS_REFUTE_ERR_GOTO(
+			err, !tmp_mem, CCS_RESULT_ERROR_OUT_OF_MEMORY,
+			memory);
+	}
 	bounds_tmp = (ccs_interval_t *)tmp_mem;
 	data_types_tmp =
 		(ccs_numeric_type_t

--- a/src/expression.c
+++ b/src/expression.c
@@ -1670,10 +1670,18 @@ ccs_create_expression(
 	CCS_VALIDATE(_ccs_validate_nodes(num_nodes, nodes));
 
 	ccs_result_t err;
-	uintptr_t    mem = (uintptr_t)calloc(
-                1, sizeof(struct _ccs_expression_s) +
-                           sizeof(struct _ccs_expression_data_s) +
-                           num_nodes * sizeof(ccs_expression_t));
+	size_t       _sz;
+	CCS_REFUTE(
+		_ccs_size_mul(num_nodes, sizeof(ccs_expression_t), &_sz),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	CCS_REFUTE(
+		_ccs_size_add(
+			_sz,
+			sizeof(struct _ccs_expression_s) +
+				sizeof(struct _ccs_expression_data_s),
+			&_sz),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	uintptr_t mem = (uintptr_t)calloc(1, _sz);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 
 	ccs_expression_t expression = (ccs_expression_t)mem;
@@ -1746,11 +1754,19 @@ ccs_create_user_defined_expression(
 	CCS_VALIDATE(_ccs_validate_nodes(num_nodes, nodes));
 
 	ccs_result_t err;
-	uintptr_t    mem = (uintptr_t)calloc(
-                1, sizeof(struct _ccs_expression_s) +
-                           sizeof(struct _ccs_expression_user_defined_data_s) +
-                           num_nodes * sizeof(ccs_expression_t) + strlen(name) +
-                           1);
+	size_t       _sz;
+	CCS_REFUTE(
+		_ccs_size_mul(num_nodes, sizeof(ccs_expression_t), &_sz),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	CCS_REFUTE(
+		_ccs_size_add(
+			_sz,
+			sizeof(struct _ccs_expression_s) +
+				sizeof(struct _ccs_expression_user_defined_data_s) +
+				strlen(name) + 1,
+			&_sz),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	uintptr_t mem = (uintptr_t)calloc(1, _sz);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 
 	ccs_expression_t expression;

--- a/src/objective_space.c
+++ b/src/objective_space.c
@@ -244,14 +244,23 @@ ccs_create_objective_space(
 	CCS_CHECK_ARY(num_objectives, objectives);
 	CCS_CHECK_ARY(num_objectives, types);
 
-	uintptr_t mem = (uintptr_t)calloc(
-		1,
-		sizeof(struct _ccs_objective_space_s) +
-			sizeof(struct _ccs_objective_space_data_s) +
-			sizeof(ccs_parameter_t) * num_parameters +
-			sizeof(_ccs_parameter_index_hash_t) * num_parameters +
-			sizeof(_ccs_objective_t) * num_objectives +
-			strlen(name) + 1);
+	size_t _sz;
+	CCS_REFUTE(
+		_ccs_size_sum2(
+			num_parameters,
+			sizeof(ccs_parameter_t) +
+				sizeof(_ccs_parameter_index_hash_t),
+			num_objectives, sizeof(_ccs_objective_t), &_sz),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	CCS_REFUTE(
+		_ccs_size_add(
+			_sz,
+			sizeof(struct _ccs_objective_space_s) +
+				sizeof(struct _ccs_objective_space_data_s) +
+				strlen(name) + 1,
+			&_sz),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	uintptr_t mem = (uintptr_t)calloc(1, _sz);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	uintptr_t             mem_orig = mem;
 	ccs_result_t          err;

--- a/src/parameter_categorical.c
+++ b/src/parameter_categorical.c
@@ -312,11 +312,20 @@ _ccs_create_categorical_parameter(
 		}
 
 	ccs_result_t err = CCS_RESULT_SUCCESS;
-	uintptr_t    mem = (uintptr_t)calloc(
-                1, sizeof(struct _ccs_parameter_s) +
-                           sizeof(_ccs_parameter_categorical_data_t) +
-                           sizeof(_ccs_hash_datum_t) * num_possible_values +
-                           strlen(name) + 1 + size_strs);
+	size_t       _sz;
+	CCS_REFUTE(
+		_ccs_size_mul(
+			num_possible_values, sizeof(_ccs_hash_datum_t), &_sz),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	CCS_REFUTE(
+		_ccs_size_add(
+			_sz,
+			sizeof(struct _ccs_parameter_s) +
+				sizeof(_ccs_parameter_categorical_data_t) +
+				strlen(name) + 1 + size_strs,
+			&_sz),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	uintptr_t mem = (uintptr_t)calloc(1, _sz);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 
 	ccs_interval_t interval;

--- a/src/tree_configuration.c
+++ b/src/tree_configuration.c
@@ -160,10 +160,18 @@ ccs_create_tree_configuration(
 	CCS_CHECK_ARY(position_size, position);
 	ccs_result_t err;
 	ccs_bool_t   is_valid;
-	uintptr_t    mem = (uintptr_t)calloc(
-                1, sizeof(struct _ccs_tree_configuration_s) +
-                           sizeof(struct _ccs_tree_configuration_data_s) +
-                           position_size * sizeof(size_t));
+	size_t       _sz;
+	CCS_REFUTE(
+		_ccs_size_mul(position_size, sizeof(size_t), &_sz),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	CCS_REFUTE(
+		_ccs_size_add(
+			_sz,
+			sizeof(struct _ccs_tree_configuration_s) +
+				sizeof(struct _ccs_tree_configuration_data_s),
+			&_sz),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	uintptr_t mem = (uintptr_t)calloc(1, _sz);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	uintptr_t                mem_orig = mem;
 	ccs_tree_configuration_t config;


### PR DESCRIPTION
## Summary

Apply the checked-overflow helpers from PR #74 to 7 MEDIUM-risk creation-path allocation sites that are called from deserializers with untrusted counts:

- \`configuration_space.c\`: 7-term sum-of-products allocation
- \`objective_space.c\`: \`num_parameters\` + \`num_objectives\` products
- \`expression.c\`: \`num_nodes * sizeof\` in \`ccs_create_expression\` and \`ccs_create_user_defined_expression\`
- \`parameter_categorical.c\`: \`num_possible_values * sizeof\`
- \`distribution_mixture.c\`: \`num_distributions\` + \`dimension\` products (both allocations)
- \`tree_configuration.c\`: \`position_size * sizeof\`

## Test plan

- [x] All 30 C tests pass (gcc, g++)
- [x] Ruby and Python binding tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)