### PR TITLE
Standardize mem/cur_mem naming to mem/mem_orig

### DIFF
--- a/src/distribution_mixture.c
+++ b/src/distribution_mixture.c
@@ -210,8 +210,8 @@ ccs_create_mixture_distribution(
 		isnan(weights_sum_inverse) || !isfinite(weights_sum_inverse),
 		CCS_RESULT_ERROR_INVALID_VALUE);
 
+	uintptr_t                         mem_orig;
 	uintptr_t                         mem;
-	uintptr_t                         cur_mem;
 	uintptr_t                         tmp_mem;
 	ccs_interval_t                   *bounds_tmp;
 	ccs_numeric_type_t               *data_types_tmp;
@@ -237,10 +237,10 @@ ccs_create_mixture_distribution(
 					sizeof(ccs_float_t),
 				&_sz),
 			CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		mem = (uintptr_t)calloc(1, _sz);
-		CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		mem_orig = (uintptr_t)calloc(1, _sz);
+		CCS_REFUTE(!mem_orig, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	}
-	cur_mem = mem;
+	mem = mem_orig;
 
 	{
 		size_t _sz;
@@ -259,23 +259,23 @@ ccs_create_mixture_distribution(
 		(ccs_numeric_type_t *)(tmp_mem + sizeof(ccs_interval_t) *
 							 num_distributions);
 
-	distrib = CCS_ALLOC_CARVE_TYPE(cur_mem, struct _ccs_distribution_s);
+	distrib = CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_distribution_s);
 	_ccs_object_init(
 		&(distrib->obj), CCS_OBJECT_TYPE_DISTRIBUTION,
 		(_ccs_object_ops_t *)&_ccs_distribution_mixture_ops);
 	distrib_data =
-		CCS_ALLOC_CARVE_TYPE(cur_mem, _ccs_distribution_mixture_data_t);
+		CCS_ALLOC_CARVE_TYPE(mem, _ccs_distribution_mixture_data_t);
 	distrib_data->common_data.type      = CCS_DISTRIBUTION_TYPE_MIXTURE;
 	distrib_data->common_data.dimension = dimension;
 	distrib_data->num_distributions     = num_distributions;
 	distrib_data->distributions         = CCS_ALLOC_CARVE_ARRAY(
-                cur_mem, num_distributions, ccs_distribution_t);
+                mem, num_distributions, ccs_distribution_t);
 	distrib_data->bounds =
-		CCS_ALLOC_CARVE_ARRAY(cur_mem, dimension, ccs_interval_t);
-	distrib_data->weights = CCS_ALLOC_CARVE_ARRAY(
-		cur_mem, num_distributions + 1, ccs_float_t);
+		CCS_ALLOC_CARVE_ARRAY(mem, dimension, ccs_interval_t);
+	distrib_data->weights =
+		CCS_ALLOC_CARVE_ARRAY(mem, num_distributions + 1, ccs_float_t);
 	distrib_data->common_data.data_types =
-		CCS_ALLOC_CARVE_ARRAY(cur_mem, dimension, ccs_numeric_type_t);
+		CCS_ALLOC_CARVE_ARRAY(mem, dimension, ccs_numeric_type_t);
 
 	CCS_VALIDATE_ERR_GOTO(
 		err,
@@ -345,7 +345,7 @@ tmpmemory:
 	_ccs_object_deinit(&(distrib->obj));
 	free((void *)tmp_mem);
 memory:
-	free((void *)mem);
+	free((void *)mem_orig);
 	return err;
 }
 

--- a/src/distribution_multivariate.c
+++ b/src/distribution_multivariate.c
@@ -191,8 +191,8 @@ ccs_create_multivariate_distribution(
 		dimension += dim;
 	}
 
