### PR TITLE
Replace malloc with calloc in deserializers for safe error cleanup

### DIFF
--- a/src/distribution_deserialize.h
+++ b/src/distribution_deserialize.h
@@ -137,7 +137,7 @@ _ccs_deserialize_bin_ccs_distribution_roulette_data(
 			_ccs_size_mul(
 				data->num_areas, sizeof(ccs_float_t), &_sz),
 			CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		data->areas = (ccs_float_t *)malloc(_sz);
+		data->areas = (ccs_float_t *)calloc(1, _sz);
 		CCS_REFUTE(!data->areas, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	}
 	for (size_t i = 0; i < data->num_areas; i++)
@@ -206,7 +206,7 @@ _ccs_deserialize_bin_ccs_distribution_mixture_data(
 				data->num_distributions, sizeof(ccs_float_t),
 				&_sz),
 			CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		data->weights = (ccs_float_t *)malloc(_sz);
+		data->weights = (ccs_float_t *)calloc(1, _sz);
 		CCS_REFUTE(!data->weights, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	}
 	for (size_t i = 0; i < data->num_distributions; i++) {

--- a/src/map_deserialize.h
+++ b/src/map_deserialize.h
@@ -28,7 +28,7 @@ _ccs_deserialize_bin_ccs_map_data(
 			_ccs_size_mul(
 				data->num_pairs, sizeof(_ccs_map_pair_t), &_sz),
 			CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		data->pairs = (_ccs_map_pair_t *)malloc(_sz);
+		data->pairs = (_ccs_map_pair_t *)calloc(1, _sz);
 		CCS_REFUTE(!data->pairs, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	}
 	for (size_t i = 0; i < data->num_pairs; i++) {

--- a/src/parameter_deserialize.h
+++ b/src/parameter_deserialize.h
@@ -57,7 +57,7 @@ _ccs_deserialize_bin_ccs_parameter_categorical_data(
 				data->num_possible_values, sizeof(ccs_datum_t),
 				&_sz),
 			CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		data->possible_values = (ccs_datum_t *)malloc(_sz);
+		data->possible_values = (ccs_datum_t *)calloc(1, _sz);
 		CCS_REFUTE(
 			!data->possible_values, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	}

--- a/src/tree_configuration_deserialize.h
+++ b/src/tree_configuration_deserialize.h
@@ -30,7 +30,7 @@ _ccs_deserialize_bin_tree_configuration_data(
 		CCS_REFUTE(
 			_ccs_size_mul(data->position_size, sizeof(size_t), &_sz),
 			CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		data->position = (size_t *)malloc(_sz);
+		data->position = (size_t *)calloc(1, _sz);
 		CCS_REFUTE(!data->position, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 		for (size_t i = 0; i < data->position_size; i++)
 			CCS_VALIDATE(_ccs_deserialize_bin_size(


### PR DESCRIPTION
## Summary

Deserializers used \`malloc\` to allocate arrays whose elements are later NULL-checked on error cleanup. Since \`malloc\` doesn't zero-initialize, unwritten slots contain garbage that the NULL checks interpret as valid pointers.

Change all remaining \`malloc\` calls in deserializers to \`calloc(1, sz)\`:
- \`parameter_deserialize.h\`: \`possible_values\` (\`ccs_datum_t\` array — could carry \`CCS_DATA_TYPE_OBJECT\` handles)
- \`map_deserialize.h\`: \`pairs\` (\`_ccs_map_pair_t\` array — each pair contains two \`ccs_datum_t\`)
- \`distribution_deserialize.h\`: \`areas\`, \`weights\` (scalar arrays, changed for consistency)
- \`tree_configuration_deserialize.h\`: \`position\` (scalar array, changed for consistency)

## Test plan

- [x] All 30 C tests pass
- [x] Ruby and Python binding tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)