### PR TITLE
Add coverage tests for uncovered code paths

### DIFF
--- a/tests/test_categorical_parameter.c
+++ b/tests/test_categorical_parameter.c
@@ -313,6 +313,37 @@ test_oversampling(void)
 	assert(err == CCS_RESULT_SUCCESS);
 }
 
+static void
+test_default_distribution(void)
+{
+	ccs_parameter_t         parameter    = NULL;
+	ccs_distribution_t      distribution = NULL;
+	ccs_result_t            err;
+	ccs_datum_t             possible_values[4];
+	ccs_distribution_type_t dtype;
+
+	for (size_t i = 0; i < 4; i++) {
+		possible_values[i].type    = CCS_DATA_TYPE_INT;
+		possible_values[i].value.i = (ccs_int_t)(i + 1) * 2;
+	}
+
+	err = ccs_create_categorical_parameter(
+		"my_param", 4, possible_values, 0, &parameter);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	err = ccs_parameter_get_default_distribution(parameter, &distribution);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	err = ccs_distribution_get_type(distribution, &dtype);
+	assert(err == CCS_RESULT_SUCCESS);
+	assert(dtype == CCS_DISTRIBUTION_TYPE_UNIFORM);
+
+	err = ccs_release_object(distribution);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_release_object(parameter);
+	assert(err == CCS_RESULT_SUCCESS);
+}
+
 int
 main(void)
 {
@@ -320,6 +351,7 @@ main(void)
 	test_create();
 	test_samples();
 	test_oversampling();
+	test_default_distribution();
 	ccs_clear_thread_error();
 	ccs_fini();
 	return 0;

--- a/tests/test_configuration_space.c
+++ b/tests/test_configuration_space.c
@@ -544,6 +544,44 @@ test_configuration_with_features(void)
 	ccs_release_object(parameter);
 }
 
+static int destroy_callback_count = 0;
+static void
+destroy_callback_counter(ccs_object_t object, void *user_data)
+{
+	(void)object;
+	(void)user_data;
+	destroy_callback_count++;
+}
+
+void
+test_multiple_destroy_callbacks(void)
+{
+	ccs_result_t err;
+	ccs_rng_t    rng;
+
+	err = ccs_create_rng(&rng);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	destroy_callback_count = 0;
+
+	err                    = ccs_object_set_destroy_callback(
+                rng, &destroy_callback_counter, NULL);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	err = ccs_object_set_destroy_callback(
+		rng, &destroy_callback_counter, (void *)1);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	err = ccs_object_set_destroy_callback(
+		rng, &destroy_callback_counter, (void *)2);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	err = ccs_release_object(rng);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	assert(destroy_callback_count == 3);
+}
+
 int
 main(void)
 {
@@ -555,6 +593,7 @@ main(void)
 	test_configuration_deserialize();
 	test_deserialize_errors();
 	test_configuration_with_features();
+	test_multiple_destroy_callbacks();
 	ccs_clear_thread_error();
 	ccs_fini();
 	return 0;

--- a/tests/test_expression.c
+++ b/tests/test_expression.c
@@ -1476,6 +1476,151 @@ test_less_ordinal(void)
 	ccs_release_object(parameters[1]);
 }
 
