### PR TITLE
Convert remaining files to CCS_ALLOC_CARVE macros

### DIFF
--- a/src/configuration.c
+++ b/src/configuration.c
@@ -174,16 +174,15 @@ _ccs_create_configuration(
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	uintptr_t           mem_orig = mem;
 	ccs_configuration_t config;
-	config = (ccs_configuration_t)mem;
-	mem += sizeof(struct _ccs_configuration_s);
+	config = CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_configuration_s);
 	_ccs_object_init(
 		&(config->obj), CCS_OBJECT_TYPE_CONFIGURATION,
 		(_ccs_object_ops_t *)&_configuration_ops);
-	config->data = (struct _ccs_configuration_data_s *)mem;
-	mem += sizeof(struct _ccs_configuration_data_s);
+	config->data =
+		CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_configuration_data_s);
 	config->data->num_values = num_parameters;
-	config->data->values     = (ccs_datum_t *)mem;
-	mem += sizeof(ccs_datum_t) * num_parameters;
+	config->data->values =
+		CCS_ALLOC_CARVE_ARRAY(mem, num_parameters, ccs_datum_t);
 	CCS_VALIDATE_ERR_GOTO(
 		err, ccs_retain_object(configuration_space), errinit);
 	config->data->configuration_space = configuration_space;

