### PR TITLE
Harden LOWER-risk internal allocation sites with overflow checks

### DIFF
--- a/src/distribution.c
+++ b/src/distribution.c
@@ -221,9 +221,15 @@ ccs_distribution_parameters_samples(
 			oversampling = CCS_TRUE;
 			break;
 		}
-	uintptr_t mem = (uintptr_t)malloc(
-		num_values * dim *
-		(sizeof(ccs_numeric_t) + sizeof(ccs_datum_t)));
+	size_t _sz;
+	CCS_REFUTE(
+		_ccs_size_mul(num_values, dim, &_sz),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	CCS_REFUTE(
+		_ccs_size_mul(
+			_sz, sizeof(ccs_numeric_t) + sizeof(ccs_datum_t), &_sz),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	uintptr_t mem = (uintptr_t)malloc(_sz);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	ccs_datum_t *ds = (ccs_datum_t *)mem;
 	p_vs[0] =
@@ -273,12 +279,26 @@ ccs_distribution_parameters_samples(
 			CCS_REFUTE_ERR_GOTO(
 				err, coeff > 32,
 				CCS_RESULT_ERROR_SAMPLING_UNSUCCESSFUL, errmem);
-			size_t    buff_len = (num_values - found) * coeff;
-			uintptr_t oldmem   = mem;
-			mem                = (uintptr_t)realloc(
-                                (void *)oldmem, buff_len * dim *
-                                                        (sizeof(ccs_numeric_t) +
-                                                         sizeof(ccs_datum_t)));
+			size_t buff_len;
+			CCS_REFUTE_ERR_GOTO(
+				err,
+				_ccs_size_mul(
+					num_values - found, coeff, &buff_len),
+				CCS_RESULT_ERROR_OUT_OF_MEMORY, errmem);
+			size_t _rsz;
+			CCS_REFUTE_ERR_GOTO(
+				err, _ccs_size_mul(buff_len, dim, &_rsz),
+				CCS_RESULT_ERROR_OUT_OF_MEMORY, errmem);
+			CCS_REFUTE_ERR_GOTO(
+				err,
+				_ccs_size_mul(
+					_rsz,
+					sizeof(ccs_numeric_t) +
+						sizeof(ccs_datum_t),
+					&_rsz),
+				CCS_RESULT_ERROR_OUT_OF_MEMORY, errmem);
+			uintptr_t oldmem = mem;
+			mem = (uintptr_t)realloc((void *)oldmem, _rsz);
 			if (CCS_UNLIKELY(!mem)) {
 				if (oldmem)
 					free((void *)oldmem);

--- a/src/distribution_space.c
+++ b/src/distribution_space.c
@@ -342,10 +342,16 @@ ccs_distribution_space_set_distribution(
 				CCS_RESULT_ERROR_INVALID_VALUE);
 	}
 
-	mem = (uintptr_t)malloc(
-		sizeof(void *) * num_parameters * 2 +
-		sizeof(size_t) * num_parameters);
-	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	{
+		size_t _sz;
+		CCS_REFUTE(
+			_ccs_size_mul(
+				num_parameters,
+				sizeof(void *) * 2 + sizeof(size_t), &_sz),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		mem = (uintptr_t)malloc(_sz);
+		CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	}
 
 	CCS_OBJ_WRLOCK(distribution_space);
 	cur_mem            = mem;

--- a/src/parameter_categorical.c
+++ b/src/parameter_categorical.c
@@ -175,10 +175,19 @@ _ccs_parameter_categorical_samples(
 			CCS_REFUTE_ERR_GOTO(
 				err, coeff > 32,
 				CCS_RESULT_ERROR_SAMPLING_UNSUCCESSFUL, errmem);
-			size_t     buff_sz = (num_values - found) * coeff;
-			ccs_int_t *oldvs   = vs;
-			vs                 = (ccs_int_t *)realloc(
-                                oldvs, sizeof(ccs_int_t) * buff_sz);
+			size_t buff_sz;
+			CCS_REFUTE_ERR_GOTO(
+				err,
+				_ccs_size_mul(
+					num_values - found, coeff, &buff_sz),
+				CCS_RESULT_ERROR_OUT_OF_MEMORY, errmem);
+			size_t _rsz;
+			CCS_REFUTE_ERR_GOTO(
+				err,
+				_ccs_size_mul(sizeof(ccs_int_t), buff_sz, &_rsz),
+				CCS_RESULT_ERROR_OUT_OF_MEMORY, errmem);
+			ccs_int_t *oldvs = vs;
+			vs               = (ccs_int_t *)realloc(oldvs, _rsz);
 			if (CCS_UNLIKELY(!vs)) {
 				if (oldvs)
 					free(oldvs);


### PR DESCRIPTION
## Summary

Apply checked-overflow helpers to the remaining internal allocation sites:

- \`distribution.c\`: \`num_values * dim * sizeof\` in \`ccs_distribution_parameters_samples\` — both the initial malloc and the realloc in the oversampling retry loop (triple multiplication)
- \`distribution_space.c\`: \`num_parameters * (sizeof(void*)*2 + sizeof(size_t))\` in \`ccs_distribution_space_set_distribution\`
- \`parameter_categorical.c\`: \`(num_values - found) * coeff * sizeof\` in the categorical oversampling retry realloc

Completes the overflow hardening across all identified allocation sites (HIGH, MEDIUM, and LOWER risk).

## Test plan

- [x] All 30 C tests pass (gcc, g++)
- [x] Ruby and Python binding tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)