+static void
+test_expression_list_eval(void)
+{
+	ccs_expression_t expr = NULL;
+	ccs_datum_t      nodes[2];
+	ccs_datum_t      result;
+	ccs_result_t     err;
+
+	nodes[0] = ccs_int(1);
+	nodes[1] = ccs_int(2);
+
+	err = ccs_create_expression(CCS_EXPRESSION_TYPE_LIST, 2, nodes, &expr);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	err = ccs_expression_eval(expr, 0, NULL, &result);
+	assert(err == CCS_RESULT_ERROR_UNSUPPORTED_OPERATION);
+
+	err = ccs_release_object(expr);
+	assert(err == CCS_RESULT_SUCCESS);
+}
+
+static void
+test_expression_modulo_float(void)
+{
+	ccs_expression_t expr = NULL;
+	ccs_datum_t      nodes[2];
+	ccs_datum_t      result;
+	ccs_result_t     err;
+
+	/* float % int */
+	nodes[0] = ccs_float(5.5);
+	nodes[1] = ccs_int(2);
+	err      = ccs_create_expression(
+                CCS_EXPRESSION_TYPE_MODULO, 2, nodes, &expr);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_expression_eval(expr, 0, NULL, &result);
+	assert(err == CCS_RESULT_SUCCESS);
+	assert(result.type == CCS_DATA_TYPE_FLOAT);
+	assert(result.value.f == fmod(5.5, 2));
+	err = ccs_release_object(expr);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	/* float % float */
+	nodes[0] = ccs_float(5.5);
+	nodes[1] = ccs_float(2.5);
+	err      = ccs_create_expression(
+                CCS_EXPRESSION_TYPE_MODULO, 2, nodes, &expr);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_expression_eval(expr, 0, NULL, &result);
+	assert(err == CCS_RESULT_SUCCESS);
+	assert(result.type == CCS_DATA_TYPE_FLOAT);
+	assert(result.value.f == fmod(5.5, 2.5));
+	err = ccs_release_object(expr);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	/* int % float */
+	nodes[0] = ccs_int(5);
+	nodes[1] = ccs_float(2.5);
+	err      = ccs_create_expression(
+                CCS_EXPRESSION_TYPE_MODULO, 2, nodes, &expr);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_expression_eval(expr, 0, NULL, &result);
+	assert(err == CCS_RESULT_SUCCESS);
+	assert(result.type == CCS_DATA_TYPE_FLOAT);
+	assert(result.value.f == fmod(5, 2.5));
+	err = ccs_release_object(expr);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	/* division by zero: float % 0.0 */
+	nodes[0] = ccs_float(5.5);
+	nodes[1] = ccs_float(0.0);
+	err      = ccs_create_expression(
+                CCS_EXPRESSION_TYPE_MODULO, 2, nodes, &expr);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_expression_eval(expr, 0, NULL, &result);
+	assert(err == CCS_RESULT_ERROR_INVALID_VALUE);
+	err = ccs_release_object(expr);
+	assert(err == CCS_RESULT_SUCCESS);
+}
+
+static void
+test_expression_not_type_error(void)
+{
+	ccs_expression_t expr = NULL;
+	ccs_datum_t      node;
+	ccs_datum_t      result;
+	ccs_result_t     err;
+
+	node = ccs_int(42);
+	err  = ccs_create_expression(CCS_EXPRESSION_TYPE_NOT, 1, &node, &expr);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	err = ccs_expression_eval(expr, 0, NULL, &result);
+	assert(err == CCS_RESULT_ERROR_INVALID_VALUE);
+
+	err = ccs_release_object(expr);
+	assert(err == CCS_RESULT_SUCCESS);
+}
+
+static void
+test_expression_comparison_categorical_error(void)
+{
+	ccs_configuration_space_t configuration_space;
+	ccs_configuration_t       configuration;
+	ccs_parameter_t           parameter;
+	ccs_datum_t               nodes[2];
+	ccs_datum_t               values[1];
+	ccs_result_t              err;
+
+	parameter = create_dummy_categorical("cat_cmp");
+
+	err       = ccs_create_configuration_space(
+                "cmp_space", 1, &parameter, NULL, 0, NULL, NULL, NULL,
+                &configuration_space);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	values[0] = ccs_int(1);
+	err       = ccs_create_configuration(
+                configuration_space, NULL, 1, values, &configuration);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	nodes[0] = ccs_object(parameter);
+	nodes[1] = ccs_int(1);
+
+	test_expression_wrapper(
+		CCS_EXPRESSION_TYPE_LESS, 2, nodes, configuration,
+		ccs_bool(CCS_FALSE), CCS_RESULT_ERROR_INVALID_VALUE);
+	test_expression_wrapper(
+		CCS_EXPRESSION_TYPE_GREATER, 2, nodes, configuration,
+		ccs_bool(CCS_FALSE), CCS_RESULT_ERROR_INVALID_VALUE);
+	test_expression_wrapper(
+		CCS_EXPRESSION_TYPE_LESS_OR_EQUAL, 2, nodes, configuration,
+		ccs_bool(CCS_FALSE), CCS_RESULT_ERROR_INVALID_VALUE);
+	test_expression_wrapper(
+		CCS_EXPRESSION_TYPE_GREATER_OR_EQUAL, 2, nodes, configuration,
+		ccs_bool(CCS_FALSE), CCS_RESULT_ERROR_INVALID_VALUE);
+
+	err = ccs_release_object(configuration);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_release_object(parameter);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_release_object(configuration_space);
+	assert(err == CCS_RESULT_SUCCESS);
+}
+
 int
 main(void)
 {
@@ -1507,6 +1652,10 @@ main(void)
 	test_deserialize_literal();
 	test_deserialize_variable();
 	test_deserialize();
+	test_expression_list_eval();
+	test_expression_modulo_float();
+	test_expression_not_type_error();
+	test_expression_comparison_categorical_error();
 	ccs_clear_thread_error();
 	ccs_fini();
 }

