### PR TITLE
Replace _ccs_size_sum helpers with CCS_ALLOC_SIZE variadic macro

### DIFF
--- a/src/cconfigspace_internal.h
+++ b/src/cconfigspace_internal.h
@@ -957,35 +957,44 @@ _ccs_size_add(size_t a, size_t b, size_t *result)
 	return __builtin_add_overflow(a, b, result) ? CCS_TRUE : CCS_FALSE;
 }
 
-static inline ccs_bool_t
-_ccs_size_sum2(size_t n1, size_t s1, size_t n2, size_t s2, size_t *result)
-{
-	size_t p1, p2;
-	if (_ccs_size_mul(n1, s1, &p1))
-		return CCS_TRUE;
-	if (_ccs_size_mul(n2, s2, &p2))
-		return CCS_TRUE;
-	return _ccs_size_add(p1, p2, result);
-}
+/* Checked allocation size computation. Each entry is a (count, elem_size)
+ * pair. The total is the sum of count*elem_size for all entries.
+ * Returns CCS_TRUE on overflow. */
+typedef struct {
+	size_t count;
+	size_t elem_size;
+} _ccs_alloc_entry_t;
 
 static inline ccs_bool_t
-_ccs_size_sum3(
-	size_t  n1,
-	size_t  s1,
-	size_t  n2,
-	size_t  s2,
-	size_t  n3,
-	size_t  s3,
-	size_t *result)
+_ccs_alloc_size(size_t *result, const _ccs_alloc_entry_t *entries)
 {
-	size_t p;
-	if (_ccs_size_sum2(n1, s1, n2, s2, &p))
-		return CCS_TRUE;
-	size_t p3;
-	if (_ccs_size_mul(n3, s3, &p3))
-		return CCS_TRUE;
-	return _ccs_size_add(p, p3, result);
+	size_t sz = 0;
+	for (const _ccs_alloc_entry_t *e = entries; e->elem_size; e++) {
+		size_t p;
+		if (_ccs_size_mul(e->count, e->elem_size, &p))
+			return CCS_TRUE;
+		if (_ccs_size_add(sz, p, &sz))
+			return CCS_TRUE;
+	}
+	*result = sz;
+	return CCS_FALSE;
 }
+
+#define CCS_ALLOC_SIZE_TYPE(type)                                              \
+	{                                                                      \
+		(size_t)1, sizeof(type)                                        \
+	}
+#define CCS_ALLOC_SIZE_ARRAY(count, type)                                      \
+	{                                                                      \
+		(size_t)(count), sizeof(type)                                  \
+	}
+
+/* __extension__ suppresses -Wpedantic for compound literals in C++ (GCC/Clang).
+ */
+#define CCS_ALLOC_SIZE(result, ...)                                            \
+	_ccs_alloc_size(                                                       \
+		result, __extension__(const _ccs_alloc_entry_t[]){             \
+				__VA_ARGS__, {0, 0}})
 
 /* Carve out a block of 'size' bytes from a running uintptr_t pointer.
  * Advances 'mem' past the carved block and returns the pre-advance

--- a/src/cconfigspace_internal.h
+++ b/src/cconfigspace_internal.h
@@ -989,12 +989,14 @@ _ccs_alloc_size(size_t *result, const _ccs_alloc_entry_t *entries)
 		(size_t)(count), sizeof(type)                                  \
 	}
 
-/* __extension__ suppresses -Wpedantic for compound literals in C++ (GCC/Clang).
- */
+/* __extension__ suppresses -Wpedantic warnings for the statement
+ * expression (GCC/Clang). A stack array avoids compound literal
+ * issues in C++. */
 #define CCS_ALLOC_SIZE(result, ...)                                            \
