### PR TITLE
Introduce CCS_ALLOC_CARVE macros for single-allocation layout

### DIFF
--- a/src/cconfigspace_internal.h
+++ b/src/cconfigspace_internal.h
@@ -987,6 +987,17 @@ _ccs_size_sum3(
 	return _ccs_size_add(p, p3, result);
 }
 
+/* Carve out a block of 'size' bytes from a running uintptr_t pointer.
+ * Advances 'mem' past the carved block and returns the pre-advance
+ * address. Save the original mem value for cleanup before using. */
+#define CCS_ALLOC_CARVE(mem, size) ((void *)((mem) += (size), (mem) - (size)))
+
+#define CCS_ALLOC_CARVE_TYPE(mem, type)                                        \
+	((type *)CCS_ALLOC_CARVE(mem, sizeof(type)))
+
+#define CCS_ALLOC_CARVE_ARRAY(mem, count, type)                                \
+	((type *)CCS_ALLOC_CARVE(mem, (count) * sizeof(type)))
+
 static inline size_t
 _ccs_serialize_bin_size_string(const char *str)
 {

--- a/src/feature_space.c
+++ b/src/feature_space.c
@@ -101,19 +101,19 @@ ccs_create_feature_space(
 			sizeof(_ccs_parameter_index_hash_t) * num_parameters +
 			strlen(name) + 1);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-	uintptr_t           mem_orig   = mem;
+	uintptr_t           mem_orig = mem;
 
-	ccs_feature_space_t feat_space = (ccs_feature_space_t)mem;
-	mem += sizeof(struct _ccs_feature_space_s);
+	ccs_feature_space_t feat_space =
+		CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_feature_space_s);
 	_ccs_object_init(
 		&(feat_space->obj), CCS_OBJECT_TYPE_FEATURE_SPACE,
 		(_ccs_object_ops_t *)&_feature_space_ops);
-	feat_space->data = (struct _ccs_feature_space_data_s *)mem;
-	mem += sizeof(struct _ccs_feature_space_data_s);
-	feat_space->data->parameters = (ccs_parameter_t *)mem;
-	mem += sizeof(ccs_parameter_t) * num_parameters;
-	feat_space->data->hash_elems = (_ccs_parameter_index_hash_t *)mem;
-	mem += sizeof(_ccs_parameter_index_hash_t) * num_parameters;
+	feat_space->data =
+		CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_feature_space_data_s);
+	feat_space->data->parameters =
+		CCS_ALLOC_CARVE_ARRAY(mem, num_parameters, ccs_parameter_t);
+	feat_space->data->hash_elems = CCS_ALLOC_CARVE_ARRAY(
+		mem, num_parameters, _ccs_parameter_index_hash_t);
 	feat_space->data->name           = (const char *)mem;
 	feat_space->data->num_parameters = num_parameters;
 	strcpy((char *)(feat_space->data->name), name);

--- a/src/map.c
+++ b/src/map.c
@@ -158,11 +158,11 @@ ccs_create_map(ccs_map_t *map_ret)
 	uintptr_t mem = (uintptr_t)calloc(
 		1, sizeof(struct _ccs_map_s) + sizeof(_ccs_map_data_t));
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-	ccs_map_t map = (ccs_map_t)mem;
+	ccs_map_t map = CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_map_s);
 	_ccs_object_init(
 		&(map->obj), CCS_OBJECT_TYPE_MAP,
 		(_ccs_object_ops_t *)&_ccs_map_ops);
-	map->data = (_ccs_map_data_t *)(mem + sizeof(struct _ccs_map_s));
+	map->data = CCS_ALLOC_CARVE_TYPE(mem, _ccs_map_data_t);
 	*map_ret  = map;
 	return CCS_RESULT_SUCCESS;
 }

--- a/src/rng.c
+++ b/src/rng.c
@@ -119,11 +119,11 @@ ccs_create_rng_with_type(const gsl_rng_type *rng_type, ccs_rng_t *rng_ret)
 	uintptr_t mem = (uintptr_t)calloc(
 		1, sizeof(struct _ccs_rng_s) + sizeof(struct _ccs_rng_data_s));
 	CCS_REFUTE_ERR_GOTO(res, !mem, CCS_RESULT_ERROR_OUT_OF_MEMORY, err_rng);
-	rng = (ccs_rng_t)mem;
+	rng = CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_rng_s);
 	_ccs_object_init(
 		&(rng->obj), CCS_OBJECT_TYPE_RNG,
 		(_ccs_object_ops_t *)&_rng_ops);
-	rng->data = (struct _ccs_rng_data_s *)(mem + sizeof(struct _ccs_rng_s));
+	rng->data           = CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_rng_data_s);
 	rng->data->rng_type = rng_type;
 	rng->data->rng      = grng;
 	*rng_ret            = rng;

--- a/src/tree_space_static.c
+++ b/src/tree_space_static.c
@@ -192,17 +192,15 @@ ccs_create_static_tree_space(
                            sizeof(struct _ccs_tree_space_static_data_s) +
                            strlen(name) + 1);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-	uintptr_t                      mem_orig = mem;
+	uintptr_t        mem_orig = mem;
 
-	ccs_tree_space_t               tree_space;
-	_ccs_tree_space_static_data_t *data;
-	tree_space = (ccs_tree_space_t)mem;
-	mem += sizeof(struct _ccs_tree_space_s);
+	ccs_tree_space_t tree_space =
+		CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_tree_space_s);
 	_ccs_object_init(
 		&(tree_space->obj), CCS_OBJECT_TYPE_TREE_SPACE,
 		(_ccs_object_ops_t *)&_ccs_tree_space_static_ops);
-	data = (struct _ccs_tree_space_static_data_s *)mem;
-	mem += sizeof(struct _ccs_tree_space_static_data_s);
+	_ccs_tree_space_static_data_t *data =
+		CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_tree_space_static_data_s);
 	data->common_data.type = CCS_TREE_SPACE_TYPE_STATIC;
 	data->common_data.name = (const char *)mem;
 	tree_space->data       = (_ccs_tree_space_data_t *)data;


### PR DESCRIPTION
## Summary

Add \`CCS_ALLOC_CARVE\`, \`CCS_ALLOC_CARVE_TYPE\`, and \`CCS_ALLOC_CARVE_ARRAY\` macros that carve out typed blocks from a running \`uintptr_t\` pointer, replacing the two inconsistent patterns used in the codebase:

- **Pattern 1** (base+offset): \`ptr = (type *)(mem + sizeof(prev_type))\` — error-prone, repeated offset math
- **Pattern 2** (manual advance): \`ptr = (type *)mem; mem += sizeof(type)\` — correct but verbose

The new macros combine the cast and advance into one expression:
\`\`\`c
ccs_map_t map = CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_map_s);
map->data = CCS_ALLOC_CARVE_TYPE(mem, _ccs_map_data_t);
data->parameters = CCS_ALLOC_CARVE_ARRAY(mem, num_params, ccs_parameter_t);
\`\`\`

Converted 4 representative files to demonstrate the pattern. The original \`mem_orig\` save for error cleanup is preserved.

## Test plan

- [x] All 30 C tests pass (gcc, g++)
- [x] Ruby and Python binding tests pass
- [x] clang-format-17 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)