### PR TITLE
Convert all remaining sites to CCS_ALLOC_SIZE/CARVE macros

### DIFF
--- a/src/configuration.c
+++ b/src/configuration.c
@@ -167,10 +167,14 @@ _ccs_create_configuration(
 {
 	ccs_result_t err;
 	size_t       num_parameters = configuration_space->data->num_parameters;
-	uintptr_t    mem            = (uintptr_t)calloc(
-                1, sizeof(struct _ccs_configuration_s) +
-                           sizeof(struct _ccs_configuration_data_s) +
-                           num_parameters * sizeof(ccs_datum_t));
+	size_t       _sz;
+	CCS_REFUTE(
+		CCS_ALLOC_SIZE(
+			&_sz, CCS_ALLOC_SIZE_TYPE(struct _ccs_configuration_s),
+			CCS_ALLOC_SIZE_TYPE(struct _ccs_configuration_data_s),
+			CCS_ALLOC_SIZE_ARRAY(num_parameters, ccs_datum_t)),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	uintptr_t mem = (uintptr_t)calloc(1, _sz);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	uintptr_t           mem_orig = mem;
 	ccs_configuration_t config;

--- a/src/configuration_space.c
+++ b/src/configuration_space.c
@@ -747,10 +747,13 @@ _sample(ccs_configuration_space_t configuration_space,
 	size_t       num_parameters = configuration_space->data->num_parameters;
 	ccs_datum_t *p_values;
 	ccs_parameter_t *hps;
-	uintptr_t        mem;
-	mem = (uintptr_t)malloc(
-		num_parameters *
-		(sizeof(ccs_datum_t) + sizeof(ccs_parameter_t)));
+	size_t           _sz;
+	CCS_REFUTE(
+		CCS_ALLOC_SIZE(
+			&_sz, CCS_ALLOC_SIZE_ARRAY(num_parameters, ccs_datum_t),
+			CCS_ALLOC_SIZE_ARRAY(num_parameters, ccs_parameter_t)),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	uintptr_t mem = (uintptr_t)malloc(_sz);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	uintptr_t mem_orig = mem;
 

--- a/src/distribution_deserialize.h
+++ b/src/distribution_deserialize.h
@@ -134,8 +134,9 @@ _ccs_deserialize_bin_ccs_distribution_roulette_data(
 	{
 		size_t _sz;
 		CCS_REFUTE(
-			_ccs_size_mul(
-				data->num_areas, sizeof(ccs_float_t), &_sz),
+			CCS_ALLOC_SIZE(
+				&_sz, CCS_ALLOC_SIZE_ARRAY(
+					      data->num_areas, ccs_float_t)),
 			CCS_RESULT_ERROR_OUT_OF_MEMORY);
 		data->areas = (ccs_float_t *)calloc(1, _sz);
 		CCS_REFUTE(!data->areas, CCS_RESULT_ERROR_OUT_OF_MEMORY);
@@ -202,9 +203,10 @@ _ccs_deserialize_bin_ccs_distribution_mixture_data(
 	{
 		size_t _sz;
 		CCS_REFUTE(
-			_ccs_size_mul(
-				data->num_distributions, sizeof(ccs_float_t),
-				&_sz),
+			CCS_ALLOC_SIZE(
+				&_sz,
+				CCS_ALLOC_SIZE_ARRAY(
+					data->num_distributions, ccs_float_t)),
 			CCS_RESULT_ERROR_OUT_OF_MEMORY);
 		data->weights = (ccs_float_t *)calloc(1, _sz);
 		CCS_REFUTE(!data->weights, CCS_RESULT_ERROR_OUT_OF_MEMORY);

--- a/src/distribution_mixture.c
+++ b/src/distribution_mixture.c
@@ -213,6 +213,7 @@ ccs_create_mixture_distribution(
 	uintptr_t                         mem_orig;
 	uintptr_t                         mem;
 	uintptr_t                         tmp_mem;
+	uintptr_t                         tmp_mem_orig;
 	ccs_interval_t                   *bounds_tmp;
 	ccs_numeric_type_t               *data_types_tmp;
 	ccs_distribution_t                distrib;
@@ -253,10 +254,11 @@ ccs_create_mixture_distribution(
 		CCS_REFUTE_ERR_GOTO(
 			err, !tmp_mem, CCS_RESULT_ERROR_OUT_OF_MEMORY, memory);
 	}
-	bounds_tmp = (ccs_interval_t *)tmp_mem;
+	tmp_mem_orig = tmp_mem;
+	bounds_tmp   = CCS_ALLOC_CARVE_ARRAY(
+                tmp_mem, num_distributions, ccs_interval_t);
 	data_types_tmp =
-		(ccs_numeric_type_t *)(tmp_mem + sizeof(ccs_interval_t) *
-							 num_distributions);
+		CCS_ALLOC_CARVE_ARRAY(tmp_mem, dimension, ccs_numeric_type_t);
 
 	distrib = CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_distribution_s);
 	_ccs_object_init(
@@ -333,7 +335,7 @@ ccs_create_mixture_distribution(
 	}
 	distrib->data     = (_ccs_distribution_data_t *)distrib_data;
 	*distribution_ret = distrib;
-	free((void *)tmp_mem);
+	free((void *)tmp_mem_orig);
 	return CCS_RESULT_SUCCESS;
 distrib:
 	for (i = 0; i < num_distributions; i++) {
@@ -342,7 +344,7 @@ distrib:
 	}
 tmpmemory:
 	_ccs_object_deinit(&(distrib->obj));
-	free((void *)tmp_mem);
+	free((void *)tmp_mem_orig);
 memory:
 	free((void *)mem_orig);
 	return err;

--- a/src/distribution_multivariate.c
+++ b/src/distribution_multivariate.c
@@ -181,6 +181,9 @@ ccs_create_multivariate_distribution(
 	ccs_result_t                           err;
 	size_t                                 i         = 0;
 	size_t                                 dimension = 0;
+	size_t                                 _sz;
+	uintptr_t                              mem_orig;
+	uintptr_t                              mem;
 	ccs_distribution_t                     distrib;
 	_ccs_distribution_multivariate_data_t *distrib_data;
 
@@ -191,15 +194,18 @@ ccs_create_multivariate_distribution(
 		dimension += dim;
 	}
 
-	uintptr_t mem_orig, mem;
-	mem_orig = (uintptr_t)calloc(
-		1, sizeof(struct _ccs_distribution_s) +
-			   sizeof(_ccs_distribution_multivariate_data_t) +
-			   sizeof(ccs_distribution_t) * num_distributions +
-			   sizeof(size_t) * num_distributions +
-			   sizeof(ccs_interval_t) * dimension +
-			   sizeof(ccs_numeric_type_t) * dimension);
-
+	CCS_REFUTE(
+		CCS_ALLOC_SIZE(
+			&_sz, CCS_ALLOC_SIZE_TYPE(struct _ccs_distribution_s),
+			CCS_ALLOC_SIZE_TYPE(
+				_ccs_distribution_multivariate_data_t),
+			CCS_ALLOC_SIZE_ARRAY(
+				num_distributions, ccs_distribution_t),
+			CCS_ALLOC_SIZE_ARRAY(num_distributions, size_t),
+			CCS_ALLOC_SIZE_ARRAY(dimension, ccs_interval_t),
+			CCS_ALLOC_SIZE_ARRAY(dimension, ccs_numeric_type_t)),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	mem_orig = (uintptr_t)calloc(1, _sz);
 	CCS_REFUTE(!mem_orig, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	mem     = mem_orig;
 

--- a/src/distribution_roulette.c
+++ b/src/distribution_roulette.c
@@ -238,11 +238,15 @@ ccs_create_roulette_distribution(
 	CCS_VALIDATE(_ccs_distribution_roulette_validate_areas(
 		num_areas, areas, &sum_areas_inverse));
 
-	uintptr_t mem = (uintptr_t)calloc(
-		1, sizeof(struct _ccs_distribution_s) +
-			   sizeof(_ccs_distribution_roulette_data_t) +
-			   sizeof(ccs_float_t) * (num_areas + 1) +
-			   sizeof(ccs_numeric_type_t));
+	size_t _sz;
+	CCS_REFUTE(
+		CCS_ALLOC_SIZE(
+			&_sz, CCS_ALLOC_SIZE_TYPE(struct _ccs_distribution_s),
+			CCS_ALLOC_SIZE_TYPE(_ccs_distribution_roulette_data_t),
+			CCS_ALLOC_SIZE_ARRAY(num_areas + 1, ccs_float_t),
+			CCS_ALLOC_SIZE_ARRAY(1, ccs_numeric_type_t)),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	uintptr_t mem = (uintptr_t)calloc(1, _sz);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 
 	ccs_distribution_t distrib =

--- a/src/distribution_space.c
+++ b/src/distribution_space.c
@@ -217,11 +217,10 @@ _ccs_distribution_space_create_user_wrapper(
 	CCS_REFUTE(!dmem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 
 	_ccs_distribution_wrapper_t *dwrapper =
-		(_ccs_distribution_wrapper_t *)dmem;
-	dwrapper->distribution = distribution;
-	dwrapper->dimension    = dim;
-	dwrapper->parameter_indexes =
-		(size_t *)(dmem + sizeof(_ccs_distribution_wrapper_t));
+		CCS_ALLOC_CARVE_TYPE(dmem, _ccs_distribution_wrapper_t);
+	dwrapper->distribution      = distribution;
+	dwrapper->dimension         = dim;
+	dwrapper->parameter_indexes = CCS_ALLOC_CARVE_ARRAY(dmem, dim, size_t);
 	/* Record each parameter index and remove it from the
 	 * "without distribution" list. */
 	for (size_t i = 0; i < dim; i++) {
@@ -257,19 +256,19 @@ _ccs_distribution_space_create_default_wrappers(
 	_ccs_distribution_wrapper_t **p_dwrappers,
 	size_t                       *count_ret)
 {
-	size_t       count = 0;
-	uintptr_t    dmem  = 0;
-	ccs_result_t err   = CCS_RESULT_SUCCESS;
+	size_t                       count    = 0;
+	_ccs_distribution_wrapper_t *dwrapper = NULL;
+	ccs_result_t                 err      = CCS_RESULT_SUCCESS;
 	for (size_t i = 0; i < without_distrib_count; i++) {
-		dmem = (uintptr_t)malloc(
+		uintptr_t dmem = (uintptr_t)malloc(
 			sizeof(_ccs_distribution_wrapper_t) + sizeof(size_t));
 		CCS_REFUTE_ERR_GOTO(
 			err, !dmem, CCS_RESULT_ERROR_OUT_OF_MEMORY,
 			err_wrappers);
-		_ccs_distribution_wrapper_t *dwrapper =
-			(_ccs_distribution_wrapper_t *)dmem;
+		dwrapper =
+			CCS_ALLOC_CARVE_TYPE(dmem, _ccs_distribution_wrapper_t);
 		dwrapper->parameter_indexes =
-			(size_t *)(dmem + sizeof(_ccs_distribution_wrapper_t));
+			CCS_ALLOC_CARVE_ARRAY(dmem, 1, size_t);
 		dwrapper->dimension            = 1;
 		dwrapper->parameter_indexes[0] = parameters_without_distrib[i];
 
@@ -280,16 +279,16 @@ _ccs_distribution_space_create_default_wrappers(
 				&(dwrapper->distribution)),
 			err_dmem);
 		p_dwrappers[count++] = dwrapper;
-		/* Clear dmem so err_dmem won't double-free on a later
+		/* Clear dwrapper so err_dmem won't double-free on a later
 		 * iteration's failure. */
-		dmem                 = 0;
+		dwrapper             = NULL;
 	}
 	*count_ret = count;
 	return CCS_RESULT_SUCCESS;
 err_dmem:
 	/* Free the current (unfinished) wrapper whose distribution was
 	 * not yet retained. */
-	free((void *)dmem);
+	free(dwrapper);
 err_wrappers:
 	/* Release and free all previously completed wrappers. */
 	for (size_t i = 0; i < count; i++) {
@@ -345,9 +344,15 @@ ccs_distribution_space_set_distribution(
 	{
 		size_t _sz;
 		CCS_REFUTE(
-			_ccs_size_mul(
-				num_parameters,
-				sizeof(void *) * 2 + sizeof(size_t), &_sz),
+			CCS_ALLOC_SIZE(
+				&_sz,
+				CCS_ALLOC_SIZE_ARRAY(
+					num_parameters,
+					_ccs_distribution_wrapper_t *),
+				CCS_ALLOC_SIZE_ARRAY(
+					num_parameters,
+					_ccs_distribution_wrapper_t *),
+				CCS_ALLOC_SIZE_ARRAY(num_parameters, size_t)),
 			CCS_RESULT_ERROR_OUT_OF_MEMORY);
 		mem = (uintptr_t)malloc(_sz);
 		CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);

--- a/src/distribution_space.c
+++ b/src/distribution_space.c
@@ -266,7 +266,8 @@ _ccs_distribution_space_create_default_wrappers(
 	_ccs_distribution_wrapper_t *dwrapper = NULL;
 	ccs_result_t                 err      = CCS_RESULT_SUCCESS;
 	for (size_t i = 0; i < without_distrib_count; i++) {
-		size_t _sz;
+		size_t    _sz;
+		uintptr_t dmem;
 		CCS_REFUTE_ERR_GOTO(
 			err,
 			CCS_ALLOC_SIZE(
@@ -274,7 +275,7 @@ _ccs_distribution_space_create_default_wrappers(
 				CCS_ALLOC_SIZE_TYPE(_ccs_distribution_wrapper_t),
 				CCS_ALLOC_SIZE_ARRAY(1, size_t)),
 			CCS_RESULT_ERROR_OUT_OF_MEMORY, err_wrappers);
-		uintptr_t dmem = (uintptr_t)malloc(_sz);
+		dmem = (uintptr_t)malloc(_sz);
 		CCS_REFUTE_ERR_GOTO(
 			err, !dmem, CCS_RESULT_ERROR_OUT_OF_MEMORY,
 			err_wrappers);

--- a/src/distribution_space.c
+++ b/src/distribution_space.c
@@ -212,8 +212,13 @@ _ccs_distribution_space_create_user_wrapper(
 	size_t                       *without_distrib_count,
 	_ccs_distribution_wrapper_t **wrapper_ret)
 {
-	uintptr_t dmem = (uintptr_t)malloc(
-		sizeof(_ccs_distribution_wrapper_t) + sizeof(size_t) * dim);
+	size_t _sz;
+	CCS_REFUTE(
+		CCS_ALLOC_SIZE(
+			&_sz, CCS_ALLOC_SIZE_TYPE(_ccs_distribution_wrapper_t),
+			CCS_ALLOC_SIZE_ARRAY(dim, size_t)),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	uintptr_t dmem = (uintptr_t)malloc(_sz);
 	CCS_REFUTE(!dmem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 
 	_ccs_distribution_wrapper_t *dwrapper =
@@ -235,10 +240,11 @@ _ccs_distribution_space_create_user_wrapper(
 		(*without_distrib_count)--;
 	}
 	ccs_result_t err = CCS_RESULT_SUCCESS;
-	CCS_VALIDATE_ERR_GOTO(err, ccs_retain_object(distribution), err_dmem);
+	CCS_VALIDATE_ERR_GOTO(
+		err, ccs_retain_object(distribution), err_wrapper);
 	*wrapper_ret = dwrapper;
 	return CCS_RESULT_SUCCESS;
-err_dmem:
+err_wrapper:
 	free(dwrapper);
 	return err;
 }
@@ -260,8 +266,15 @@ _ccs_distribution_space_create_default_wrappers(
 	_ccs_distribution_wrapper_t *dwrapper = NULL;
 	ccs_result_t                 err      = CCS_RESULT_SUCCESS;
 	for (size_t i = 0; i < without_distrib_count; i++) {
-		uintptr_t dmem = (uintptr_t)malloc(
-			sizeof(_ccs_distribution_wrapper_t) + sizeof(size_t));
+		size_t _sz;
+		CCS_REFUTE_ERR_GOTO(
+			err,
+			CCS_ALLOC_SIZE(
+				&_sz,
+				CCS_ALLOC_SIZE_TYPE(_ccs_distribution_wrapper_t),
+				CCS_ALLOC_SIZE_ARRAY(1, size_t)),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY, err_wrappers);
+		uintptr_t dmem = (uintptr_t)malloc(_sz);
 		CCS_REFUTE_ERR_GOTO(
 			err, !dmem, CCS_RESULT_ERROR_OUT_OF_MEMORY,
 			err_wrappers);
@@ -277,15 +290,15 @@ _ccs_distribution_space_create_default_wrappers(
 			ccs_parameter_get_default_distribution(
 				parameters[parameters_without_distrib[i]],
 				&(dwrapper->distribution)),
-			err_dmem);
+			err_wrapper);
 		p_dwrappers[count++] = dwrapper;
-		/* Clear dwrapper so err_dmem won't double-free on a later
+		/* Clear dwrapper so err_wrapper won't double-free on a later
 		 * iteration's failure. */
 		dwrapper             = NULL;
 	}
 	*count_ret = count;
 	return CCS_RESULT_SUCCESS;
-err_dmem:
+err_wrapper:
 	/* Free the current (unfinished) wrapper whose distribution was
 	 * not yet retained. */
 	free(dwrapper);

--- a/src/distribution_space_internal.h
+++ b/src/distribution_space_internal.h
@@ -66,9 +66,14 @@ _ccs_get_distribution_wrapper(
 	CCS_VALIDATE(ccs_parameter_get_default_distribution(
 		parameter, &distribution));
 
-	uintptr_t dmem = (uintptr_t)malloc(
-		sizeof(_ccs_distribution_wrapper_t) + sizeof(size_t));
-
+	size_t _sz;
+	CCS_REFUTE_ERR_GOTO(
+		err,
+		CCS_ALLOC_SIZE(
+			&_sz, CCS_ALLOC_SIZE_TYPE(_ccs_distribution_wrapper_t),
+			CCS_ALLOC_SIZE_ARRAY(1, size_t)),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY, err_distrib);
+	uintptr_t dmem = (uintptr_t)malloc(_sz);
 	CCS_REFUTE_ERR_GOTO(
 		err, !dmem, CCS_RESULT_ERROR_OUT_OF_MEMORY, err_distrib);
 	distrib_wrapper =

--- a/src/distribution_space_internal.h
+++ b/src/distribution_space_internal.h
@@ -66,14 +66,15 @@ _ccs_get_distribution_wrapper(
 	CCS_VALIDATE(ccs_parameter_get_default_distribution(
 		parameter, &distribution));
 
-	size_t _sz;
+	size_t    _sz;
+	uintptr_t dmem;
 	CCS_REFUTE_ERR_GOTO(
 		err,
 		CCS_ALLOC_SIZE(
 			&_sz, CCS_ALLOC_SIZE_TYPE(_ccs_distribution_wrapper_t),
 			CCS_ALLOC_SIZE_ARRAY(1, size_t)),
 		CCS_RESULT_ERROR_OUT_OF_MEMORY, err_distrib);
-	uintptr_t dmem = (uintptr_t)malloc(_sz);
+	dmem = (uintptr_t)malloc(_sz);
 	CCS_REFUTE_ERR_GOTO(
 		err, !dmem, CCS_RESULT_ERROR_OUT_OF_MEMORY, err_distrib);
 	distrib_wrapper =

--- a/src/distribution_space_internal.h
+++ b/src/distribution_space_internal.h
@@ -71,11 +71,12 @@ _ccs_get_distribution_wrapper(
 
 	CCS_REFUTE_ERR_GOTO(
 		err, !dmem, CCS_RESULT_ERROR_OUT_OF_MEMORY, err_distrib);
-	distrib_wrapper               = (_ccs_distribution_wrapper_t *)dmem;
+	distrib_wrapper =
+		CCS_ALLOC_CARVE_TYPE(dmem, _ccs_distribution_wrapper_t);
 	distrib_wrapper->distribution = distribution;
 	distrib_wrapper->dimension    = 1;
 	distrib_wrapper->parameter_indexes =
-		(size_t *)(dmem + sizeof(_ccs_distribution_wrapper_t));
+		CCS_ALLOC_CARVE_ARRAY(dmem, 1, size_t);
 	distrib_wrapper->parameter_indexes[0] = index;
 	*distrib_wrapper_ret                  = distrib_wrapper;
 	return CCS_RESULT_SUCCESS;
@@ -91,6 +92,7 @@ _ccs_create_distribution_space_no_retain(
 	ccs_distribution_space_t      *distribution_space_ret)
 {
 	size_t                       num_parameters;
+	size_t                       _sz;
 	_ccs_distribution_wrapper_t *dw, *tmp;
 	ccs_distribution_space_t     distrib_space;
 	uintptr_t                    mem_orig;
@@ -98,11 +100,17 @@ _ccs_create_distribution_space_no_retain(
 	ccs_result_t                 err = CCS_RESULT_SUCCESS;
 	CCS_VALIDATE(_ccs_context_get_num_parameters(
 		(ccs_context_t)configuration_space, &num_parameters));
-	mem = (uintptr_t)calloc(
-		1, sizeof(struct _ccs_distribution_space_s) +
-			   sizeof(struct _ccs_distribution_space_data_s) +
-			   sizeof(struct _ccs_parameter_distribution_s) *
-				   num_parameters);
+	CCS_REFUTE(
+		CCS_ALLOC_SIZE(
+			&_sz,
+			CCS_ALLOC_SIZE_TYPE(struct _ccs_distribution_space_s),
+			CCS_ALLOC_SIZE_TYPE(
+				struct _ccs_distribution_space_data_s),
+			CCS_ALLOC_SIZE_ARRAY(
+				num_parameters,
+				struct _ccs_parameter_distribution_s)),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	mem = (uintptr_t)calloc(1, _sz);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 
 	mem_orig = mem;

--- a/src/expression.c
+++ b/src/expression.c
@@ -1540,10 +1540,15 @@ ccs_create_literal(ccs_datum_t value, ccs_expression_t *expression_ret)
 	if (value.type == CCS_DATA_TYPE_STRING && value.value.s) {
 		size_str = strlen(value.value.s) + 1;
 	}
-	uintptr_t mem = (uintptr_t)calloc(
-		1, sizeof(struct _ccs_expression_s) +
-			   sizeof(struct _ccs_expression_literal_data_s) +
-			   size_str);
+	size_t _sz;
+	CCS_REFUTE(
+		CCS_ALLOC_SIZE(
+			&_sz, CCS_ALLOC_SIZE_TYPE(struct _ccs_expression_s),
+			CCS_ALLOC_SIZE_TYPE(
+				struct _ccs_expression_literal_data_s),
+			CCS_ALLOC_SIZE_ARRAY(size_str, char)),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	uintptr_t mem = (uintptr_t)calloc(1, _sz);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	ccs_expression_t expression =
 		CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_expression_s);

--- a/src/feature_space.c
+++ b/src/feature_space.c
@@ -93,14 +93,18 @@ ccs_create_feature_space(
 	for (size_t i = 0; i < num_parameters; i++)
 		CCS_CHECK_OBJ(parameters[i], CCS_OBJECT_TYPE_PARAMETER);
 
-	size_t    name_len = strlen(name) + 1;
-	uintptr_t mem      = (uintptr_t)calloc(
-                1,
-                sizeof(struct _ccs_feature_space_s) +
-                        sizeof(struct _ccs_feature_space_data_s) +
-                        sizeof(ccs_parameter_t) * num_parameters +
-                        sizeof(_ccs_parameter_index_hash_t) * num_parameters +
-                        name_len);
+	size_t name_len = strlen(name) + 1;
+	size_t _sz;
+	CCS_REFUTE(
+		CCS_ALLOC_SIZE(
+			&_sz, CCS_ALLOC_SIZE_TYPE(struct _ccs_feature_space_s),
+			CCS_ALLOC_SIZE_TYPE(struct _ccs_feature_space_data_s),
+			CCS_ALLOC_SIZE_ARRAY(num_parameters, ccs_parameter_t),
+			CCS_ALLOC_SIZE_ARRAY(
+				num_parameters, _ccs_parameter_index_hash_t),
+			CCS_ALLOC_SIZE_ARRAY(name_len, char)),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	uintptr_t mem = (uintptr_t)calloc(1, _sz);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	uintptr_t           mem_orig = mem;
 

--- a/src/features.c
+++ b/src/features.c
@@ -86,10 +86,14 @@ _ccs_create_features(
 {
 	size_t       num_parameters = feature_space->data->num_parameters;
 	ccs_result_t err            = CCS_RESULT_SUCCESS;
-	uintptr_t    mem            = (uintptr_t)calloc(
-                1, sizeof(struct _ccs_features_s) +
-                           sizeof(struct _ccs_features_data_s) +
-                           num_parameters * sizeof(ccs_datum_t));
+	size_t       _sz;
+	CCS_REFUTE(
+		CCS_ALLOC_SIZE(
+			&_sz, CCS_ALLOC_SIZE_TYPE(struct _ccs_features_s),
+			CCS_ALLOC_SIZE_TYPE(struct _ccs_features_data_s),
+			CCS_ALLOC_SIZE_ARRAY(num_parameters, ccs_datum_t)),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	uintptr_t mem = (uintptr_t)calloc(1, _sz);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	uintptr_t      mem_orig = mem;
 	ccs_features_t feat;

--- a/src/map.c
+++ b/src/map.c
@@ -224,8 +224,7 @@ ccs_map_set(ccs_map_t map, ccs_datum_t key, ccs_datum_t value)
 
 	mem = (uintptr_t)calloc(1, sz);
 	CCS_REFUTE_ERR_GOTO(res, !mem, CCS_RESULT_ERROR_OUT_OF_MEMORY, err_o2);
-	entry = (_ccs_map_datum_t *)mem;
-	mem += sizeof(_ccs_map_datum_t);
+	entry        = CCS_ALLOC_CARVE_TYPE(mem, _ccs_map_datum_t);
 	entry->key   = key;
 	entry->value = value;
 	_ccs_map_set_string(&entry->key, sz1, &mem);

--- a/src/map_deserialize.h
+++ b/src/map_deserialize.h
@@ -25,8 +25,10 @@ _ccs_deserialize_bin_ccs_map_data(
 	{
 		size_t _sz;
 		CCS_REFUTE(
-			_ccs_size_mul(
-				data->num_pairs, sizeof(_ccs_map_pair_t), &_sz),
+			CCS_ALLOC_SIZE(
+				&_sz,
+				CCS_ALLOC_SIZE_ARRAY(
+					data->num_pairs, _ccs_map_pair_t)),
 			CCS_RESULT_ERROR_OUT_OF_MEMORY);
 		data->pairs = (_ccs_map_pair_t *)calloc(1, _sz);
 		CCS_REFUTE(!data->pairs, CCS_RESULT_ERROR_OUT_OF_MEMORY);

--- a/src/parameter_deserialize.h
+++ b/src/parameter_deserialize.h
@@ -53,9 +53,10 @@ _ccs_deserialize_bin_ccs_parameter_categorical_data(
 	{
 		size_t _sz;
 		CCS_REFUTE(
-			_ccs_size_mul(
-				data->num_possible_values, sizeof(ccs_datum_t),
-				&_sz),
+			CCS_ALLOC_SIZE(
+				&_sz, CCS_ALLOC_SIZE_ARRAY(
+					      data->num_possible_values,
+					      ccs_datum_t)),
 			CCS_RESULT_ERROR_OUT_OF_MEMORY);
 		data->possible_values = (ccs_datum_t *)calloc(1, _sz);
 		CCS_REFUTE(

--- a/src/parameter_numerical.c
+++ b/src/parameter_numerical.c
@@ -296,10 +296,15 @@ ccs_create_numerical_parameter(
 			 default_value.f < lower.f ||
 			 default_value.f >= upper.f),
 		CCS_RESULT_ERROR_INVALID_VALUE);
-	size_t    name_len = strlen(name) + 1;
-	uintptr_t mem      = (uintptr_t)calloc(
-                1, sizeof(struct _ccs_parameter_s) +
-                           sizeof(_ccs_parameter_numerical_data_t) + name_len);
+	size_t name_len = strlen(name) + 1;
+	size_t _sz;
+	CCS_REFUTE(
+		CCS_ALLOC_SIZE(
+			&_sz, CCS_ALLOC_SIZE_TYPE(struct _ccs_parameter_s),
+			CCS_ALLOC_SIZE_TYPE(_ccs_parameter_numerical_data_t),
+			CCS_ALLOC_SIZE_ARRAY(name_len, char)),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	uintptr_t mem = (uintptr_t)calloc(1, _sz);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 
 	ccs_interval_t interval;

--- a/src/parameter_string.c
+++ b/src/parameter_string.c
@@ -242,10 +242,15 @@ ccs_create_string_parameter(const char *name, ccs_parameter_t *parameter_ret)
 {
 	CCS_CHECK_PTR(name);
 	CCS_CHECK_PTR(parameter_ret);
-	size_t    name_len = strlen(name) + 1;
-	uintptr_t mem      = (uintptr_t)calloc(
-                1, sizeof(struct _ccs_parameter_s) +
-                           sizeof(_ccs_parameter_string_data_t) + name_len);
+	size_t name_len = strlen(name) + 1;
+	size_t _sz;
+	CCS_REFUTE(
+		CCS_ALLOC_SIZE(
+			&_sz, CCS_ALLOC_SIZE_TYPE(struct _ccs_parameter_s),
+			CCS_ALLOC_SIZE_TYPE(_ccs_parameter_string_data_t),
+			CCS_ALLOC_SIZE_ARRAY(name_len, char)),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	uintptr_t mem = (uintptr_t)calloc(1, _sz);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 
 	ccs_parameter_t parameter =

--- a/src/tree.c
+++ b/src/tree.c
@@ -143,11 +143,17 @@ ccs_create_tree(size_t arity, ccs_datum_t value, ccs_tree_t *tree_ret)
 		size_strs += strlen(value.value.s) + 1;
 	}
 
-	uintptr_t mem = (uintptr_t)calloc(
-		1, sizeof(struct _ccs_tree_s) + sizeof(_ccs_tree_data_t) +
-			   (arity + 1) * sizeof(ccs_float_t) +
-			   (arity + 2) * sizeof(ccs_float_t) +
-			   arity * sizeof(ccs_tree_t) + size_strs);
+	size_t _sz;
+	CCS_REFUTE(
+		CCS_ALLOC_SIZE(
+			&_sz, CCS_ALLOC_SIZE_TYPE(struct _ccs_tree_s),
+			CCS_ALLOC_SIZE_TYPE(_ccs_tree_data_t),
+			CCS_ALLOC_SIZE_ARRAY(arity + 1, ccs_float_t),
+			CCS_ALLOC_SIZE_ARRAY(arity + 2, ccs_float_t),
+			CCS_ALLOC_SIZE_ARRAY(arity, ccs_tree_t),
+			CCS_ALLOC_SIZE_ARRAY(size_strs, char)),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	uintptr_t mem = (uintptr_t)calloc(1, _sz);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 
 	ccs_tree_t tree = CCS_ALLOC_CARVE_TYPE(mem, struct _ccs_tree_s);

--- a/src/tree_configuration_deserialize.h
+++ b/src/tree_configuration_deserialize.h
@@ -28,7 +28,9 @@ _ccs_deserialize_bin_tree_configuration_data(
 	if (data->position_size) {
 		size_t _sz;
 		CCS_REFUTE(
-			_ccs_size_mul(data->position_size, sizeof(size_t), &_sz),
+			CCS_ALLOC_SIZE(
+				&_sz, CCS_ALLOC_SIZE_ARRAY(
+					      data->position_size, size_t)),
 			CCS_RESULT_ERROR_OUT_OF_MEMORY);
 		data->position = (size_t *)calloc(1, _sz);
 		CCS_REFUTE(!data->position, CCS_RESULT_ERROR_OUT_OF_MEMORY);

--- a/src/tree_space_dynamic.c
+++ b/src/tree_space_dynamic.c
@@ -271,10 +271,15 @@ ccs_create_dynamic_tree_space(
 	CCS_CHECK_PTR(tree_space_ret);
 	ccs_result_t err;
 	size_t       name_len = strlen(name) + 1;
-	uintptr_t    mem      = (uintptr_t)calloc(
-                1, sizeof(struct _ccs_tree_space_s) +
-                           sizeof(struct _ccs_tree_space_dynamic_data_s) +
-                           name_len);
+	size_t       _sz;
+	CCS_REFUTE(
+		CCS_ALLOC_SIZE(
+			&_sz, CCS_ALLOC_SIZE_TYPE(struct _ccs_tree_space_s),
+			CCS_ALLOC_SIZE_TYPE(
+				struct _ccs_tree_space_dynamic_data_s),
+			CCS_ALLOC_SIZE_ARRAY(name_len, char)),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	uintptr_t mem = (uintptr_t)calloc(1, _sz);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	uintptr_t                       mem_orig = mem;
 

--- a/src/tree_space_static.c
+++ b/src/tree_space_static.c
@@ -188,10 +188,15 @@ ccs_create_static_tree_space(
 	CCS_CHECK_PTR(tree_space_ret);
 	ccs_result_t err;
 	size_t       name_len = strlen(name) + 1;
-	uintptr_t    mem      = (uintptr_t)calloc(
-                1, sizeof(struct _ccs_tree_space_s) +
-                           sizeof(struct _ccs_tree_space_static_data_s) +
-                           name_len);
+	size_t       _sz;
+	CCS_REFUTE(
+		CCS_ALLOC_SIZE(
+			&_sz, CCS_ALLOC_SIZE_TYPE(struct _ccs_tree_space_s),
+			CCS_ALLOC_SIZE_TYPE(
+				struct _ccs_tree_space_static_data_s),
+			CCS_ALLOC_SIZE_ARRAY(name_len, char)),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	uintptr_t mem = (uintptr_t)calloc(1, _sz);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	uintptr_t        mem_orig = mem;
 

--- a/src/tuner_random.c
+++ b/src/tuner_random.c
@@ -608,10 +608,15 @@ ccs_create_random_tuner(
 		search_space, &feature_space));
 	CCS_CHECK_PTR(tuner_ret);
 
-	size_t    name_len = strlen(name) + 1;
-	uintptr_t mem      = (uintptr_t)calloc(
-                1, sizeof(struct _ccs_tuner_s) +
-                           sizeof(struct _ccs_random_tuner_data_s) + name_len);
+	size_t name_len = strlen(name) + 1;
+	size_t _sz;
+	CCS_REFUTE(
+		CCS_ALLOC_SIZE(
+			&_sz, CCS_ALLOC_SIZE_TYPE(struct _ccs_tuner_s),
+			CCS_ALLOC_SIZE_TYPE(struct _ccs_random_tuner_data_s),
+			CCS_ALLOC_SIZE_ARRAY(name_len, char)),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	uintptr_t mem = (uintptr_t)calloc(1, _sz);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	uintptr_t                 mem_orig = mem;
 	ccs_tuner_t               tun;

--- a/src/tuner_user_defined.c
+++ b/src/tuner_user_defined.c
@@ -326,11 +326,16 @@ ccs_create_user_defined_tuner(
 	CCS_CHECK_PTR(vector->get_optima);
 	CCS_CHECK_PTR(vector->get_history);
 
-	size_t    name_len = strlen(name) + 1;
-	uintptr_t mem      = (uintptr_t)calloc(
-                1, sizeof(struct _ccs_tuner_s) +
-                           sizeof(struct _ccs_user_defined_tuner_data_s) +
-                           name_len);
+	size_t name_len = strlen(name) + 1;
+	size_t _sz;
+	CCS_REFUTE(
+		CCS_ALLOC_SIZE(
+			&_sz, CCS_ALLOC_SIZE_TYPE(struct _ccs_tuner_s),
+			CCS_ALLOC_SIZE_TYPE(
+				struct _ccs_user_defined_tuner_data_s),
+			CCS_ALLOC_SIZE_ARRAY(name_len, char)),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	uintptr_t mem = (uintptr_t)calloc(1, _sz);
 	CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	uintptr_t                       mem_orig = mem;
 	ccs_tuner_t                     tun;


### PR DESCRIPTION
## Summary

Complete the conversion to consistent \`CCS_ALLOC_SIZE\` / \`CCS_ALLOC_CARVE\` patterns:

- Convert 6 \`_ccs_size_mul\` single-entry allocation sites to \`CCS_ALLOC_SIZE\` (5 deserializers + distribution_space scratch buffer)
- Convert 6 manual carve sites to \`CCS_ALLOC_CARVE\` (distribution_mixture \`tmp_mem\`, distribution_space \`dmem\` ×3, distribution_space_internal \`dmem\`, map \`entry\`)

After this change, \`_ccs_size_mul\` is only used in realloc retry loops where \`CCS_ALLOC_SIZE\` is not applicable.

## Test plan

- [x] All 30 C tests pass (gcc, g++)
- [x] Ruby and Python binding tests pass
- [x] clang-format-17 clean
- [x] No remaining manual carve patterns (except cconfigspace.c fd state)
- [x] No remaining \`_ccs_size_mul\` outside realloc loops

🤖 Generated with [Claude Code](https://claude.com/claude-code)