### PR TITLE
Upgrade CI to clang-format-17 and reformat codebase

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -2,13 +2,13 @@ name: style-checks
 on: [push, pull_request]
 jobs:
   clang-format:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: sudo apt-get update
-      - run: sudo apt-get install -y clang-format-15
+      - run: sudo apt-get install -y clang-format-17
       - name: run git-clang-format
-        run: clang-format-15 --style=file --dry-run --Werror `git ls-files *.c *.cpp *.h  | grep -v -E "Kokkos_Profiling_C_Interface\.h|utarray.h|uthash.h|utlist.h"` > clang-format-diff 2>&1
+        run: clang-format-17 --style=file --dry-run --Werror `git ls-files *.c *.cpp *.h  | grep -v -E "Kokkos_Profiling_C_Interface\.h|utarray.h|uthash.h|utlist.h"` > clang-format-diff 2>&1
         shell: bash
       - name: output clang format diff
         if: always()

--- a/src/distribution.c
+++ b/src/distribution.c
@@ -309,8 +309,9 @@ ccs_distribution_parameters_samples(
 			}
 			ccs_datum_t *ds = (ccs_datum_t *)mem;
 			p_vs[0] =
-				(ccs_numeric_t
-					 *)(mem + buff_len * dim * sizeof(ccs_datum_t));
+				(ccs_numeric_t *)(mem +
+						  buff_len * dim *
+							  sizeof(ccs_datum_t));
 			for (size_t i = 1; i < dim; i++)
 				p_vs[i] = p_vs[i - 1] + buff_len;
 			CCS_OBJ_WRLOCK(rng);

--- a/src/distribution_mixture.c
+++ b/src/distribution_mixture.c
@@ -256,8 +256,8 @@ ccs_create_mixture_distribution(
 	}
 	bounds_tmp = (ccs_interval_t *)tmp_mem;
 	data_types_tmp =
-		(ccs_numeric_type_t
-			 *)(tmp_mem + sizeof(ccs_interval_t) * num_distributions);
+		(ccs_numeric_type_t *)(tmp_mem + sizeof(ccs_interval_t) *
+							 num_distributions);
 
 	distrib = (ccs_distribution_t)cur_mem;
 	cur_mem += sizeof(struct _ccs_distribution_s);

--- a/src/distribution_normal.c
+++ b/src/distribution_normal.c
@@ -558,8 +558,9 @@ ccs_create_normal_distribution(
 		(_ccs_distribution_normal_data_t
 			 *)(mem + sizeof(struct _ccs_distribution_s));
 	distrib_data->common_data.data_types =
-		(ccs_numeric_type_t
-			 *)(mem + sizeof(struct _ccs_distribution_s) + sizeof(_ccs_distribution_normal_data_t));
+		(ccs_numeric_type_t *)(mem +
+				       sizeof(struct _ccs_distribution_s) +
+				       sizeof(_ccs_distribution_normal_data_t));
 	distrib_data->common_data.type          = CCS_DISTRIBUTION_TYPE_NORMAL;
 	distrib_data->common_data.dimension     = 1;
 	distrib_data->common_data.data_types[0] = data_type;

--- a/src/distribution_roulette.c
+++ b/src/distribution_roulette.c
@@ -254,14 +254,16 @@ ccs_create_roulette_distribution(
 			 *)(mem + sizeof(struct _ccs_distribution_s));
 	distrib_data->common_data.data_types =
 		(ccs_numeric_type_t
-			 *)(mem + sizeof(struct _ccs_distribution_s) + sizeof(_ccs_distribution_roulette_data_t) + sizeof(ccs_float_t) * (num_areas + 1));
+			 *)(mem + sizeof(struct _ccs_distribution_s) +
+			    sizeof(_ccs_distribution_roulette_data_t) +
+			    sizeof(ccs_float_t) * (num_areas + 1));
 	distrib_data->common_data.type      = CCS_DISTRIBUTION_TYPE_ROULETTE;
 	distrib_data->common_data.dimension = 1;
 	distrib_data->common_data.data_types[0] = CCS_NUMERIC_TYPE_INT;
 	distrib_data->num_areas                 = num_areas;
 	distrib_data->areas =
-		(ccs_float_t
-			 *)(mem + sizeof(struct _ccs_distribution_s) + sizeof(_ccs_distribution_roulette_data_t));
+		(ccs_float_t *)(mem + sizeof(struct _ccs_distribution_s) +
+				sizeof(_ccs_distribution_roulette_data_t));
 	_ccs_distribution_roulette_normalize_areas(
 		num_areas, areas, sum_areas_inverse, distrib_data->areas);
 	distrib->data     = (_ccs_distribution_data_t *)distrib_data;