-	uintptr_t mem, cur_mem;
-	mem = (uintptr_t)calloc(
+	uintptr_t mem_orig, mem;
+	mem_orig = (uintptr_t)calloc(
 		1, sizeof(struct _ccs_distribution_s) +
 			   sizeof(_ccs_distribution_multivariate_data_t) +
 			   sizeof(ccs_distribution_t) * num_distributions +
@@ -200,26 +200,26 @@ ccs_create_multivariate_distribution(
 			   sizeof(ccs_interval_t) * dimension +
 			   sizeof(ccs_numeric_type_t) * dimension);
 
-	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-	cur_mem = mem;
+	CCS_REFUTE(!mem_orig, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	mem     = mem_orig;
 
-	distrib = CCS_ALLOC_CARVE_TYPE(cur_mem, struct _ccs_distribution_s);
+	distrib = CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_distribution_s);
 	_ccs_object_init(
 		&(distrib->obj), CCS_OBJECT_TYPE_DISTRIBUTION,
 		(_ccs_object_ops_t *)&_ccs_distribution_multivariate_ops);
 	distrib_data = CCS_ALLOC_CARVE_TYPE(
-		cur_mem, _ccs_distribution_multivariate_data_t);
+		mem, _ccs_distribution_multivariate_data_t);
 	distrib_data->common_data.type = CCS_DISTRIBUTION_TYPE_MULTIVARIATE;
 	distrib_data->common_data.dimension = dimension;
 	distrib_data->num_distributions     = num_distributions;
 	distrib_data->distributions         = CCS_ALLOC_CARVE_ARRAY(
-                cur_mem, num_distributions, ccs_distribution_t);
+                mem, num_distributions, ccs_distribution_t);
 	distrib_data->dimensions =
-		CCS_ALLOC_CARVE_ARRAY(cur_mem, num_distributions, size_t);
+		CCS_ALLOC_CARVE_ARRAY(mem, num_distributions, size_t);
 	distrib_data->bounds =
-		CCS_ALLOC_CARVE_ARRAY(cur_mem, dimension, ccs_interval_t);
+		CCS_ALLOC_CARVE_ARRAY(mem, dimension, ccs_interval_t);
 	distrib_data->common_data.data_types =
-		CCS_ALLOC_CARVE_ARRAY(cur_mem, dimension, ccs_numeric_type_t);
+		CCS_ALLOC_CARVE_ARRAY(mem, dimension, ccs_numeric_type_t);
 
 	dimension = 0;
 	for (i = 0; i < num_distributions; i++) {
@@ -261,7 +261,7 @@ distrib:
 	}
 errmemory:
 	_ccs_object_deinit(&(distrib->obj));
-	free((void *)mem);
+	free((void *)mem_orig);
 	return err;
 }
 

--- a/src/distribution_space.c
+++ b/src/distribution_space.c
@@ -318,7 +318,7 @@ ccs_distribution_space_set_distribution(
 	size_t                         num_parameters;
 	size_t                         dim;
 	uintptr_t                      mem;
-	uintptr_t                      cur_mem;
+	uintptr_t                      mem_orig;
 	size_t                        *parameters_without_distrib;
 	size_t                         to_add_count          = 0;
 	size_t                         to_del_count          = 0;
@@ -354,12 +354,13 @@ ccs_distribution_space_set_distribution(
 	}
 
 	CCS_OBJ_WRLOCK(distribution_space);
-	cur_mem            = mem;
-	p_dwrappers_to_del = (_ccs_distribution_wrapper_t **)cur_mem;
-	cur_mem += sizeof(_ccs_distribution_wrapper_t *) * num_parameters;
-	p_dwrappers_to_add = (_ccs_distribution_wrapper_t **)cur_mem;
-	cur_mem += sizeof(_ccs_distribution_wrapper_t *) * num_parameters;
-	parameters_without_distrib = (size_t *)cur_mem;
+	mem_orig           = mem;
+	p_dwrappers_to_del = CCS_ALLOC_CARVE_ARRAY(
+		mem, num_parameters, _ccs_distribution_wrapper_t *);
+	p_dwrappers_to_add = CCS_ALLOC_CARVE_ARRAY(
+		mem, num_parameters, _ccs_distribution_wrapper_t *);
+	parameters_without_distrib =
+		CCS_ALLOC_CARVE_ARRAY(mem, num_parameters, size_t);
 
 	/* Collect the unique wrappers currently covering the target
 	 * parameter indexes — these will be removed. */
@@ -425,7 +426,7 @@ ccs_distribution_space_set_distribution(
 		}
 	}
 