--- a/tests/test_map.c
+++ b/tests/test_map.c
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 #include <assert.h>
+#include <string.h>
 #include <cconfigspace.h>
 
 void
@@ -228,6 +229,38 @@ test_map_error_paths(void)
 	assert(err == CCS_RESULT_SUCCESS);
 }
 
+static void
+test_map_set_duplicate_value(void)
+{
+	ccs_map_t    map = NULL;
+	ccs_result_t err;
+	ccs_datum_t  value;
+	size_t       count;
+
+	err = ccs_create_map(&map);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	err = ccs_map_set(map, ccs_int(1), ccs_string("hello"));
+	assert(err == CCS_RESULT_SUCCESS);
+
+	/* Set same key with same value */
+	err = ccs_map_set(map, ccs_int(1), ccs_string("hello"));
+	assert(err == CCS_RESULT_SUCCESS);
+
+	/* Should still have just 1 entry */
+	err = ccs_map_get_keys(map, 0, NULL, &count);
+	assert(err == CCS_RESULT_SUCCESS);
+	assert(count == 1);
+
+	err = ccs_map_get(map, ccs_int(1), &value);
+	assert(err == CCS_RESULT_SUCCESS);
+	assert(value.type == CCS_DATA_TYPE_STRING);
+	assert(strcmp(value.value.s, "hello") == 0);
+
+	err = ccs_release_object(map);
+	assert(err == CCS_RESULT_SUCCESS);
+}
+
 int
 main(void)
 {
@@ -235,6 +268,8 @@ main(void)
 	test_map();
 	ccs_clear_thread_error();
 	test_map_error_paths();
+	ccs_clear_thread_error();
+	test_map_set_duplicate_value();
 	ccs_clear_thread_error();
 	ccs_fini();
 	return 0;

--- a/tests/test_normal_distribution.c
+++ b/tests/test_normal_distribution.c
@@ -743,6 +743,131 @@ test_normal_distribution_int_strided_samples(void)
 	assert(err == CCS_RESULT_SUCCESS);
 }
 