--- a/src/configuration_space.c
+++ b/src/configuration_space.c
@@ -560,12 +560,13 @@ ccs_create_configuration_space(
 				sizeof(UT_array *) * 2 + sizeof(size_t),
 			num_forbidden_clauses, sizeof(ccs_expression_t), &_sz),
 		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	size_t name_len = strlen(name) + 1;
 	CCS_REFUTE(
 		_ccs_size_add(
 			_sz,
 			sizeof(struct _ccs_configuration_space_s) +
 				sizeof(struct _ccs_configuration_space_data_s) +
-				strlen(name) + 1,
+				name_len,
 			&_sz),
 		CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	uintptr_t mem = (uintptr_t)calloc(1, _sz);
@@ -594,7 +595,7 @@ ccs_create_configuration_space(
 		CCS_ALLOC_CARVE_ARRAY(mem, num_parameters, size_t);
 	config_space->data->forbidden_clauses = CCS_ALLOC_CARVE_ARRAY(
 		mem, num_forbidden_clauses, ccs_expression_t);
-	config_space->data->name                  = (const char *)mem;
+	config_space->data->name = CCS_ALLOC_CARVE_ARRAY(mem, name_len, char);
 	config_space->data->num_parameters        = num_parameters;
 	config_space->data->num_forbidden_clauses = num_forbidden_clauses;
 	if (rng)

--- a/src/configuration_space.c
+++ b/src/configuration_space.c
@@ -573,27 +573,27 @@ ccs_create_configuration_space(
 	uintptr_t                 mem_orig = mem;
 
 	ccs_configuration_space_t config_space;
-	config_space = (ccs_configuration_space_t)mem;
-	mem += sizeof(struct _ccs_configuration_space_s);
+	config_space =
+		CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_configuration_space_s);
 	_ccs_object_init(
 		&(config_space->obj), CCS_OBJECT_TYPE_CONFIGURATION_SPACE,
 		(_ccs_object_ops_t *)&_configuration_space_ops);
-	config_space->data = (struct _ccs_configuration_space_data_s *)mem;
-	mem += sizeof(struct _ccs_configuration_space_data_s);
-	config_space->data->parameters = (ccs_parameter_t *)mem;
-	mem += sizeof(ccs_parameter_t) * num_parameters;
-	config_space->data->hash_elems = (_ccs_parameter_index_hash_t *)mem;
-	mem += sizeof(_ccs_parameter_index_hash_t) * num_parameters;
-	config_space->data->conditions = (ccs_expression_t *)mem;
-	mem += sizeof(ccs_expression_t) * num_parameters;
-	config_space->data->parents = (UT_array **)mem;
-	mem += sizeof(UT_array *) * num_parameters;
-	config_space->data->children = (UT_array **)mem;
-	mem += sizeof(UT_array *) * num_parameters;
-	config_space->data->sorted_indexes = (size_t *)mem;
-	mem += sizeof(size_t) * num_parameters;
-	config_space->data->forbidden_clauses = (ccs_expression_t *)mem;
-	mem += sizeof(ccs_expression_t) * num_forbidden_clauses;
+	config_space->data = CCS_ALLOC_CARVE_TYPE(
+		mem, struct _ccs_configuration_space_data_s);
+	config_space->data->parameters =
+		CCS_ALLOC_CARVE_ARRAY(mem, num_parameters, ccs_parameter_t);
+	config_space->data->hash_elems = CCS_ALLOC_CARVE_ARRAY(
+		mem, num_parameters, _ccs_parameter_index_hash_t);
+	config_space->data->conditions =
+		CCS_ALLOC_CARVE_ARRAY(mem, num_parameters, ccs_expression_t);
+	config_space->data->parents =
+		CCS_ALLOC_CARVE_ARRAY(mem, num_parameters, UT_array *);
+	config_space->data->children =
+		CCS_ALLOC_CARVE_ARRAY(mem, num_parameters, UT_array *);
+	config_space->data->sorted_indexes =
+		CCS_ALLOC_CARVE_ARRAY(mem, num_parameters, size_t);
+	config_space->data->forbidden_clauses = CCS_ALLOC_CARVE_ARRAY(
+		mem, num_forbidden_clauses, ccs_expression_t);
 	config_space->data->name                  = (const char *)mem;
 	config_space->data->num_parameters        = num_parameters;
 	config_space->data->num_forbidden_clauses = num_forbidden_clauses;
@@ -751,9 +751,10 @@ _sample(ccs_configuration_space_t configuration_space,
 		num_parameters *
 		(sizeof(ccs_datum_t) + sizeof(ccs_parameter_t)));
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	uintptr_t mem_orig = mem;
 
-	p_values = (ccs_datum_t *)mem;
-	hps = (ccs_parameter_t *)(mem + num_parameters * sizeof(ccs_datum_t));
+	p_values = CCS_ALLOC_CARVE_ARRAY(mem, num_parameters, ccs_datum_t);
+	hps      = CCS_ALLOC_CARVE_ARRAY(mem, num_parameters, ccs_parameter_t);
 
 	_ccs_distribution_wrapper_t *dwrapper = NULL;
 	DL_FOREACH(distribution_space->data->distribution_list, dwrapper)
@@ -778,7 +779,7 @@ _sample(ccs_configuration_space_t configuration_space,
 		err, _test_forbidden(configuration_space, config, found),
 		errmem);
 errmem:
-	free((void *)mem);
+	free((void *)mem_orig);
 	return err;
 }
 

--- a/src/distribution_mixture.c
+++ b/src/distribution_mixture.c
@@ -259,24 +259,23 @@ ccs_create_mixture_distribution(
 		(ccs_numeric_type_t *)(tmp_mem + sizeof(ccs_interval_t) *
 							 num_distributions);
 
-	distrib = (ccs_distribution_t)cur_mem;
-	cur_mem += sizeof(struct _ccs_distribution_s);
+	distrib = CCS_ALLOC_CARVE_TYPE(cur_mem, struct _ccs_distribution_s);
 	_ccs_object_init(
 		&(distrib->obj), CCS_OBJECT_TYPE_DISTRIBUTION,
 		(_ccs_object_ops_t *)&_ccs_distribution_mixture_ops);
-	distrib_data = (_ccs_distribution_mixture_data_t *)(cur_mem);
-	cur_mem += sizeof(_ccs_distribution_mixture_data_t);
+	distrib_data =
+		CCS_ALLOC_CARVE_TYPE(cur_mem, _ccs_distribution_mixture_data_t);
 	distrib_data->common_data.type      = CCS_DISTRIBUTION_TYPE_MIXTURE;
 	distrib_data->common_data.dimension = dimension;
 	distrib_data->num_distributions     = num_distributions;
-	distrib_data->distributions         = (ccs_distribution_t *)(cur_mem);
-	cur_mem += sizeof(ccs_distribution_t) * num_distributions;
-	distrib_data->bounds = (ccs_interval_t *)(cur_mem);
-	cur_mem += sizeof(ccs_interval_t) * dimension;
-	distrib_data->weights = (ccs_float_t *)(cur_mem);
-	cur_mem += sizeof(ccs_float_t) * (num_distributions + 1);
-	distrib_data->common_data.data_types = (ccs_numeric_type_t *)(cur_mem);
-	cur_mem += sizeof(ccs_numeric_type_t) * dimension;
+	distrib_data->distributions         = CCS_ALLOC_CARVE_ARRAY(
+                cur_mem, num_distributions, ccs_distribution_t);
+	distrib_data->bounds =
+		CCS_ALLOC_CARVE_ARRAY(cur_mem, dimension, ccs_interval_t);
+	distrib_data->weights = CCS_ALLOC_CARVE_ARRAY(
+		cur_mem, num_distributions + 1, ccs_float_t);
+	distrib_data->common_data.data_types =
+		CCS_ALLOC_CARVE_ARRAY(cur_mem, dimension, ccs_numeric_type_t);
 
 	CCS_VALIDATE_ERR_GOTO(
 		err,

--- a/src/distribution_multivariate.c
+++ b/src/distribution_multivariate.c
@@ -203,24 +203,23 @@ ccs_create_multivariate_distribution(
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	cur_mem = mem;
 
-	distrib = (ccs_distribution_t)cur_mem;
-	cur_mem += sizeof(struct _ccs_distribution_s);
+	distrib = CCS_ALLOC_CARVE_TYPE(cur_mem, struct _ccs_distribution_s);
 	_ccs_object_init(
 		&(distrib->obj), CCS_OBJECT_TYPE_DISTRIBUTION,
 		(_ccs_object_ops_t *)&_ccs_distribution_multivariate_ops);
-	distrib_data = (_ccs_distribution_multivariate_data_t *)(cur_mem);
-	cur_mem += sizeof(_ccs_distribution_multivariate_data_t);
+	distrib_data = CCS_ALLOC_CARVE_TYPE(
+		cur_mem, _ccs_distribution_multivariate_data_t);
 	distrib_data->common_data.type = CCS_DISTRIBUTION_TYPE_MULTIVARIATE;
 	distrib_data->common_data.dimension = dimension;
 	distrib_data->num_distributions     = num_distributions;
-	distrib_data->distributions         = (ccs_distribution_t *)(cur_mem);
-	cur_mem += sizeof(ccs_distribution_t) * num_distributions;
-	distrib_data->dimensions = (size_t *)(cur_mem);
-	cur_mem += sizeof(size_t) * num_distributions;
-	distrib_data->bounds = (ccs_interval_t *)(cur_mem);
-	cur_mem += sizeof(ccs_interval_t) * dimension;
-	distrib_data->common_data.data_types = (ccs_numeric_type_t *)(cur_mem);
-	cur_mem += sizeof(ccs_numeric_type_t) * dimension;
+	distrib_data->distributions         = CCS_ALLOC_CARVE_ARRAY(
+                cur_mem, num_distributions, ccs_distribution_t);
+	distrib_data->dimensions =
+		CCS_ALLOC_CARVE_ARRAY(cur_mem, num_distributions, size_t);
+	distrib_data->bounds =
+		CCS_ALLOC_CARVE_ARRAY(cur_mem, dimension, ccs_interval_t);
+	distrib_data->common_data.data_types =
+		CCS_ALLOC_CARVE_ARRAY(cur_mem, dimension, ccs_numeric_type_t);
 
 	dimension = 0;
 	for (i = 0; i < num_distributions; i++) {

--- a/src/distribution_normal.c
+++ b/src/distribution_normal.c
@@ -550,7 +550,6 @@ ccs_create_normal_distribution(
 			   sizeof(_ccs_distribution_normal_data_t) +
 			   sizeof(ccs_numeric_type_t));
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-	uintptr_t          mem_orig = mem;
 	ccs_distribution_t distrib =
 		CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_distribution_s);
 	_ccs_object_init(
@@ -560,7 +559,6 @@ ccs_create_normal_distribution(
 		CCS_ALLOC_CARVE_TYPE(mem, _ccs_distribution_normal_data_t);
 	distrib_data->common_data.data_types =
 		CCS_ALLOC_CARVE_ARRAY(mem, 1, ccs_numeric_type_t);
-	(void)mem_orig;
 	distrib_data->common_data.type          = CCS_DISTRIBUTION_TYPE_NORMAL;
 	distrib_data->common_data.dimension     = 1;
 	distrib_data->common_data.data_types[0] = data_type;

--- a/src/distribution_normal.c
+++ b/src/distribution_normal.c
@@ -550,17 +550,17 @@ ccs_create_normal_distribution(
 			   sizeof(_ccs_distribution_normal_data_t) +
 			   sizeof(ccs_numeric_type_t));
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-	ccs_distribution_t distrib = (ccs_distribution_t)mem;
+	uintptr_t          mem_orig = mem;
+	ccs_distribution_t distrib =
+		CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_distribution_s);
 	_ccs_object_init(
 		&(distrib->obj), CCS_OBJECT_TYPE_DISTRIBUTION,
 		(_ccs_object_ops_t *)&_ccs_distribution_normal_ops);
 	_ccs_distribution_normal_data_t *distrib_data =
-		(_ccs_distribution_normal_data_t
-			 *)(mem + sizeof(struct _ccs_distribution_s));
+		CCS_ALLOC_CARVE_TYPE(mem, _ccs_distribution_normal_data_t);
 	distrib_data->common_data.data_types =
-		(ccs_numeric_type_t *)(mem +
-				       sizeof(struct _ccs_distribution_s) +
-				       sizeof(_ccs_distribution_normal_data_t));
+		CCS_ALLOC_CARVE_ARRAY(mem, 1, ccs_numeric_type_t);
+	(void)mem_orig;
 	distrib_data->common_data.type          = CCS_DISTRIBUTION_TYPE_NORMAL;
 	distrib_data->common_data.dimension     = 1;
 	distrib_data->common_data.data_types[0] = data_type;

--- a/src/distribution_roulette.c
+++ b/src/distribution_roulette.c
@@ -245,25 +245,23 @@ ccs_create_roulette_distribution(
 			   sizeof(ccs_numeric_type_t));
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 
-	ccs_distribution_t distrib = (ccs_distribution_t)mem;
+	uintptr_t          mem_orig = mem;
+	ccs_distribution_t distrib =
+		CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_distribution_s);
 	_ccs_object_init(
 		&(distrib->obj), CCS_OBJECT_TYPE_DISTRIBUTION,
 		(_ccs_object_ops_t *)&_ccs_distribution_roulette_ops);
 	_ccs_distribution_roulette_data_t *distrib_data =
-		(_ccs_distribution_roulette_data_t
-			 *)(mem + sizeof(struct _ccs_distribution_s));
+		CCS_ALLOC_CARVE_TYPE(mem, _ccs_distribution_roulette_data_t);
+	distrib_data->areas =
+		CCS_ALLOC_CARVE_ARRAY(mem, num_areas + 1, ccs_float_t);
 	distrib_data->common_data.data_types =
-		(ccs_numeric_type_t
-			 *)(mem + sizeof(struct _ccs_distribution_s) +
-			    sizeof(_ccs_distribution_roulette_data_t) +
-			    sizeof(ccs_float_t) * (num_areas + 1));
+		CCS_ALLOC_CARVE_ARRAY(mem, 1, ccs_numeric_type_t);
 	distrib_data->common_data.type      = CCS_DISTRIBUTION_TYPE_ROULETTE;
 	distrib_data->common_data.dimension = 1;
 	distrib_data->common_data.data_types[0] = CCS_NUMERIC_TYPE_INT;
 	distrib_data->num_areas                 = num_areas;
-	distrib_data->areas =
-		(ccs_float_t *)(mem + sizeof(struct _ccs_distribution_s) +
-				sizeof(_ccs_distribution_roulette_data_t));
+	(void)mem_orig;
 	_ccs_distribution_roulette_normalize_areas(
 		num_areas, areas, sum_areas_inverse, distrib_data->areas);
 	distrib->data     = (_ccs_distribution_data_t *)distrib_data;

--- a/src/distribution_roulette.c
+++ b/src/distribution_roulette.c
@@ -245,7 +245,6 @@ ccs_create_roulette_distribution(
 			   sizeof(ccs_numeric_type_t));
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 
-	uintptr_t          mem_orig = mem;
 	ccs_distribution_t distrib =
 		CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_distribution_s);
 	_ccs_object_init(
@@ -261,7 +260,6 @@ ccs_create_roulette_distribution(
 	distrib_data->common_data.dimension = 1;
 	distrib_data->common_data.data_types[0] = CCS_NUMERIC_TYPE_INT;
 	distrib_data->num_areas                 = num_areas;
-	(void)mem_orig;
 	_ccs_distribution_roulette_normalize_areas(
 		num_areas, areas, sum_areas_inverse, distrib_data->areas);
 	distrib->data     = (_ccs_distribution_data_t *)distrib_data;

--- a/src/distribution_space_internal.h
+++ b/src/distribution_space_internal.h
@@ -92,32 +92,33 @@ _ccs_create_distribution_space_no_retain(
 {
 	size_t                       num_parameters;
 	_ccs_distribution_wrapper_t *dw, *tmp;
+	ccs_distribution_space_t     distrib_space;
+	uintptr_t                    mem_orig;
+	uintptr_t                    mem;
 	ccs_result_t                 err = CCS_RESULT_SUCCESS;
 	CCS_VALIDATE(_ccs_context_get_num_parameters(
 		(ccs_context_t)configuration_space, &num_parameters));
-	uintptr_t mem = (uintptr_t)calloc(
+	mem = (uintptr_t)calloc(
 		1, sizeof(struct _ccs_distribution_space_s) +
 			   sizeof(struct _ccs_distribution_space_data_s) +
 			   sizeof(struct _ccs_parameter_distribution_s) *
 				   num_parameters);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 
-	ccs_distribution_space_t distrib_space;
-	distrib_space = (ccs_distribution_space_t)mem;
+	mem_orig = mem;
+	distrib_space =
+		CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_distribution_space_s);
 	if (ops) {
 		_ccs_object_init(
 			&(distrib_space->obj),
 			CCS_OBJECT_TYPE_DISTRIBUTION_SPACE,
 			(_ccs_object_ops_t *)ops);
 	}
-	distrib_space->data =
-		(struct _ccs_distribution_space_data_s
-			 *)(mem + sizeof(struct _ccs_distribution_space_s));
-	distrib_space->data->num_parameters = num_parameters;
-	distrib_space->data->parameter_distributions =
-		(struct _ccs_parameter_distribution_s
-			 *)(mem + sizeof(struct _ccs_distribution_space_s) +
-			    sizeof(struct _ccs_distribution_space_data_s));
+	distrib_space->data = CCS_ALLOC_CARVE_TYPE(
+		mem, struct _ccs_distribution_space_data_s);
+	distrib_space->data->num_parameters          = num_parameters;
+	distrib_space->data->parameter_distributions = CCS_ALLOC_CARVE_ARRAY(
+		mem, num_parameters, struct _ccs_parameter_distribution_s);
 	distrib_space->data->configuration_space = configuration_space;
 	for (size_t i = 0; i < num_parameters; i++) {
 		_ccs_distribution_wrapper_t   *distrib_wrapper;
@@ -143,7 +144,7 @@ err_dis:
 		ccs_release_object(dw->distribution);
 		free(dw);
 	}
-	free((void *)mem);
+	free((void *)mem_orig);
 	return err;
 }
 

--- a/src/distribution_uniform.c
+++ b/src/distribution_uniform.c
@@ -405,7 +405,6 @@ ccs_create_uniform_distribution(
 			   sizeof(_ccs_distribution_uniform_data_t) +
 			   sizeof(ccs_numeric_type_t));
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-	uintptr_t          mem_orig = mem;
 	ccs_distribution_t distrib =
 		CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_distribution_s);
 	_ccs_object_init(
@@ -415,7 +414,6 @@ ccs_create_uniform_distribution(
 		CCS_ALLOC_CARVE_TYPE(mem, _ccs_distribution_uniform_data_t);
 	distrib_data->common_data.data_types =
 		CCS_ALLOC_CARVE_ARRAY(mem, 1, ccs_numeric_type_t);
-	(void)mem_orig;
 	distrib_data->common_data.type          = CCS_DISTRIBUTION_TYPE_UNIFORM;
 	distrib_data->common_data.dimension     = 1;
 	distrib_data->common_data.data_types[0] = data_type;

--- a/src/distribution_uniform.c
+++ b/src/distribution_uniform.c
@@ -405,17 +405,17 @@ ccs_create_uniform_distribution(
 			   sizeof(_ccs_distribution_uniform_data_t) +
 			   sizeof(ccs_numeric_type_t));
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-	ccs_distribution_t distrib = (ccs_distribution_t)mem;
+	uintptr_t          mem_orig = mem;
+	ccs_distribution_t distrib =
+		CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_distribution_s);
 	_ccs_object_init(
 		&(distrib->obj), CCS_OBJECT_TYPE_DISTRIBUTION,
 		(_ccs_object_ops_t *)&_ccs_distribution_uniform_ops);
 	_ccs_distribution_uniform_data_t *distrib_data =
-		(_ccs_distribution_uniform_data_t
-			 *)(mem + sizeof(struct _ccs_distribution_s));
+		CCS_ALLOC_CARVE_TYPE(mem, _ccs_distribution_uniform_data_t);
 	distrib_data->common_data.data_types =
-		(ccs_numeric_type_t *)(mem +
-				       sizeof(struct _ccs_distribution_s) +
-				       sizeof(_ccs_distribution_uniform_data_t));
+		CCS_ALLOC_CARVE_ARRAY(mem, 1, ccs_numeric_type_t);
+	(void)mem_orig;
 	distrib_data->common_data.type          = CCS_DISTRIBUTION_TYPE_UNIFORM;
 	distrib_data->common_data.dimension     = 1;
 	distrib_data->common_data.data_types[0] = data_type;

--- a/src/error_stack.c
+++ b/src/error_stack.c
@@ -97,7 +97,7 @@ _ccs_create_error_stack(
 		(_ccs_object_ops_t *)&_error_stack_ops);
 	error_stack->data =
 		CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_error_stack_data_s);
-	error_stack->data->msg = (const char *)mem;
+	error_stack->data->msg = CCS_ALLOC_CARVE_ARRAY(mem, msg_size, char);
 	utarray_new(error_stack->data->elems, &_error_stack_elem_icd);
 	error_stack->data->error = error_code;
 	if (msg) {

--- a/src/error_stack.c
+++ b/src/error_stack.c
@@ -89,16 +89,15 @@ _ccs_create_error_stack(
 			   sizeof(struct _ccs_error_stack_data_s) + msg_size);
 	if (!mem)
 		return CCS_RESULT_ERROR_OUT_OF_MEMORY;
-	ccs_error_stack_t error_stack = (ccs_error_stack_t)mem;
+	uintptr_t         mem_orig = mem;
+	ccs_error_stack_t error_stack =
+		CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_error_stack_s);
 	_ccs_object_init(
 		&(error_stack->obj), CCS_OBJECT_TYPE_ERROR_STACK,
 		(_ccs_object_ops_t *)&_error_stack_ops);
 	error_stack->data =
-		(struct _ccs_error_stack_data_s
-			 *)(mem + sizeof(struct _ccs_error_stack_s));
-	error_stack->data->msg =
-		(const char *)(mem + sizeof(struct _ccs_error_stack_s) +
-			       sizeof(struct _ccs_error_stack_data_s));
+		CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_error_stack_data_s);
+	error_stack->data->msg = (const char *)mem;
 	utarray_new(error_stack->data->elems, &_error_stack_elem_icd);
 	error_stack->data->error = error_code;
 	if (msg) {
@@ -111,7 +110,7 @@ _ccs_create_error_stack(
 	return CCS_RESULT_SUCCESS;
 arrays:
 	_ccs_object_deinit(&(error_stack->obj));
-	free((void *)mem);
+	free((void *)mem_orig);
 	return err;
 }
 

--- a/src/evaluation.c
+++ b/src/evaluation.c
@@ -282,7 +282,8 @@ ccs_create_evaluation(
 	eval->data->result          = result;
 	eval->data->values =
 		CCS_ALLOC_CARVE_ARRAY(cur_mem, num_parameters, ccs_datum_t);
-	eval->data->objective_values = (ccs_datum_t *)(cur_mem);
+	eval->data->objective_values =
+		CCS_ALLOC_CARVE_ARRAY(cur_mem, num_objectives, ccs_datum_t);
 
 	for (size_t i = 0; i < num_values; i++)
 		CCS_VALIDATE_ERR_GOTO(

--- a/src/evaluation.c
+++ b/src/evaluation.c
@@ -269,20 +269,19 @@ ccs_create_evaluation(
 	CCS_VALIDATE_ERR_GOTO(err, ccs_retain_object(objective_space), errmem);
 	CCS_VALIDATE_ERR_GOTO(err, ccs_retain_object(configuration), erros);
 	ccs_evaluation_t eval;
-	eval = (ccs_evaluation_t)cur_mem;
-	cur_mem += sizeof(struct _ccs_evaluation_s);
+	eval = CCS_ALLOC_CARVE_TYPE(cur_mem, struct _ccs_evaluation_s);
 	_ccs_object_init(
 		&(eval->obj), CCS_OBJECT_TYPE_EVALUATION,
 		(_ccs_object_ops_t *)&_evaluation_ops);
-	eval->data = (struct _ccs_evaluation_data_s *)(cur_mem);
-	cur_mem += sizeof(struct _ccs_evaluation_data_s);
+	eval->data =
+		CCS_ALLOC_CARVE_TYPE(cur_mem, struct _ccs_evaluation_data_s);
 	eval->data->num_values      = num_parameters;
 	eval->data->num_objectives  = num_objectives;
 	eval->data->objective_space = objective_space;
 	eval->data->configuration   = configuration;
 	eval->data->result          = result;
-	eval->data->values          = (ccs_datum_t *)(cur_mem);
-	cur_mem += num_parameters * sizeof(ccs_datum_t);
+	eval->data->values =
+		CCS_ALLOC_CARVE_ARRAY(cur_mem, num_parameters, ccs_datum_t);
 	eval->data->objective_values = (ccs_datum_t *)(cur_mem);
 
 	for (size_t i = 0; i < num_values; i++)

--- a/src/expression.c
+++ b/src/expression.c
@@ -1545,7 +1545,6 @@ ccs_create_literal(ccs_datum_t value, ccs_expression_t *expression_ret)
 			   sizeof(struct _ccs_expression_literal_data_s) +
 			   size_str);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-	uintptr_t        mem_orig = mem;
 	ccs_expression_t expression =
 		CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_expression_s);
 	_ccs_object_init(
@@ -1557,9 +1556,8 @@ ccs_create_literal(ccs_datum_t value, ccs_expression_t *expression_ret)
 	expression_data->expr.type      = CCS_EXPRESSION_TYPE_LITERAL;
 	expression_data->expr.num_nodes = 0;
 	expression_data->expr.nodes     = NULL;
-	(void)mem_orig;
 	if (size_str) {
-		char *str_pool         = (char *)mem;
+		char *str_pool = CCS_ALLOC_CARVE_ARRAY(mem, size_str, char);
 		expression_data->value = ccs_string(str_pool);
 		strcpy(str_pool, value.value.s);
 	} else {
@@ -1592,7 +1590,6 @@ ccs_create_variable(ccs_parameter_t parameter, ccs_expression_t *expression_ret)
 			CCS_EXPRESSION_TYPE_VARIABLE));
 	expression_data = CCS_ALLOC_CARVE_TYPE(
 		mem, struct _ccs_expression_variable_data_s);
-	(void)mem_orig;
 	expression_data->expr.type      = CCS_EXPRESSION_TYPE_VARIABLE;
 	expression_data->expr.num_nodes = 0;
 	expression_data->expr.nodes     = NULL;
@@ -1698,7 +1695,6 @@ ccs_create_expression(
 	expression_data->num_nodes = num_nodes;
 	expression_data->nodes =
 		CCS_ALLOC_CARVE_ARRAY(mem, num_nodes, ccs_expression_t);
-	(void)mem_orig;
 	CCS_VALIDATE_ERR_GOTO(
 		err,
 		_ccs_create_nodes(num_nodes, nodes, expression_data->nodes),
@@ -1758,6 +1754,7 @@ ccs_create_user_defined_expression(
 
 	ccs_result_t err;
 	size_t       _sz;
+	size_t       name_len = strlen(name) + 1;
 	CCS_REFUTE(
 		_ccs_size_mul(num_nodes, sizeof(ccs_expression_t), &_sz),
 		CCS_RESULT_ERROR_OUT_OF_MEMORY);
@@ -1766,7 +1763,7 @@ ccs_create_user_defined_expression(
 			_sz,
 			sizeof(struct _ccs_expression_s) +
 				sizeof(struct _ccs_expression_user_defined_data_s) +
-				strlen(name) + 1,
+				name_len,
 			&_sz),
 		CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	uintptr_t mem = (uintptr_t)calloc(1, _sz);
@@ -1785,9 +1782,8 @@ ccs_create_user_defined_expression(
 	expression_data->expr.num_nodes = num_nodes;
 	expression_data->expr.nodes =
 		CCS_ALLOC_CARVE_ARRAY(mem, num_nodes, ccs_expression_t);
-	expression_data->name = (const char *)mem;
-	(void)mem_orig;
-	expression_data->vector          = *vector;
+	expression_data->name   = CCS_ALLOC_CARVE_ARRAY(mem, name_len, char);
+	expression_data->vector = *vector;
 	expression_data->expression_data = expr_data;
 	strcpy((char *)expression_data->name, name);
 	CCS_VALIDATE_ERR_GOTO(

--- a/src/expression.c
+++ b/src/expression.c
@@ -1545,21 +1545,21 @@ ccs_create_literal(ccs_datum_t value, ccs_expression_t *expression_ret)
 			   sizeof(struct _ccs_expression_literal_data_s) +
 			   size_str);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-	ccs_expression_t expression = (ccs_expression_t)mem;
+	uintptr_t        mem_orig = mem;
+	ccs_expression_t expression =
+		CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_expression_s);
 	_ccs_object_init(
 		&(expression->obj), CCS_OBJECT_TYPE_EXPRESSION,
 		(_ccs_object_ops_t *)_ccs_expression_ops_broker(
 			CCS_EXPRESSION_TYPE_LITERAL));
-	_ccs_expression_literal_data_t *expression_data =
-		(_ccs_expression_literal_data_t
-			 *)(mem + sizeof(struct _ccs_expression_s));
+	_ccs_expression_literal_data_t *expression_data = CCS_ALLOC_CARVE_TYPE(
+		mem, struct _ccs_expression_literal_data_s);
 	expression_data->expr.type      = CCS_EXPRESSION_TYPE_LITERAL;
 	expression_data->expr.num_nodes = 0;
 	expression_data->expr.nodes     = NULL;
+	(void)mem_orig;
 	if (size_str) {
-		char *str_pool =
-			(char *)(mem + sizeof(struct _ccs_expression_s) +
-				 sizeof(struct _ccs_expression_literal_data_s));
+		char *str_pool         = (char *)mem;
 		expression_data->value = ccs_string(str_pool);
 		strcpy(str_pool, value.value.s);
 	} else {
@@ -1576,21 +1576,23 @@ ccs_create_variable(ccs_parameter_t parameter, ccs_expression_t *expression_ret)
 {
 	CCS_CHECK_OBJ(parameter, CCS_OBJECT_TYPE_PARAMETER);
 	CCS_CHECK_PTR(expression_ret);
-	ccs_result_t err;
-	uintptr_t    mem = (uintptr_t)calloc(
+	ccs_result_t                     err;
+	ccs_expression_t                 expression;
+	_ccs_expression_variable_data_t *expression_data;
+	uintptr_t                        mem = (uintptr_t)calloc(
                 1, sizeof(struct _ccs_expression_s) +
                            sizeof(struct _ccs_expression_variable_data_s));
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	uintptr_t mem_orig = mem;
 	CCS_VALIDATE_ERR_GOTO(err, ccs_retain_object(parameter), errmem);
-	ccs_expression_t expression;
-	expression = (ccs_expression_t)mem;
+	expression = CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_expression_s);
 	_ccs_object_init(
 		&(expression->obj), CCS_OBJECT_TYPE_EXPRESSION,
 		(_ccs_object_ops_t *)_ccs_expression_ops_broker(
 			CCS_EXPRESSION_TYPE_VARIABLE));
-	_ccs_expression_variable_data_t *expression_data;
-	expression_data                 = (_ccs_expression_variable_data_t
-                                   *)(mem + sizeof(struct _ccs_expression_s));
+	expression_data = CCS_ALLOC_CARVE_TYPE(
+		mem, struct _ccs_expression_variable_data_s);
+	(void)mem_orig;
 	expression_data->expr.type      = CCS_EXPRESSION_TYPE_VARIABLE;
 	expression_data->expr.num_nodes = 0;
 	expression_data->expr.nodes     = NULL;
@@ -1599,7 +1601,7 @@ ccs_create_variable(ccs_parameter_t parameter, ccs_expression_t *expression_ret)
 	*expression_ret  = expression;
 	return CCS_RESULT_SUCCESS;
 errmem:
-	free((void *)mem);
+	free((void *)mem_orig);
 	return err;
 }
 
@@ -1684,19 +1686,19 @@ ccs_create_expression(
 		CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	uintptr_t mem = (uintptr_t)calloc(1, _sz);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-
-	ccs_expression_t expression = (ccs_expression_t)mem;
+	uintptr_t        mem_orig = mem;
+	ccs_expression_t expression =
+		CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_expression_s);
 	_ccs_object_init(
 		&(expression->obj), CCS_OBJECT_TYPE_EXPRESSION,
 		(_ccs_object_ops_t *)_ccs_expression_ops_broker(type));
 	_ccs_expression_data_t *expression_data =
-		(_ccs_expression_data_t *)(mem +
-					   sizeof(struct _ccs_expression_s));
+		CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_expression_data_s);
 	expression_data->type      = type;
 	expression_data->num_nodes = num_nodes;
 	expression_data->nodes =
-		(ccs_expression_t *)(mem + sizeof(struct _ccs_expression_s) +
-				     sizeof(struct _ccs_expression_data_s));
+		CCS_ALLOC_CARVE_ARRAY(mem, num_nodes, ccs_expression_t);
+	(void)mem_orig;
 	CCS_VALIDATE_ERR_GOTO(
 		err,
 		_ccs_create_nodes(num_nodes, nodes, expression_data->nodes),
@@ -1710,7 +1712,7 @@ cleanup:
 			ccs_release_object(expression_data->nodes[i]);
 	}
 	_ccs_object_deinit(&(expression->obj));
-	free((void *)mem);
+	free((void *)mem_orig);
 	return err;
 }
 
@@ -1769,27 +1771,22 @@ ccs_create_user_defined_expression(
 		CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	uintptr_t mem = (uintptr_t)calloc(1, _sz);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-
-	ccs_expression_t expression;
-	expression = (ccs_expression_t)mem;
+	uintptr_t        mem_orig = mem;
+	ccs_expression_t expression =
+		CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_expression_s);
 	_ccs_object_init(
 		&(expression->obj), CCS_OBJECT_TYPE_EXPRESSION,
 		(_ccs_object_ops_t *)_ccs_expression_ops_broker(
 			CCS_EXPRESSION_TYPE_USER_DEFINED));
-	_ccs_expression_user_defined_data_t *expression_data;
-	expression_data                 = (_ccs_expression_user_defined_data_t
-                                   *)(mem + sizeof(struct _ccs_expression_s));
+	_ccs_expression_user_defined_data_t *expression_data =
+		CCS_ALLOC_CARVE_TYPE(
+			mem, struct _ccs_expression_user_defined_data_s);
 	expression_data->expr.type      = CCS_EXPRESSION_TYPE_USER_DEFINED;
 	expression_data->expr.num_nodes = num_nodes;
 	expression_data->expr.nodes =
-		(ccs_expression_t
-			 *)(mem + sizeof(struct _ccs_expression_s) +
-			    sizeof(struct _ccs_expression_user_defined_data_s));
-	expression_data->name =
-		(const char
-			 *)(mem + sizeof(struct _ccs_expression_s) +
-			    sizeof(struct _ccs_expression_user_defined_data_s) +
-			    sizeof(ccs_expression_t) * num_nodes);
+		CCS_ALLOC_CARVE_ARRAY(mem, num_nodes, ccs_expression_t);
+	expression_data->name = (const char *)mem;
+	(void)mem_orig;
 	expression_data->vector          = *vector;
 	expression_data->expression_data = expr_data;
 	strcpy((char *)expression_data->name, name);
@@ -1806,7 +1803,7 @@ cleanup:
 			ccs_release_object(expression_data->expr.nodes[i]);
 	}
 	_ccs_object_deinit(&(expression->obj));
-	free((void *)mem);
+	free((void *)mem_orig);
 	return err;
 }
 

--- a/src/feature_space.c
+++ b/src/feature_space.c
@@ -93,13 +93,14 @@ ccs_create_feature_space(
 	for (size_t i = 0; i < num_parameters; i++)
 		CCS_CHECK_OBJ(parameters[i], CCS_OBJECT_TYPE_PARAMETER);
 
-	uintptr_t mem = (uintptr_t)calloc(
-		1,
-		sizeof(struct _ccs_feature_space_s) +
-			sizeof(struct _ccs_feature_space_data_s) +
-			sizeof(ccs_parameter_t) * num_parameters +
-			sizeof(_ccs_parameter_index_hash_t) * num_parameters +
-			strlen(name) + 1);
+	size_t    name_len = strlen(name) + 1;
+	uintptr_t mem      = (uintptr_t)calloc(
+                1,
+                sizeof(struct _ccs_feature_space_s) +
+                        sizeof(struct _ccs_feature_space_data_s) +
+                        sizeof(ccs_parameter_t) * num_parameters +
+                        sizeof(_ccs_parameter_index_hash_t) * num_parameters +
+                        name_len);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	uintptr_t           mem_orig = mem;
 
@@ -114,7 +115,7 @@ ccs_create_feature_space(
 		CCS_ALLOC_CARVE_ARRAY(mem, num_parameters, ccs_parameter_t);
 	feat_space->data->hash_elems = CCS_ALLOC_CARVE_ARRAY(
 		mem, num_parameters, _ccs_parameter_index_hash_t);
-	feat_space->data->name           = (const char *)mem;
+	feat_space->data->name = CCS_ALLOC_CARVE_ARRAY(mem, name_len, char);
 	feat_space->data->num_parameters = num_parameters;
 	strcpy((char *)(feat_space->data->name), name);
 	CCS_VALIDATE_ERR_GOTO(

--- a/src/features.c
+++ b/src/features.c
@@ -93,16 +93,14 @@ _ccs_create_features(
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	uintptr_t      mem_orig = mem;
 	ccs_features_t feat;
-	feat = (ccs_features_t)mem;
-	mem += sizeof(struct _ccs_features_s);
+	feat = CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_features_s);
 	_ccs_object_init(
 		&(feat->obj), CCS_OBJECT_TYPE_FEATURES,
 		(_ccs_object_ops_t *)&_features_ops);
-	feat->data = (struct _ccs_features_data_s *)mem;
-	mem += sizeof(struct _ccs_features_data_s);
+	feat->data = CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_features_data_s);
 	feat->data->num_values = num_parameters;
-	feat->data->values     = (ccs_datum_t *)mem;
-	mem += sizeof(ccs_datum_t) * num_parameters;
+	feat->data->values =
+		CCS_ALLOC_CARVE_ARRAY(mem, num_parameters, ccs_datum_t);
 	CCS_VALIDATE_ERR_GOTO(err, ccs_retain_object(feature_space), errinit);
 	feat->data->feature_space = feature_space;
 	if (values) {

--- a/src/objective_space.c
+++ b/src/objective_space.c
@@ -245,6 +245,7 @@ ccs_create_objective_space(
 	CCS_CHECK_ARY(num_objectives, types);
 
 	size_t _sz;
+	size_t name_len = strlen(name) + 1;
 	CCS_REFUTE(
 		_ccs_size_sum2(
 			num_parameters,
@@ -257,7 +258,7 @@ ccs_create_objective_space(
 			_sz,
 			sizeof(struct _ccs_objective_space_s) +
 				sizeof(struct _ccs_objective_space_data_s) +
-				strlen(name) + 1,
+				name_len,
 			&_sz),
 		CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	uintptr_t mem = (uintptr_t)calloc(1, _sz);
@@ -277,7 +278,7 @@ ccs_create_objective_space(
 		mem, num_parameters, _ccs_parameter_index_hash_t);
 	obj_space->data->objectives =
 		CCS_ALLOC_CARVE_ARRAY(mem, num_objectives, _ccs_objective_t);
-	obj_space->data->name           = (const char *)mem;
+	obj_space->data->name = CCS_ALLOC_CARVE_ARRAY(mem, name_len, char);
 	obj_space->data->num_parameters = num_parameters;
 	obj_space->data->num_objectives = num_objectives;
 	strcpy((char *)(obj_space->data->name), name);

--- a/src/objective_space.c
+++ b/src/objective_space.c
@@ -264,19 +264,19 @@ ccs_create_objective_space(
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	uintptr_t             mem_orig = mem;
 	ccs_result_t          err;
-	ccs_objective_space_t obj_space = (ccs_objective_space_t)mem;
-	mem += sizeof(struct _ccs_objective_space_s);
+	ccs_objective_space_t obj_space =
+		CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_objective_space_s);
 	_ccs_object_init(
 		&(obj_space->obj), CCS_OBJECT_TYPE_OBJECTIVE_SPACE,
 		(_ccs_object_ops_t *)&_objective_space_ops);
-	obj_space->data = (struct _ccs_objective_space_data_s *)mem;
-	mem += sizeof(struct _ccs_objective_space_data_s);
-	obj_space->data->parameters = (ccs_parameter_t *)mem;
-	mem += sizeof(ccs_parameter_t) * num_parameters;
-	obj_space->data->hash_elems = (_ccs_parameter_index_hash_t *)mem;
-	mem += sizeof(_ccs_parameter_index_hash_t) * num_parameters;
-	obj_space->data->objectives = (_ccs_objective_t *)mem;
-	mem += sizeof(_ccs_objective_t) * num_objectives;
+	obj_space->data =
+		CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_objective_space_data_s);
+	obj_space->data->parameters =
+		CCS_ALLOC_CARVE_ARRAY(mem, num_parameters, ccs_parameter_t);
+	obj_space->data->hash_elems = CCS_ALLOC_CARVE_ARRAY(
+		mem, num_parameters, _ccs_parameter_index_hash_t);
+	obj_space->data->objectives =
+		CCS_ALLOC_CARVE_ARRAY(mem, num_objectives, _ccs_objective_t);
 	obj_space->data->name           = (const char *)mem;
 	obj_space->data->num_parameters = num_parameters;
 	obj_space->data->num_objectives = num_objectives;

--- a/src/parameter_categorical.c
+++ b/src/parameter_categorical.c
@@ -305,6 +305,7 @@ _ccs_create_categorical_parameter(
 					possible_values[i].type !=
 						CCS_DATA_TYPE_INT,
 				CCS_RESULT_ERROR_INVALID_VALUE);
+	size_t name_len  = strlen(name) + 1;
 	size_t size_strs = 0;
 	if (type != CCS_PARAMETER_TYPE_DISCRETE)
 		for (size_t i = 0; i < num_possible_values; i++) {
@@ -331,7 +332,7 @@ _ccs_create_categorical_parameter(
 			_sz,
 			sizeof(struct _ccs_parameter_s) +
 				sizeof(_ccs_parameter_categorical_data_t) +
-				strlen(name) + 1 + size_strs,
+				name_len + size_strs,
 			&_sz),
 		CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	ccs_interval_t                     interval;
@@ -361,7 +362,8 @@ _ccs_create_categorical_parameter(
 	pvs = CCS_ALLOC_CARVE_ARRAY(
 		mem, num_possible_values, _ccs_hash_datum_t);
 	parameter_data->common_data.type = type;
-	parameter_data->common_data.name = (const char *)mem;
+	parameter_data->common_data.name =
+		CCS_ALLOC_CARVE_ARRAY(mem, name_len, char);
 	strcpy((char *)parameter_data->common_data.name, name);
 	parameter_data->common_data.interval = interval;
 	parameter_data->num_possible_values  = num_possible_values;
@@ -369,8 +371,7 @@ _ccs_create_categorical_parameter(
 	parameter_data->hash                 = NULL;
 	parameter->data = (_ccs_parameter_data_t *)parameter_data;
 
-	str_pool =
-		(char *)(parameter_data->common_data.name) + strlen(name) + 1;
+	str_pool        = CCS_ALLOC_CARVE_ARRAY(mem, size_strs, char);
 	for (size_t i = 0; i < num_possible_values; i++) {
 		_ccs_hash_datum_t *p = NULL;
 		HASH_FIND(

--- a/src/parameter_categorical.c
+++ b/src/parameter_categorical.c
@@ -272,7 +272,7 @@ static _ccs_parameter_ops_t _ccs_parameter_categorical_ops = {
 #define uthash_nonfatal_oom(elt)                                               \
 	{                                                                      \
 		HASH_CLEAR(hh, parameter_data->hash);                          \
-		free((void *)mem);                                             \
+		free((void *)mem_orig);                                        \
 		CCS_RAISE(                                                     \
 			CCS_RESULT_ERROR_OUT_OF_MEMORY,                        \
 			"Not enough memory to allocate hash");                 \
@@ -334,39 +334,42 @@ _ccs_create_categorical_parameter(
 				strlen(name) + 1 + size_strs,
 			&_sz),
 		CCS_RESULT_ERROR_OUT_OF_MEMORY);
-	uintptr_t mem = (uintptr_t)calloc(1, _sz);
+	ccs_interval_t                     interval;
+	uintptr_t                          mem_orig;
+	uintptr_t                          mem;
+	ccs_parameter_t                    parameter;
+	_ccs_parameter_categorical_data_t *parameter_data;
+	_ccs_hash_datum_t                 *pvs;
+	char                              *str_pool;
+
+	mem = (uintptr_t)calloc(1, _sz);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 
-	ccs_interval_t interval;
-	interval.type             = CCS_NUMERIC_TYPE_INT;
-	interval.lower.i          = 0;
-	interval.upper.i          = (ccs_int_t)num_possible_values;
-	interval.lower_included   = CCS_TRUE;
-	interval.upper_included   = CCS_FALSE;
+	interval.type           = CCS_NUMERIC_TYPE_INT;
+	interval.lower.i        = 0;
+	interval.upper.i        = (ccs_int_t)num_possible_values;
+	interval.lower_included = CCS_TRUE;
+	interval.upper_included = CCS_FALSE;
 
-	ccs_parameter_t parameter = (ccs_parameter_t)mem;
+	mem_orig                = mem;
+	parameter = CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_parameter_s);
 	_ccs_object_init(
 		&(parameter->obj), CCS_OBJECT_TYPE_PARAMETER,
 		(_ccs_object_ops_t *)&_ccs_parameter_categorical_ops);
-	_ccs_parameter_categorical_data_t *parameter_data =
-		(_ccs_parameter_categorical_data_t
-			 *)(mem + sizeof(struct _ccs_parameter_s));
+	parameter_data =
+		CCS_ALLOC_CARVE_TYPE(mem, _ccs_parameter_categorical_data_t);
+	pvs = CCS_ALLOC_CARVE_ARRAY(
+		mem, num_possible_values, _ccs_hash_datum_t);
 	parameter_data->common_data.type = type;
-	parameter_data->common_data.name =
-		(char *)(mem + sizeof(struct _ccs_parameter_s) +
-			 sizeof(_ccs_parameter_categorical_data_t) +
-			 sizeof(_ccs_hash_datum_t) * num_possible_values);
+	parameter_data->common_data.name = (const char *)mem;
 	strcpy((char *)parameter_data->common_data.name, name);
 	parameter_data->common_data.interval = interval;
 	parameter_data->num_possible_values  = num_possible_values;
-	_ccs_hash_datum_t *pvs =
-		(_ccs_hash_datum_t *)(mem + sizeof(struct _ccs_parameter_s) +
-				      sizeof(_ccs_parameter_categorical_data_t));
-	parameter_data->possible_values = pvs;
-	parameter_data->hash            = NULL;
+	parameter_data->possible_values      = pvs;
+	parameter_data->hash                 = NULL;
 	parameter->data = (_ccs_parameter_data_t *)parameter_data;
 
-	char *str_pool =
+	str_pool =
 		(char *)(parameter_data->common_data.name) + strlen(name) + 1;
 	for (size_t i = 0; i < num_possible_values; i++) {
 		_ccs_hash_datum_t *p = NULL;
@@ -396,7 +399,7 @@ _ccs_create_categorical_parameter(
 errmem:
 	_ccs_parameter_categorical_del(parameter);
 	_ccs_object_deinit(&(parameter->obj));
-	free((void *)mem);
+	free((void *)mem_orig);
 	return err;
 }
 

--- a/src/parameter_numerical.c
+++ b/src/parameter_numerical.c
@@ -296,20 +296,19 @@ ccs_create_numerical_parameter(
 			 default_value.f < lower.f ||
 			 default_value.f >= upper.f),
 		CCS_RESULT_ERROR_INVALID_VALUE);
-	uintptr_t mem = (uintptr_t)calloc(
-		1, sizeof(struct _ccs_parameter_s) +
-			   sizeof(_ccs_parameter_numerical_data_t) +
-			   strlen(name) + 1);
+	size_t    name_len = strlen(name) + 1;
+	uintptr_t mem      = (uintptr_t)calloc(
+                1, sizeof(struct _ccs_parameter_s) +
+                           sizeof(_ccs_parameter_numerical_data_t) + name_len);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 
 	ccs_interval_t interval;
-	interval.type            = data_type;
-	interval.lower           = lower;
-	interval.upper           = upper;
-	interval.lower_included  = CCS_TRUE;
-	interval.upper_included  = CCS_FALSE;
+	interval.type           = data_type;
+	interval.lower          = lower;
+	interval.upper          = upper;
+	interval.lower_included = CCS_TRUE;
+	interval.upper_included = CCS_FALSE;
 
-	uintptr_t       mem_orig = mem;
 	ccs_parameter_t parameter =
 		CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_parameter_s);
 	_ccs_object_init(
@@ -318,9 +317,9 @@ ccs_create_numerical_parameter(
 	_ccs_parameter_numerical_data_t *parameter_data =
 		CCS_ALLOC_CARVE_TYPE(mem, _ccs_parameter_numerical_data_t);
 	parameter_data->common_data.type = CCS_PARAMETER_TYPE_NUMERICAL;
-	parameter_data->common_data.name = (const char *)mem;
+	parameter_data->common_data.name =
+		CCS_ALLOC_CARVE_ARRAY(mem, name_len, char);
 	strcpy((char *)parameter_data->common_data.name, name);
-	(void)mem_orig;
 	if (data_type == CCS_NUMERIC_TYPE_FLOAT) {
 		parameter_data->common_data.default_value.type =
 			CCS_DATA_TYPE_FLOAT;

--- a/src/parameter_numerical.c
+++ b/src/parameter_numerical.c
@@ -303,24 +303,24 @@ ccs_create_numerical_parameter(
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 
 	ccs_interval_t interval;
-	interval.type             = data_type;
-	interval.lower            = lower;
-	interval.upper            = upper;
-	interval.lower_included   = CCS_TRUE;
-	interval.upper_included   = CCS_FALSE;
+	interval.type            = data_type;
+	interval.lower           = lower;
+	interval.upper           = upper;
+	interval.lower_included  = CCS_TRUE;
+	interval.upper_included  = CCS_FALSE;
 
-	ccs_parameter_t parameter = (ccs_parameter_t)mem;
+	uintptr_t       mem_orig = mem;
+	ccs_parameter_t parameter =
+		CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_parameter_s);
 	_ccs_object_init(
 		&(parameter->obj), CCS_OBJECT_TYPE_PARAMETER,
 		(_ccs_object_ops_t *)&_ccs_parameter_numerical_ops);
 	_ccs_parameter_numerical_data_t *parameter_data =
-		(_ccs_parameter_numerical_data_t
-			 *)(mem + sizeof(struct _ccs_parameter_s));
+		CCS_ALLOC_CARVE_TYPE(mem, _ccs_parameter_numerical_data_t);
 	parameter_data->common_data.type = CCS_PARAMETER_TYPE_NUMERICAL;
-	parameter_data->common_data.name =
-		(char *)(mem + sizeof(struct _ccs_parameter_s) +
-			 sizeof(_ccs_parameter_numerical_data_t));
+	parameter_data->common_data.name = (const char *)mem;
 	strcpy((char *)parameter_data->common_data.name, name);
+	(void)mem_orig;
 	if (data_type == CCS_NUMERIC_TYPE_FLOAT) {
 		parameter_data->common_data.default_value.type =
 			CCS_DATA_TYPE_FLOAT;

--- a/src/parameter_string.c
+++ b/src/parameter_string.c
@@ -248,18 +248,18 @@ ccs_create_string_parameter(const char *name, ccs_parameter_t *parameter_ret)
 			   1);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 
-	ccs_parameter_t parameter = (ccs_parameter_t)mem;
+	uintptr_t       mem_orig = mem;
+	ccs_parameter_t parameter =
+		CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_parameter_s);
 	_ccs_object_init(
 		&(parameter->obj), CCS_OBJECT_TYPE_PARAMETER,
 		(_ccs_object_ops_t *)&_ccs_parameter_string_ops);
 	_ccs_parameter_string_data_t *parameter_data =
-		(_ccs_parameter_string_data_t
-			 *)(mem + sizeof(struct _ccs_parameter_s));
+		CCS_ALLOC_CARVE_TYPE(mem, _ccs_parameter_string_data_t);
 	parameter_data->common_data.type = CCS_PARAMETER_TYPE_STRING;
-	parameter_data->common_data.name =
-		(char *)(mem + sizeof(struct _ccs_parameter_s) +
-			 sizeof(_ccs_parameter_string_data_t));
+	parameter_data->common_data.name = (const char *)mem;
 	strcpy((char *)parameter_data->common_data.name, name);
+	(void)mem_orig;
 	parameter_data->common_data.interval.type = CCS_NUMERIC_TYPE_INT;
 	parameter_data->stored_values             = NULL;
 #if CCS_THREAD_SAFE

--- a/src/parameter_string.c
+++ b/src/parameter_string.c
@@ -242,13 +242,12 @@ ccs_create_string_parameter(const char *name, ccs_parameter_t *parameter_ret)
 {
 	CCS_CHECK_PTR(name);
 	CCS_CHECK_PTR(parameter_ret);
-	uintptr_t mem = (uintptr_t)calloc(
-		1, sizeof(struct _ccs_parameter_s) +
-			   sizeof(_ccs_parameter_string_data_t) + strlen(name) +
-			   1);
+	size_t    name_len = strlen(name) + 1;
+	uintptr_t mem      = (uintptr_t)calloc(
+                1, sizeof(struct _ccs_parameter_s) +
+                           sizeof(_ccs_parameter_string_data_t) + name_len);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 
-	uintptr_t       mem_orig = mem;
 	ccs_parameter_t parameter =
 		CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_parameter_s);
 	_ccs_object_init(
@@ -257,9 +256,9 @@ ccs_create_string_parameter(const char *name, ccs_parameter_t *parameter_ret)
 	_ccs_parameter_string_data_t *parameter_data =
 		CCS_ALLOC_CARVE_TYPE(mem, _ccs_parameter_string_data_t);
 	parameter_data->common_data.type = CCS_PARAMETER_TYPE_STRING;
-	parameter_data->common_data.name = (const char *)mem;
+	parameter_data->common_data.name =
+		CCS_ALLOC_CARVE_ARRAY(mem, name_len, char);
 	strcpy((char *)parameter_data->common_data.name, name);
-	(void)mem_orig;
 	parameter_data->common_data.interval.type = CCS_NUMERIC_TYPE_INT;
 	parameter_data->stored_values             = NULL;
 #if CCS_THREAD_SAFE

--- a/src/tree.c
+++ b/src/tree.c
@@ -150,36 +150,25 @@ ccs_create_tree(size_t arity, ccs_datum_t value, ccs_tree_t *tree_ret)
 			   arity * sizeof(ccs_tree_t) + size_strs);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 
-	ccs_tree_t tree = (ccs_tree_t)mem;
+	ccs_tree_t tree = CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_tree_s);
 	_ccs_object_init(
 		&(tree->obj), CCS_OBJECT_TYPE_TREE,
 		(_ccs_object_ops_t *)&_ccs_tree_ops);
-	_ccs_tree_data_t *data =
-		(_ccs_tree_data_t *)(mem + sizeof(struct _ccs_tree_s));
-	data->arity   = arity;
-	data->weights = (ccs_float_t *)(mem + sizeof(struct _ccs_tree_s) +
-					sizeof(_ccs_tree_data_t));
+	_ccs_tree_data_t *data = CCS_ALLOC_CARVE_TYPE(mem, _ccs_tree_data_t);
+	data->arity            = arity;
+	data->weights = CCS_ALLOC_CARVE_ARRAY(mem, arity + 1, ccs_float_t);
 	for (size_t j = 0; j < arity + 1; j++)
 		data->weights[j] = 1.0;
 	data->sum_weights = arity + 1;
-	data->areas       = (ccs_float_t *)(mem + sizeof(struct _ccs_tree_s) +
-                                      sizeof(_ccs_tree_data_t) +
-                                      (arity + 1) * sizeof(ccs_float_t));
+	data->areas       = CCS_ALLOC_CARVE_ARRAY(mem, arity + 2, ccs_float_t);
 	_ccs_distribution_roulette_normalize_areas(
 		arity + 1, data->weights, 1.0 / (data->sum_weights),
 		data->areas);
 	data->bias     = 1.0;
 	data->parent   = NULL;
-	data->children = (ccs_tree_t *)(mem + sizeof(struct _ccs_tree_s) +
-					sizeof(_ccs_tree_data_t) +
-					(arity + 1) * sizeof(ccs_float_t) +
-					(arity + 2) * sizeof(ccs_float_t));
+	data->children = CCS_ALLOC_CARVE_ARRAY(mem, arity, ccs_tree_t);
 	if (value.type == CCS_DATA_TYPE_STRING) {
-		char *str_pool = (char *)(mem + sizeof(struct _ccs_tree_s) +
-					  sizeof(_ccs_tree_data_t) +
-					  (arity + 1) * sizeof(ccs_float_t) +
-					  (arity + 2) * sizeof(ccs_float_t) +
-					  arity * sizeof(ccs_tree_t));
+		char *str_pool = (char *)mem;
 		data->value    = ccs_string(str_pool);
 		strcpy(str_pool, value.value.s);
 	} else {

--- a/src/tree.c
+++ b/src/tree.c
@@ -168,7 +168,7 @@ ccs_create_tree(size_t arity, ccs_datum_t value, ccs_tree_t *tree_ret)
 	data->parent   = NULL;
 	data->children = CCS_ALLOC_CARVE_ARRAY(mem, arity, ccs_tree_t);
 	if (value.type == CCS_DATA_TYPE_STRING) {
-		char *str_pool = (char *)mem;
+		char *str_pool = CCS_ALLOC_CARVE_ARRAY(mem, size_strs, char);
 		data->value    = ccs_string(str_pool);
 		strcpy(str_pool, value.value.s);
 	} else {

--- a/src/tree_configuration.c
+++ b/src/tree_configuration.c
@@ -175,16 +175,15 @@ ccs_create_tree_configuration(
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	uintptr_t                mem_orig = mem;
 	ccs_tree_configuration_t config;
-	config = (ccs_tree_configuration_t)mem;
-	mem += sizeof(struct _ccs_tree_configuration_s);
+	config = CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_tree_configuration_s);
 	_ccs_object_init(
 		&(config->obj), CCS_OBJECT_TYPE_TREE_CONFIGURATION,
 		(_ccs_object_ops_t *)&_tree_configuration_ops);
-	config->data = (struct _ccs_tree_configuration_data_s *)mem;
-	mem += sizeof(struct _ccs_tree_configuration_data_s);
+	config->data = CCS_ALLOC_CARVE_TYPE(
+		mem, struct _ccs_tree_configuration_data_s);
 	config->data->position_size = position_size;
-	config->data->position      = (size_t *)mem;
-	mem += sizeof(size_t) * position_size;
+	config->data->position =
+		CCS_ALLOC_CARVE_ARRAY(mem, position_size, size_t);
 	CCS_VALIDATE_ERR_GOTO(err, ccs_retain_object(tree_space), errinit);
 	config->data->tree_space = tree_space;
 	if (features)

--- a/src/tree_space_dynamic.c
+++ b/src/tree_space_dynamic.c
@@ -270,10 +270,11 @@ ccs_create_dynamic_tree_space(
 	CCS_CHECK_PTR(vector->get_child);
 	CCS_CHECK_PTR(tree_space_ret);
 	ccs_result_t err;
-	uintptr_t    mem = (uintptr_t)calloc(
+	size_t       name_len = strlen(name) + 1;
+	uintptr_t    mem      = (uintptr_t)calloc(
                 1, sizeof(struct _ccs_tree_space_s) +
                            sizeof(struct _ccs_tree_space_dynamic_data_s) +
-                           strlen(name) + 1);
+                           name_len);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	uintptr_t                       mem_orig = mem;
 
@@ -285,7 +286,7 @@ ccs_create_dynamic_tree_space(
 		(_ccs_object_ops_t *)&_ccs_tree_space_dynamic_ops);
 	data = CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_tree_space_dynamic_data_s);
 	data->common_data.type = CCS_TREE_SPACE_TYPE_DYNAMIC;
-	data->common_data.name = (const char *)mem;
+	data->common_data.name = CCS_ALLOC_CARVE_ARRAY(mem, name_len, char);
 	tree_space->data       = (_ccs_tree_space_data_t *)data;
 	if (!rng)
 		CCS_VALIDATE_ERR_GOTO(err, ccs_create_rng(&rng), errinit);

--- a/src/tree_space_dynamic.c
+++ b/src/tree_space_dynamic.c
@@ -279,13 +279,11 @@ ccs_create_dynamic_tree_space(
 
 	ccs_tree_space_t                tree_space;
 	_ccs_tree_space_dynamic_data_t *data;
-	tree_space = (ccs_tree_space_t)mem;
-	mem += sizeof(struct _ccs_tree_space_s);
+	tree_space = CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_tree_space_s);
 	_ccs_object_init(
 		&(tree_space->obj), CCS_OBJECT_TYPE_TREE_SPACE,
 		(_ccs_object_ops_t *)&_ccs_tree_space_dynamic_ops);
-	data = (struct _ccs_tree_space_dynamic_data_s *)mem;
-	mem += sizeof(struct _ccs_tree_space_dynamic_data_s);
+	data = CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_tree_space_dynamic_data_s);
 	data->common_data.type = CCS_TREE_SPACE_TYPE_DYNAMIC;
 	data->common_data.name = (const char *)mem;
 	tree_space->data       = (_ccs_tree_space_data_t *)data;

--- a/src/tree_space_static.c
+++ b/src/tree_space_static.c
@@ -187,10 +187,11 @@ ccs_create_static_tree_space(
 		CCS_CHECK_OBJ(rng, CCS_OBJECT_TYPE_RNG);
 	CCS_CHECK_PTR(tree_space_ret);
 	ccs_result_t err;
-	uintptr_t    mem = (uintptr_t)calloc(
+	size_t       name_len = strlen(name) + 1;
+	uintptr_t    mem      = (uintptr_t)calloc(
                 1, sizeof(struct _ccs_tree_space_s) +
                            sizeof(struct _ccs_tree_space_static_data_s) +
-                           strlen(name) + 1);
+                           name_len);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	uintptr_t        mem_orig = mem;
 
@@ -202,7 +203,7 @@ ccs_create_static_tree_space(
 	_ccs_tree_space_static_data_t *data =
 		CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_tree_space_static_data_s);
 	data->common_data.type = CCS_TREE_SPACE_TYPE_STATIC;
-	data->common_data.name = (const char *)mem;
+	data->common_data.name = CCS_ALLOC_CARVE_ARRAY(mem, name_len, char);
 	tree_space->data       = (_ccs_tree_space_data_t *)data;
 	if (!rng)
 		CCS_VALIDATE_ERR_GOTO(err, ccs_create_rng(&rng), errinit);

--- a/src/tuner_random.c
+++ b/src/tuner_random.c
@@ -613,6 +613,7 @@ ccs_create_random_tuner(
 			   sizeof(struct _ccs_random_tuner_data_s) +
 			   strlen(name) + 1);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	uintptr_t                 mem_orig = mem;
 	ccs_tuner_t               tun;
 	_ccs_random_tuner_data_t *data;
 	ccs_result_t              err;
@@ -623,21 +624,19 @@ ccs_create_random_tuner(
 		CCS_VALIDATE_ERR_GOTO(
 			err, ccs_retain_object(feature_space), erros);
 
-	tun = (ccs_tuner_t)mem;
+	tun = CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_tuner_s);
 	_ccs_object_init(
 		&(tun->obj), CCS_OBJECT_TYPE_TUNER,
 		(_ccs_object_ops_t *)&_ccs_tuner_random_ops);
-	tun->data =
-		(struct _ccs_tuner_data_s *)(mem + sizeof(struct _ccs_tuner_s));
-	data                   = (_ccs_random_tuner_data_t *)tun->data;
-	data->common_data.type = CCS_TUNER_TYPE_RANDOM;
-	data->common_data.name =
-		(const char *)(mem + sizeof(struct _ccs_tuner_s) +
-			       sizeof(struct _ccs_random_tuner_data_s));
+	data      = CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_random_tuner_data_s);
+	tun->data = (struct _ccs_tuner_data_s *)data;
+	data->common_data.type            = CCS_TUNER_TYPE_RANDOM;
+	data->common_data.name            = (const char *)mem;
 	data->common_data.search_space    = search_space;
 	data->common_data.objective_space = objective_space;
 	data->common_data.feature_space   = feature_space;
 	strcpy((char *)data->common_data.name, name);
+	(void)mem_orig;
 	*tuner_ret = tun;
 	return CCS_RESULT_SUCCESS;
 
@@ -646,6 +645,6 @@ erros:
 errcs:
 	ccs_release_object(search_space);
 errmem:
-	free((void *)mem);
+	free((void *)mem_orig);
 	return err;
 }

--- a/src/tuner_random.c
+++ b/src/tuner_random.c
@@ -608,10 +608,10 @@ ccs_create_random_tuner(
 		search_space, &feature_space));
 	CCS_CHECK_PTR(tuner_ret);
 
-	uintptr_t mem = (uintptr_t)calloc(
-		1, sizeof(struct _ccs_tuner_s) +
-			   sizeof(struct _ccs_random_tuner_data_s) +
-			   strlen(name) + 1);
+	size_t    name_len = strlen(name) + 1;
+	uintptr_t mem      = (uintptr_t)calloc(
+                1, sizeof(struct _ccs_tuner_s) +
+                           sizeof(struct _ccs_random_tuner_data_s) + name_len);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	uintptr_t                 mem_orig = mem;
 	ccs_tuner_t               tun;
@@ -630,13 +630,12 @@ ccs_create_random_tuner(
 		(_ccs_object_ops_t *)&_ccs_tuner_random_ops);
 	data      = CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_random_tuner_data_s);
 	tun->data = (struct _ccs_tuner_data_s *)data;
-	data->common_data.type            = CCS_TUNER_TYPE_RANDOM;
-	data->common_data.name            = (const char *)mem;
+	data->common_data.type = CCS_TUNER_TYPE_RANDOM;
+	data->common_data.name = CCS_ALLOC_CARVE_ARRAY(mem, name_len, char);
 	data->common_data.search_space    = search_space;
 	data->common_data.objective_space = objective_space;
 	data->common_data.feature_space   = feature_space;
 	strcpy((char *)data->common_data.name, name);
-	(void)mem_orig;
 	*tuner_ret = tun;
 	return CCS_RESULT_SUCCESS;
 

--- a/src/tuner_user_defined.c
+++ b/src/tuner_user_defined.c
@@ -326,10 +326,11 @@ ccs_create_user_defined_tuner(
 	CCS_CHECK_PTR(vector->get_optima);
 	CCS_CHECK_PTR(vector->get_history);
 
-	uintptr_t mem = (uintptr_t)calloc(
-		1, sizeof(struct _ccs_tuner_s) +
-			   sizeof(struct _ccs_user_defined_tuner_data_s) +
-			   strlen(name) + 1);
+	size_t    name_len = strlen(name) + 1;
+	uintptr_t mem      = (uintptr_t)calloc(
+                1, sizeof(struct _ccs_tuner_s) +
+                           sizeof(struct _ccs_user_defined_tuner_data_s) +
+                           name_len);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	uintptr_t                       mem_orig = mem;
 	ccs_tuner_t                     tun;
@@ -347,16 +348,15 @@ ccs_create_user_defined_tuner(
 		&(tun->obj), CCS_OBJECT_TYPE_TUNER,
 		(_ccs_object_ops_t *)&_ccs_tuner_user_defined_ops);
 	data = CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_user_defined_tuner_data_s);
-	tun->data                         = (struct _ccs_tuner_data_s *)data;
-	data->common_data.type            = CCS_TUNER_TYPE_USER_DEFINED;
-	data->common_data.name            = (const char *)mem;
+	tun->data              = (struct _ccs_tuner_data_s *)data;
+	data->common_data.type = CCS_TUNER_TYPE_USER_DEFINED;
+	data->common_data.name = CCS_ALLOC_CARVE_ARRAY(mem, name_len, char);
 	data->common_data.search_space    = search_space;
 	data->common_data.objective_space = objective_space;
 	data->common_data.feature_space   = feature_space;
 	data->vector                      = *vector;
 	data->tuner_data                  = tuner_data;
 	strcpy((char *)data->common_data.name, name);
-	(void)mem_orig;
 	*tuner_ret = tun;
 	return CCS_RESULT_SUCCESS;
 erros:

--- a/src/tuner_user_defined.c
+++ b/src/tuner_user_defined.c
@@ -331,6 +331,7 @@ ccs_create_user_defined_tuner(
 			   sizeof(struct _ccs_user_defined_tuner_data_s) +
 			   strlen(name) + 1);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	uintptr_t                       mem_orig = mem;
 	ccs_tuner_t                     tun;
 	_ccs_user_defined_tuner_data_t *data;
 	ccs_result_t                    err;
@@ -341,23 +342,21 @@ ccs_create_user_defined_tuner(
 		CCS_VALIDATE_ERR_GOTO(
 			err, ccs_retain_object(feature_space), erros);
 
-	tun = (ccs_tuner_t)mem;
+	tun = CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_tuner_s);
 	_ccs_object_init(
 		&(tun->obj), CCS_OBJECT_TYPE_TUNER,
 		(_ccs_object_ops_t *)&_ccs_tuner_user_defined_ops);
-	tun->data =
-		(struct _ccs_tuner_data_s *)(mem + sizeof(struct _ccs_tuner_s));
-	data                   = (_ccs_user_defined_tuner_data_t *)tun->data;
-	data->common_data.type = CCS_TUNER_TYPE_USER_DEFINED;
-	data->common_data.name =
-		(const char *)(mem + sizeof(struct _ccs_tuner_s) +
-			       sizeof(struct _ccs_user_defined_tuner_data_s));
+	data = CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_user_defined_tuner_data_s);
+	tun->data                         = (struct _ccs_tuner_data_s *)data;
+	data->common_data.type            = CCS_TUNER_TYPE_USER_DEFINED;
+	data->common_data.name            = (const char *)mem;
 	data->common_data.search_space    = search_space;
 	data->common_data.objective_space = objective_space;
 	data->common_data.feature_space   = feature_space;
 	data->vector                      = *vector;
 	data->tuner_data                  = tuner_data;
 	strcpy((char *)data->common_data.name, name);
+	(void)mem_orig;
 	*tuner_ret = tun;
 	return CCS_RESULT_SUCCESS;
 erros:
@@ -365,7 +364,7 @@ erros:
 errcs:
 	ccs_release_object(search_space);
 errmem:
-	free((void *)mem);
+	free((void *)mem_orig);
 	return err;
 }
 


### PR DESCRIPTION
## Summary

Complete the codebase-wide conversion to \`CCS_ALLOC_CARVE\` macros (follow-up to PR #79).

21 files converted, net -85 lines. All allocation layout sites now use a consistent pattern:
\`\`\`c
ptr = CCS_ALLOC_CARVE_TYPE(mem, struct_type);
arr = CCS_ALLOC_CARVE_ARRAY(mem, count, elem_type);
\`\`\`

Files using \`cur_mem\` as the running pointer (\`distribution_mixture\`, \`distribution_multivariate\`, \`evaluation\`) preserve \`mem\` as the base for cleanup. Files using \`mem\` directly save \`mem_orig\` before carving.

## Test plan

- [x] All 30 C tests pass (gcc, g++)
- [x] Ruby and Python binding tests pass
- [x] clang-format-17 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)