-	_ccs_alloc_size(                                                       \
-		result, __extension__(const _ccs_alloc_entry_t[]){             \
-				__VA_ARGS__, {0, 0}})
+	__extension__({                                                        \
+		const _ccs_alloc_entry_t _entries[] = {__VA_ARGS__, {0, 0}};   \
+		_ccs_alloc_size(result, _entries);                             \
+	})
 
 /* Carve out a block of 'size' bytes from a running uintptr_t pointer.
  * Advances 'mem' past the carved block and returns the pre-advance

--- a/src/configuration_space.c
+++ b/src/configuration_space.c
@@ -551,23 +551,23 @@ ccs_create_configuration_space(
 
 	ccs_result_t err;
 	size_t       _sz;
+	size_t       name_len = strlen(name) + 1;
 	CCS_REFUTE(
-		_ccs_size_sum2(
-			num_parameters,
-			sizeof(ccs_parameter_t) +
-				sizeof(_ccs_parameter_index_hash_t) +
-				sizeof(ccs_expression_t) +
-				sizeof(UT_array *) * 2 + sizeof(size_t),
-			num_forbidden_clauses, sizeof(ccs_expression_t), &_sz),
-		CCS_RESULT_ERROR_OUT_OF_MEMORY);
-	size_t name_len = strlen(name) + 1;
-	CCS_REFUTE(
-		_ccs_size_add(
-			_sz,
-			sizeof(struct _ccs_configuration_space_s) +
-				sizeof(struct _ccs_configuration_space_data_s) +
-				name_len,
-			&_sz),
+		CCS_ALLOC_SIZE(
+			&_sz,
+			CCS_ALLOC_SIZE_TYPE(struct _ccs_configuration_space_s),
+			CCS_ALLOC_SIZE_TYPE(
+				struct _ccs_configuration_space_data_s),
+			CCS_ALLOC_SIZE_ARRAY(num_parameters, ccs_parameter_t),
+			CCS_ALLOC_SIZE_ARRAY(
+				num_parameters, _ccs_parameter_index_hash_t),
+			CCS_ALLOC_SIZE_ARRAY(num_parameters, ccs_expression_t),
+			CCS_ALLOC_SIZE_ARRAY(num_parameters, UT_array *),
+			CCS_ALLOC_SIZE_ARRAY(num_parameters, UT_array *),
+			CCS_ALLOC_SIZE_ARRAY(num_parameters, size_t),
+			CCS_ALLOC_SIZE_ARRAY(
+				num_forbidden_clauses, ccs_expression_t),
+			CCS_ALLOC_SIZE_ARRAY(name_len, char)),
 		CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	uintptr_t mem = (uintptr_t)calloc(1, _sz);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);

--- a/src/configuration_space_deserialize.h
+++ b/src/configuration_space_deserialize.h
@@ -54,11 +54,15 @@ _ccs_deserialize_bin_ccs_configuration_space_data(
 	{
 		size_t _sz;
 		CCS_REFUTE(
-			_ccs_size_sum3(
-				data->num_parameters, sizeof(ccs_parameter_t),
-				data->num_parameters, sizeof(ccs_expression_t),
-				data->num_forbidden_clauses,
-				sizeof(ccs_expression_t), &_sz),
+			CCS_ALLOC_SIZE(
+				&_sz,
+				CCS_ALLOC_SIZE_ARRAY(
+					data->num_parameters, ccs_parameter_t),
+				CCS_ALLOC_SIZE_ARRAY(
+					data->num_parameters, ccs_expression_t),
+				CCS_ALLOC_SIZE_ARRAY(
+					data->num_forbidden_clauses,
+					ccs_expression_t)),
 			CCS_RESULT_ERROR_OUT_OF_MEMORY);
 		mem = (uintptr_t)calloc(1, _sz);
 		CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);

--- a/src/distribution_mixture.c
+++ b/src/distribution_mixture.c
@@ -220,22 +220,18 @@ ccs_create_mixture_distribution(
 	{
 		size_t _sz;
 		CCS_REFUTE(
-			_ccs_size_sum2(
-				num_distributions,
-				sizeof(ccs_distribution_t) +
-					sizeof(ccs_float_t),
-				dimension,
-				sizeof(ccs_interval_t) +
-					sizeof(ccs_numeric_type_t),
-				&_sz),
-			CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		CCS_REFUTE(
-			_ccs_size_add(
-				_sz,
-				sizeof(struct _ccs_distribution_s) +
-					sizeof(_ccs_distribution_mixture_data_t) +
-					sizeof(ccs_float_t),
-				&_sz),
+			CCS_ALLOC_SIZE(
+				&_sz,
+				CCS_ALLOC_SIZE_TYPE(struct _ccs_distribution_s),
+				CCS_ALLOC_SIZE_TYPE(
+					_ccs_distribution_mixture_data_t),
+				CCS_ALLOC_SIZE_ARRAY(
+					num_distributions, ccs_distribution_t),
+				CCS_ALLOC_SIZE_ARRAY(dimension, ccs_interval_t),
+				CCS_ALLOC_SIZE_ARRAY(
+					num_distributions + 1, ccs_float_t),
+				CCS_ALLOC_SIZE_ARRAY(
+					dimension, ccs_numeric_type_t)),
 			CCS_RESULT_ERROR_OUT_OF_MEMORY);
 		mem_orig = (uintptr_t)calloc(1, _sz);
 		CCS_REFUTE(!mem_orig, CCS_RESULT_ERROR_OUT_OF_MEMORY);
@@ -246,9 +242,12 @@ ccs_create_mixture_distribution(
 		size_t _sz;
 		CCS_REFUTE_ERR_GOTO(
 			err,
-			_ccs_size_sum2(
-				num_distributions, sizeof(ccs_interval_t),
-				dimension, sizeof(ccs_numeric_type_t), &_sz),
+			CCS_ALLOC_SIZE(
+				&_sz,
+				CCS_ALLOC_SIZE_ARRAY(
+					num_distributions, ccs_interval_t),
+				CCS_ALLOC_SIZE_ARRAY(
+					dimension, ccs_numeric_type_t)),
 			CCS_RESULT_ERROR_OUT_OF_MEMORY, memory);
 		tmp_mem = (uintptr_t)calloc(1, _sz);
 		CCS_REFUTE_ERR_GOTO(

--- a/src/distribution_space_deserialize.h
+++ b/src/distribution_space_deserialize.h
@@ -37,10 +37,15 @@ _ccs_deserialize_bin_ccs_distribution_space_data(
 	{
 		size_t _sz;
 		CCS_REFUTE(
-			_ccs_size_sum2(
-				data->num_distributions,
-				sizeof(ccs_distribution_t) + sizeof(size_t),
-				data->num_parameters, sizeof(size_t), &_sz),
+			CCS_ALLOC_SIZE(
+				&_sz,
+				CCS_ALLOC_SIZE_ARRAY(
+					data->num_distributions,
+					ccs_distribution_t),
+				CCS_ALLOC_SIZE_ARRAY(
+					data->num_distributions, size_t),
+				CCS_ALLOC_SIZE_ARRAY(
+					data->num_parameters, size_t)),
 			CCS_RESULT_ERROR_OUT_OF_MEMORY);
 		mem = (uintptr_t)calloc(1, _sz);
 		CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);

--- a/src/expression.c
+++ b/src/expression.c
@@ -1672,14 +1672,10 @@ ccs_create_expression(
 	ccs_result_t err;
 	size_t       _sz;
 	CCS_REFUTE(
-		_ccs_size_mul(num_nodes, sizeof(ccs_expression_t), &_sz),
-		CCS_RESULT_ERROR_OUT_OF_MEMORY);
-	CCS_REFUTE(
-		_ccs_size_add(
-			_sz,
-			sizeof(struct _ccs_expression_s) +
-				sizeof(struct _ccs_expression_data_s),
-			&_sz),
+		CCS_ALLOC_SIZE(
+			&_sz, CCS_ALLOC_SIZE_TYPE(struct _ccs_expression_s),
+			CCS_ALLOC_SIZE_TYPE(struct _ccs_expression_data_s),
+			CCS_ALLOC_SIZE_ARRAY(num_nodes, ccs_expression_t)),
 		CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	uintptr_t mem = (uintptr_t)calloc(1, _sz);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
@@ -1756,15 +1752,12 @@ ccs_create_user_defined_expression(
 	size_t       _sz;
 	size_t       name_len = strlen(name) + 1;
 	CCS_REFUTE(
-		_ccs_size_mul(num_nodes, sizeof(ccs_expression_t), &_sz),
-		CCS_RESULT_ERROR_OUT_OF_MEMORY);
-	CCS_REFUTE(
-		_ccs_size_add(
-			_sz,
-			sizeof(struct _ccs_expression_s) +
-				sizeof(struct _ccs_expression_user_defined_data_s) +
-				name_len,
-			&_sz),
+		CCS_ALLOC_SIZE(
+			&_sz, CCS_ALLOC_SIZE_TYPE(struct _ccs_expression_s),
+			CCS_ALLOC_SIZE_TYPE(
+				struct _ccs_expression_user_defined_data_s),
+			CCS_ALLOC_SIZE_ARRAY(num_nodes, ccs_expression_t),
+			CCS_ALLOC_SIZE_ARRAY(name_len, char)),
 		CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	uintptr_t mem = (uintptr_t)calloc(1, _sz);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);

--- a/src/objective_space.c
+++ b/src/objective_space.c
@@ -247,19 +247,15 @@ ccs_create_objective_space(
 	size_t _sz;
 	size_t name_len = strlen(name) + 1;
 	CCS_REFUTE(
-		_ccs_size_sum2(
-			num_parameters,
-			sizeof(ccs_parameter_t) +
-				sizeof(_ccs_parameter_index_hash_t),
-			num_objectives, sizeof(_ccs_objective_t), &_sz),
-		CCS_RESULT_ERROR_OUT_OF_MEMORY);
-	CCS_REFUTE(
-		_ccs_size_add(
-			_sz,
-			sizeof(struct _ccs_objective_space_s) +
-				sizeof(struct _ccs_objective_space_data_s) +
-				name_len,
-			&_sz),
+		CCS_ALLOC_SIZE(
+			&_sz,
+			CCS_ALLOC_SIZE_TYPE(struct _ccs_objective_space_s),
+			CCS_ALLOC_SIZE_TYPE(struct _ccs_objective_space_data_s),
+			CCS_ALLOC_SIZE_ARRAY(num_parameters, ccs_parameter_t),
+			CCS_ALLOC_SIZE_ARRAY(
+				num_parameters, _ccs_parameter_index_hash_t),
+			CCS_ALLOC_SIZE_ARRAY(num_objectives, _ccs_objective_t),
+			CCS_ALLOC_SIZE_ARRAY(name_len, char)),
 		CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	uintptr_t mem = (uintptr_t)calloc(1, _sz);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);

--- a/src/objective_space_deserialize.h
+++ b/src/objective_space_deserialize.h
@@ -46,12 +46,15 @@ _ccs_deserialize_bin_ccs_objective_space_data(
 	{
 		size_t _sz;
 		CCS_REFUTE(
-			_ccs_size_sum2(
-				data->num_parameters, sizeof(ccs_parameter_t),
-				data->num_objectives,
-				sizeof(ccs_expression_t) +
-					sizeof(ccs_objective_type_t),
-				&_sz),
+			CCS_ALLOC_SIZE(
+				&_sz,
+				CCS_ALLOC_SIZE_ARRAY(
+					data->num_parameters, ccs_parameter_t),
+				CCS_ALLOC_SIZE_ARRAY(
+					data->num_objectives, ccs_expression_t),
+				CCS_ALLOC_SIZE_ARRAY(
+					data->num_objectives,
+					ccs_objective_type_t)),
 			CCS_RESULT_ERROR_OUT_OF_MEMORY);
 		mem = (uintptr_t)calloc(1, _sz);
 		CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);

--- a/src/parameter_categorical.c
+++ b/src/parameter_categorical.c
@@ -324,16 +324,13 @@ _ccs_create_categorical_parameter(
 	ccs_result_t err = CCS_RESULT_SUCCESS;
 	size_t       _sz;
 	CCS_REFUTE(
-		_ccs_size_mul(
-			num_possible_values, sizeof(_ccs_hash_datum_t), &_sz),
-		CCS_RESULT_ERROR_OUT_OF_MEMORY);
-	CCS_REFUTE(
-		_ccs_size_add(
-			_sz,
-			sizeof(struct _ccs_parameter_s) +
-				sizeof(_ccs_parameter_categorical_data_t) +
-				name_len + size_strs,
-			&_sz),
+		CCS_ALLOC_SIZE(
+			&_sz, CCS_ALLOC_SIZE_TYPE(struct _ccs_parameter_s),
+			CCS_ALLOC_SIZE_TYPE(_ccs_parameter_categorical_data_t),
+			CCS_ALLOC_SIZE_ARRAY(
+				num_possible_values, _ccs_hash_datum_t),
+			CCS_ALLOC_SIZE_ARRAY(name_len, char),
+			CCS_ALLOC_SIZE_ARRAY(size_strs, char)),
 		CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	ccs_interval_t                     interval;
 	uintptr_t                          mem_orig;

--- a/src/tree_configuration.c
+++ b/src/tree_configuration.c
@@ -162,14 +162,12 @@ ccs_create_tree_configuration(
 	ccs_bool_t   is_valid;
 	size_t       _sz;
 	CCS_REFUTE(
-		_ccs_size_mul(position_size, sizeof(size_t), &_sz),
-		CCS_RESULT_ERROR_OUT_OF_MEMORY);
-	CCS_REFUTE(
-		_ccs_size_add(
-			_sz,
-			sizeof(struct _ccs_tree_configuration_s) +
-				sizeof(struct _ccs_tree_configuration_data_s),
-			&_sz),
+		CCS_ALLOC_SIZE(
+			&_sz,
+			CCS_ALLOC_SIZE_TYPE(struct _ccs_tree_configuration_s),
+			CCS_ALLOC_SIZE_TYPE(
+				struct _ccs_tree_configuration_data_s),
+			CCS_ALLOC_SIZE_ARRAY(position_size, size_t)),
 		CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	uintptr_t mem = (uintptr_t)calloc(1, _sz);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);


### PR DESCRIPTION
## Summary

Introduce \`CCS_ALLOC_SIZE\`, \`CCS_ALLOC_SIZE_TYPE\`, and \`CCS_ALLOC_SIZE_ARRAY\` macros that mirror the \`CCS_ALLOC_CARVE\` family — each SIZE entry maps 1:1 to a CARVE entry:

\`\`\`c
CCS_REFUTE(
    CCS_ALLOC_SIZE(&_sz,
        CCS_ALLOC_SIZE_TYPE(struct _ccs_objective_space_s),
        CCS_ALLOC_SIZE_TYPE(struct _ccs_objective_space_data_s),
        CCS_ALLOC_SIZE_ARRAY(num_params, ccs_parameter_t),
        CCS_ALLOC_SIZE_ARRAY(num_objectives, _ccs_objective_t),
        CCS_ALLOC_SIZE_ARRAY(name_len, char)),
    CCS_RESULT_ERROR_OUT_OF_MEMORY);
// ... calloc ...
obj_space       = CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_objective_space_s);
obj_space->data = CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_objective_space_data_s);
...->parameters = CCS_ALLOC_CARVE_ARRAY(mem, num_params, ccs_parameter_t);
...->objectives = CCS_ALLOC_CARVE_ARRAY(mem, num_objectives, _ccs_objective_t);
...->name       = CCS_ALLOC_CARVE_ARRAY(mem, name_len, char);
\`\`\`

- Uses a compound literal with sentinel-terminated entry list and overflow-checked accumulation
- Removes \`_ccs_size_sum2\` and \`_ccs_size_sum3\` which are no longer needed
- Converts all 10 multi-entry allocation sites across the codebase

## Test plan

- [x] All 30 C tests pass (gcc, g++)
- [x] Ruby and Python binding tests pass
- [x] clang-format-17 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)