--- a/src/distribution_space_internal.h
+++ b/src/distribution_space_internal.h
@@ -116,7 +116,8 @@ _ccs_create_distribution_space_no_retain(
 	distrib_space->data->num_parameters = num_parameters;
 	distrib_space->data->parameter_distributions =
 		(struct _ccs_parameter_distribution_s
-			 *)(mem + sizeof(struct _ccs_distribution_space_s) + sizeof(struct _ccs_distribution_space_data_s));
+			 *)(mem + sizeof(struct _ccs_distribution_space_s) +
+			    sizeof(struct _ccs_distribution_space_data_s));
 	distrib_space->data->configuration_space = configuration_space;
 	for (size_t i = 0; i < num_parameters; i++) {
 		_ccs_distribution_wrapper_t   *distrib_wrapper;

--- a/src/distribution_uniform.c
+++ b/src/distribution_uniform.c
@@ -413,8 +413,9 @@ ccs_create_uniform_distribution(
 		(_ccs_distribution_uniform_data_t
 			 *)(mem + sizeof(struct _ccs_distribution_s));
 	distrib_data->common_data.data_types =
-		(ccs_numeric_type_t
-			 *)(mem + sizeof(struct _ccs_distribution_s) + sizeof(_ccs_distribution_uniform_data_t));
+		(ccs_numeric_type_t *)(mem +
+				       sizeof(struct _ccs_distribution_s) +
+				       sizeof(_ccs_distribution_uniform_data_t));
 	distrib_data->common_data.type          = CCS_DISTRIBUTION_TYPE_UNIFORM;
 	distrib_data->common_data.dimension     = 1;
 	distrib_data->common_data.data_types[0] = data_type;

--- a/src/error_stack.c
+++ b/src/error_stack.c
@@ -97,8 +97,8 @@ _ccs_create_error_stack(
 		(struct _ccs_error_stack_data_s
 			 *)(mem + sizeof(struct _ccs_error_stack_s));
 	error_stack->data->msg =
-		(const char
-			 *)(mem + sizeof(struct _ccs_error_stack_s) + sizeof(struct _ccs_error_stack_data_s));
+		(const char *)(mem + sizeof(struct _ccs_error_stack_s) +
+			       sizeof(struct _ccs_error_stack_data_s));
 	utarray_new(error_stack->data->elems, &_error_stack_elem_icd);
 	error_stack->data->error = error_code;
 	if (msg) {

--- a/src/expression.c
+++ b/src/expression.c
@@ -1558,7 +1558,8 @@ ccs_create_literal(ccs_datum_t value, ccs_expression_t *expression_ret)
 	expression_data->expr.nodes     = NULL;
 	if (size_str) {
 		char *str_pool =
-			(char *)(mem + sizeof(struct _ccs_expression_s) + sizeof(struct _ccs_expression_literal_data_s));
+			(char *)(mem + sizeof(struct _ccs_expression_s) +
+				 sizeof(struct _ccs_expression_literal_data_s));
 		expression_data->value = ccs_string(str_pool);
 		strcpy(str_pool, value.value.s);
 	} else {
@@ -1689,13 +1690,13 @@ ccs_create_expression(
 		&(expression->obj), CCS_OBJECT_TYPE_EXPRESSION,
 		(_ccs_object_ops_t *)_ccs_expression_ops_broker(type));
 	_ccs_expression_data_t *expression_data =
-		(_ccs_expression_data_t
-			 *)(mem + sizeof(struct _ccs_expression_s));
+		(_ccs_expression_data_t *)(mem +
+					   sizeof(struct _ccs_expression_s));
 	expression_data->type      = type;
 	expression_data->num_nodes = num_nodes;
 	expression_data->nodes =
-		(ccs_expression_t
-			 *)(mem + sizeof(struct _ccs_expression_s) + sizeof(struct _ccs_expression_data_s));
+		(ccs_expression_t *)(mem + sizeof(struct _ccs_expression_s) +
+				     sizeof(struct _ccs_expression_data_s));
 	CCS_VALIDATE_ERR_GOTO(
 		err,
 		_ccs_create_nodes(num_nodes, nodes, expression_data->nodes),
@@ -1782,10 +1783,13 @@ ccs_create_user_defined_expression(
 	expression_data->expr.num_nodes = num_nodes;
 	expression_data->expr.nodes =
 		(ccs_expression_t
-			 *)(mem + sizeof(struct _ccs_expression_s) + sizeof(struct _ccs_expression_user_defined_data_s));
+			 *)(mem + sizeof(struct _ccs_expression_s) +
+			    sizeof(struct _ccs_expression_user_defined_data_s));
 	expression_data->name =
 		(const char
-			 *)(mem + sizeof(struct _ccs_expression_s) + sizeof(struct _ccs_expression_user_defined_data_s) + sizeof(ccs_expression_t) * num_nodes);
+			 *)(mem + sizeof(struct _ccs_expression_s) +
+			    sizeof(struct _ccs_expression_user_defined_data_s) +
+			    sizeof(ccs_expression_t) * num_nodes);
 	expression_data->vector          = *vector;
 	expression_data->expression_data = expr_data;
 	strcpy((char *)expression_data->name, name);

--- a/src/parameter_categorical.c
+++ b/src/parameter_categorical.c
@@ -353,13 +353,15 @@ _ccs_create_categorical_parameter(
 			 *)(mem + sizeof(struct _ccs_parameter_s));
 	parameter_data->common_data.type = type;
 	parameter_data->common_data.name =
-		(char *)(mem + sizeof(struct _ccs_parameter_s) + sizeof(_ccs_parameter_categorical_data_t) + sizeof(_ccs_hash_datum_t) * num_possible_values);
+		(char *)(mem + sizeof(struct _ccs_parameter_s) +
+			 sizeof(_ccs_parameter_categorical_data_t) +
+			 sizeof(_ccs_hash_datum_t) * num_possible_values);
 	strcpy((char *)parameter_data->common_data.name, name);
 	parameter_data->common_data.interval = interval;
 	parameter_data->num_possible_values  = num_possible_values;
 	_ccs_hash_datum_t *pvs =
-		(_ccs_hash_datum_t
-			 *)(mem + sizeof(struct _ccs_parameter_s) + sizeof(_ccs_parameter_categorical_data_t));
+		(_ccs_hash_datum_t *)(mem + sizeof(struct _ccs_parameter_s) +
+				      sizeof(_ccs_parameter_categorical_data_t));
 	parameter_data->possible_values = pvs;
 	parameter_data->hash            = NULL;
 	parameter->data = (_ccs_parameter_data_t *)parameter_data;

--- a/src/parameter_numerical.c
+++ b/src/parameter_numerical.c
@@ -318,7 +318,8 @@ ccs_create_numerical_parameter(
 			 *)(mem + sizeof(struct _ccs_parameter_s));
 	parameter_data->common_data.type = CCS_PARAMETER_TYPE_NUMERICAL;
 	parameter_data->common_data.name =
-		(char *)(mem + sizeof(struct _ccs_parameter_s) + sizeof(_ccs_parameter_numerical_data_t));
+		(char *)(mem + sizeof(struct _ccs_parameter_s) +
+			 sizeof(_ccs_parameter_numerical_data_t));
 	strcpy((char *)parameter_data->common_data.name, name);
 	if (data_type == CCS_NUMERIC_TYPE_FLOAT) {
 		parameter_data->common_data.default_value.type =

--- a/src/parameter_string.c
+++ b/src/parameter_string.c
@@ -156,10 +156,12 @@ _ccs_parameter_string_check_values(
 					err, !p, CCS_RESULT_ERROR_OUT_OF_MEMORY,
 					errmem);
 				if (sz_str) {
-					strcpy((char *)((intptr_t)p + sizeof(_ccs_hash_datum_t)),
+					strcpy((char *)((intptr_t)p +
+							sizeof(_ccs_hash_datum_t)),
 					       values[i].value.s);
 					p->d = ccs_string((
-						char *)((intptr_t)p + sizeof(_ccs_hash_datum_t)));
+						char *)((intptr_t)p +
+							sizeof(_ccs_hash_datum_t)));
 				} else
 					p->d = ccs_string(NULL);
 				HASH_ADD(
@@ -255,7 +257,8 @@ ccs_create_string_parameter(const char *name, ccs_parameter_t *parameter_ret)
 			 *)(mem + sizeof(struct _ccs_parameter_s));
 	parameter_data->common_data.type = CCS_PARAMETER_TYPE_STRING;
 	parameter_data->common_data.name =
-		(char *)(mem + sizeof(struct _ccs_parameter_s) + sizeof(_ccs_parameter_string_data_t));
+		(char *)(mem + sizeof(struct _ccs_parameter_s) +
+			 sizeof(_ccs_parameter_string_data_t));
 	strcpy((char *)parameter_data->common_data.name, name);
 	parameter_data->common_data.interval.type = CCS_NUMERIC_TYPE_INT;
 	parameter_data->stored_values             = NULL;

--- a/src/tree.c
+++ b/src/tree.c
@@ -156,28 +156,31 @@ ccs_create_tree(size_t arity, ccs_datum_t value, ccs_tree_t *tree_ret)
 		(_ccs_object_ops_t *)&_ccs_tree_ops);
 	_ccs_tree_data_t *data =
 		(_ccs_tree_data_t *)(mem + sizeof(struct _ccs_tree_s));
-	data->arity = arity;
-	data->weights =
-		(ccs_float_t
-			 *)(mem + sizeof(struct _ccs_tree_s) + sizeof(_ccs_tree_data_t));
+	data->arity   = arity;
+	data->weights = (ccs_float_t *)(mem + sizeof(struct _ccs_tree_s) +
+					sizeof(_ccs_tree_data_t));
 	for (size_t j = 0; j < arity + 1; j++)
 		data->weights[j] = 1.0;
 	data->sum_weights = arity + 1;
-	data->areas =
-		(ccs_float_t
-			 *)(mem + sizeof(struct _ccs_tree_s) + sizeof(_ccs_tree_data_t) + (arity + 1) * sizeof(ccs_float_t));
+	data->areas       = (ccs_float_t *)(mem + sizeof(struct _ccs_tree_s) +
+                                      sizeof(_ccs_tree_data_t) +
+                                      (arity + 1) * sizeof(ccs_float_t));
 	_ccs_distribution_roulette_normalize_areas(
 		arity + 1, data->weights, 1.0 / (data->sum_weights),
 		data->areas);
-	data->bias   = 1.0;
-	data->parent = NULL;
-	data->children =
-		(ccs_tree_t
-			 *)(mem + sizeof(struct _ccs_tree_s) + sizeof(_ccs_tree_data_t) + (arity + 1) * sizeof(ccs_float_t) + (arity + 2) * sizeof(ccs_float_t));
+	data->bias     = 1.0;
+	data->parent   = NULL;
+	data->children = (ccs_tree_t *)(mem + sizeof(struct _ccs_tree_s) +
+					sizeof(_ccs_tree_data_t) +
+					(arity + 1) * sizeof(ccs_float_t) +
+					(arity + 2) * sizeof(ccs_float_t));
 	if (value.type == CCS_DATA_TYPE_STRING) {
-		char *str_pool =
-			(char *)(mem + sizeof(struct _ccs_tree_s) + sizeof(_ccs_tree_data_t) + (arity + 1) * sizeof(ccs_float_t) + (arity + 2) * sizeof(ccs_float_t) + arity * sizeof(ccs_tree_t));
-		data->value = ccs_string(str_pool);
+		char *str_pool = (char *)(mem + sizeof(struct _ccs_tree_s) +
+					  sizeof(_ccs_tree_data_t) +
+					  (arity + 1) * sizeof(ccs_float_t) +
+					  (arity + 2) * sizeof(ccs_float_t) +
+					  arity * sizeof(ccs_tree_t));
+		data->value    = ccs_string(str_pool);
 		strcpy(str_pool, value.value.s);
 	} else {
 		data->value       = value;

--- a/src/tuner_random.c
+++ b/src/tuner_random.c
@@ -632,8 +632,8 @@ ccs_create_random_tuner(
 	data                   = (_ccs_random_tuner_data_t *)tun->data;
 	data->common_data.type = CCS_TUNER_TYPE_RANDOM;
 	data->common_data.name =
-		(const char
-			 *)(mem + sizeof(struct _ccs_tuner_s) + sizeof(struct _ccs_random_tuner_data_s));
+		(const char *)(mem + sizeof(struct _ccs_tuner_s) +
+			       sizeof(struct _ccs_random_tuner_data_s));
 	data->common_data.search_space    = search_space;
 	data->common_data.objective_space = objective_space;
 	data->common_data.feature_space   = feature_space;

--- a/src/tuner_user_defined.c
+++ b/src/tuner_user_defined.c
@@ -350,8 +350,8 @@ ccs_create_user_defined_tuner(
 	data                   = (_ccs_user_defined_tuner_data_t *)tun->data;
 	data->common_data.type = CCS_TUNER_TYPE_USER_DEFINED;
 	data->common_data.name =
-		(const char
-			 *)(mem + sizeof(struct _ccs_tuner_s) + sizeof(struct _ccs_user_defined_tuner_data_s));
+		(const char *)(mem + sizeof(struct _ccs_tuner_s) +
+			       sizeof(struct _ccs_user_defined_tuner_data_s));
 	data->common_data.search_space    = search_space;
 	data->common_data.objective_space = objective_space;
 	data->common_data.feature_space   = feature_space;


### PR DESCRIPTION
## Summary

- Upgrade CI style check from \`clang-format-15\` on \`ubuntu-22.04\` to \`clang-format-17\` on \`ubuntu-latest\`
- Update \`actions/checkout\` from v3 to v4
- Apply \`clang-format-17\` formatting to all 132 source files matching the CI filter (15 files had minor formatting differences)

This eliminates the constant formatting friction we've experienced throughout this session — every PR had to deal with differences between local and CI clang-format versions.

## Test plan

- [x] All 30 C tests pass
- [x] Ruby and Python binding tests pass
- [x] \`clang-format-17 --dry-run --Werror\` passes on all filtered files

🤖 Generated with [Claude Code](https://claude.com/claude-code)