+static void
+test_normal_distribution_int_log_quantize_tail(void)
+{
+	ccs_distribution_t distrib     = NULL;
+	ccs_rng_t          rng         = NULL;
+	ccs_result_t       err         = CCS_RESULT_SUCCESS;
+	const size_t       num_samples = NUM_SAMPLES;
+	const ccs_float_t  mu          = 0.0;
+	const ccs_float_t  sigma       = 1.0;
+	const ccs_int_t    quantize    = 100L;
+	ccs_numeric_t      samples[NUM_SAMPLES];
+
+	err = ccs_create_rng(&rng);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_create_normal_distribution(
+		CCS_NUMERIC_TYPE_INT, mu, sigma, CCS_SCALE_TYPE_LOGARITHMIC,
+		CCSI(quantize), &distrib);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	err = ccs_distribution_samples(distrib, rng, num_samples, samples);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	for (size_t i = 0; i < num_samples; i++) {
+		assert(samples[i].i >= quantize);
+		assert(samples[i].i % quantize == 0);
+	}
+
+	err = ccs_release_object(distrib);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_release_object(rng);
+	assert(err == CCS_RESULT_SUCCESS);
+}
+
+static void
+test_normal_distribution_int_log_strided_samples(void)
+{
+	ccs_distribution_t distrib1    = NULL;
+	ccs_distribution_t distrib2    = NULL;
+	ccs_rng_t          rng         = NULL;
+	ccs_result_t       err         = CCS_RESULT_SUCCESS;
+	const size_t       num_samples = NUM_SAMPLES;
+	const ccs_float_t  mu1         = 3;
+	const ccs_float_t  sigma1      = 1;
+	const ccs_float_t  mu2         = 5;
+	const ccs_float_t  sigma2      = 1;
+	ccs_numeric_t      samples[NUM_SAMPLES * 2];
+
+	err = ccs_create_rng(&rng);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_create_normal_distribution(
+		CCS_NUMERIC_TYPE_INT, mu1, sigma1, CCS_SCALE_TYPE_LOGARITHMIC,
+		CCSI(0), &distrib1);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	err = ccs_create_normal_distribution(
+		CCS_NUMERIC_TYPE_INT, mu2, sigma2, CCS_SCALE_TYPE_LOGARITHMIC,
+		CCSI(0), &distrib2);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	err = ccs_distribution_strided_samples(
+		distrib1, rng, num_samples, 2, samples);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_distribution_strided_samples(
+		distrib2, rng, num_samples, 2, &(samples[0]) + 1);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	for (size_t i = 0; i < num_samples; i++) {
+		assert(samples[i * 2].i >= 1);
+		assert(samples[i * 2 + 1].i >= 1);
+	}
+
+	err = ccs_release_object(distrib1);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_release_object(distrib2);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_release_object(rng);
+	assert(err == CCS_RESULT_SUCCESS);
+}
+
+static void
+test_normal_distribution_float_log_strided_samples(void)
+{
+	ccs_distribution_t distrib1    = NULL;
+	ccs_distribution_t distrib2    = NULL;
+	ccs_rng_t          rng         = NULL;
+	ccs_result_t       err         = CCS_RESULT_SUCCESS;
+	const size_t       num_samples = NUM_SAMPLES;
+	const ccs_float_t  mu1         = 1;
+	const ccs_float_t  sigma1      = 2;
+	const ccs_float_t  mu2         = 0;
+	const ccs_float_t  sigma2      = 2;
+	ccs_numeric_t      samples[NUM_SAMPLES * 2];
+
+	err = ccs_create_rng(&rng);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_create_normal_distribution(
+		CCS_NUMERIC_TYPE_FLOAT, mu1, sigma1, CCS_SCALE_TYPE_LOGARITHMIC,
+		CCSF(0.0), &distrib1);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	err = ccs_create_normal_distribution(
+		CCS_NUMERIC_TYPE_FLOAT, mu2, sigma2, CCS_SCALE_TYPE_LOGARITHMIC,
+		CCSF(0.0), &distrib2);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	err = ccs_distribution_strided_samples(
+		distrib1, rng, num_samples, 2, samples);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_distribution_strided_samples(
+		distrib2, rng, num_samples, 2, &(samples[0]) + 1);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	for (size_t i = 0; i < num_samples; i++) {
+		assert(samples[i * 2].f > 0.0);
+		assert(samples[i * 2 + 1].f > 0.0);
+	}
+
+	err = ccs_release_object(distrib1);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_release_object(distrib2);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_release_object(rng);
+	assert(err == CCS_RESULT_SUCCESS);
+}
+
 int
 main(void)
 {
@@ -761,6 +886,9 @@ main(void)
 	test_normal_distribution_strided_samples();
 	test_normal_distribution_int_strided_samples();
 	test_normal_distribution_soa_samples();
+	test_normal_distribution_int_log_quantize_tail();
+	test_normal_distribution_int_log_strided_samples();
+	test_normal_distribution_float_log_strided_samples();
 	ccs_clear_thread_error();
 	ccs_fini();
 	return 0;


### PR DESCRIPTION
## Summary

- Add tests targeting the lowest-coverage library source files
- **distribution_normal.c** (79.2% -> 87.0%): INT+LOG tail sampling branch, LOG strided sampling for both float and int
- **expression.c**: list eval unsupported-operation error, float modulo (`fmod` paths), NOT with non-boolean type error, categorical parameter comparison rejection for all 4 comparison operators
- **parameter_categorical.c**: default distribution retrieval
- **map.c**: duplicate key-value set (early-exit optimization)
- **configuration_space.c**: multiple destroy callbacks on a single object

Library source coverage: 90.7% -> 91.0% lines, 98.2% -> 98.3% functions.

## Test plan

- [x] All 30 C tests pass
- [x] Coverage report generated successfully
- [x] No new compiler warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)