-	free((void *)mem);
+	free((void *)mem_orig);
 	CCS_OBJ_UNLOCK(distribution_space);
 	return CCS_RESULT_SUCCESS;
 err_user_wrapper:
@@ -433,7 +434,7 @@ err_user_wrapper:
 	ccs_release_object(p_dwrappers_to_add[0]->distribution);
 	free(p_dwrappers_to_add[0]);
 memory:
-	free((void *)mem);
+	free((void *)mem_orig);
 	CCS_OBJ_UNLOCK(distribution_space);
 	return err;
 }

--- a/src/evaluation.c
+++ b/src/evaluation.c
@@ -259,31 +259,30 @@ ccs_create_evaluation(
 		objective_space, 0, NULL, NULL, &num_objectives));
 	CCS_REFUTE(
 		num_parameters != num_values, CCS_RESULT_ERROR_INVALID_VALUE);
-	uintptr_t mem = (uintptr_t)calloc(
+	uintptr_t mem_orig = (uintptr_t)calloc(
 		1, sizeof(struct _ccs_evaluation_s) +
 			   sizeof(struct _ccs_evaluation_data_s) +
 			   num_parameters * sizeof(ccs_datum_t) +
 			   num_objectives * sizeof(ccs_datum_t));
-	uintptr_t cur_mem = mem;
-	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	uintptr_t mem = mem_orig;
+	CCS_REFUTE(!mem_orig, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	CCS_VALIDATE_ERR_GOTO(err, ccs_retain_object(objective_space), errmem);
 	CCS_VALIDATE_ERR_GOTO(err, ccs_retain_object(configuration), erros);
 	ccs_evaluation_t eval;
-	eval = CCS_ALLOC_CARVE_TYPE(cur_mem, struct _ccs_evaluation_s);
+	eval = CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_evaluation_s);
 	_ccs_object_init(
 		&(eval->obj), CCS_OBJECT_TYPE_EVALUATION,
 		(_ccs_object_ops_t *)&_evaluation_ops);
-	eval->data =
-		CCS_ALLOC_CARVE_TYPE(cur_mem, struct _ccs_evaluation_data_s);
+	eval->data = CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_evaluation_data_s);
 	eval->data->num_values      = num_parameters;
 	eval->data->num_objectives  = num_objectives;
 	eval->data->objective_space = objective_space;
 	eval->data->configuration   = configuration;
 	eval->data->result          = result;
 	eval->data->values =
-		CCS_ALLOC_CARVE_ARRAY(cur_mem, num_parameters, ccs_datum_t);
+		CCS_ALLOC_CARVE_ARRAY(mem, num_parameters, ccs_datum_t);
 	eval->data->objective_values =
-		CCS_ALLOC_CARVE_ARRAY(cur_mem, num_objectives, ccs_datum_t);
+		CCS_ALLOC_CARVE_ARRAY(mem, num_objectives, ccs_datum_t);
 
 	for (size_t i = 0; i < num_values; i++)
 		CCS_VALIDATE_ERR_GOTO(
@@ -337,7 +336,7 @@ errc:
 erros:
 	ccs_release_object(objective_space);
 errmem:
-	free((void *)mem);
+	free((void *)mem_orig);
 	return err;
 }
 


### PR DESCRIPTION
## Summary

Rename the \`mem\`/\`cur_mem\` pattern to the standard \`mem\`/\`mem_orig\` pattern used everywhere else:
- \`mem_orig\`: base pointer saved for cleanup (\`free\` on error)
- \`mem\`: running pointer advanced by \`CCS_ALLOC_CARVE\`

4 files converted: \`evaluation.c\`, \`distribution_multivariate.c\`, \`distribution_mixture.c\`, \`distribution_space.c\`.

Also converted the remaining manual carves in \`distribution_space.c\` to \`CCS_ALLOC_CARVE_ARRAY\`.

## Test plan

- [x] All 30 C tests pass
- [x] Ruby and Python binding tests pass
- [x] clang-format-17 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)