### PR TITLE
Add JSON serialization dispatch for distributions

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -8,7 +8,7 @@ jobs:
       - run: sudo apt-get update
       - run: sudo apt-get install -y clang-format-17
       - name: run git-clang-format
-        run: clang-format-17 --style=file --dry-run --Werror `git ls-files *.c *.cpp *.h  | grep -v -E "Kokkos_Profiling_C_Interface\.h|utarray.h|uthash.h|utlist.h"` > clang-format-diff 2>&1
+        run: clang-format-17 --style=file --dry-run --Werror `git ls-files *.c *.cpp *.h  | grep -v -E "Kokkos_Profiling_C_Interface\.h|utarray.h|uthash.h|utlist.h|cJSON\.[ch]"` > clang-format-diff 2>&1
         shell: bash
       - name: output clang format diff
         if: always()

--- a/configure.ac
+++ b/configure.ac
@@ -99,6 +99,7 @@ AC_CONFIG_HEADERS([src/config.h])
 AC_CONFIG_FILES([Makefile
 		include/Makefile
 		src/Makefile
+		src/cjson/Makefile
 		tests/Makefile
 		connectors/Makefile
 		bindings/Makefile

--- a/include/cconfigspace/base.h
+++ b/include/cconfigspace/base.h
@@ -901,6 +901,8 @@ ccs_object_set_serialize_callback(
 enum ccs_serialize_format_e {
 	/** A binary format that should be compact and performant. */
 	CCS_SERIALIZE_FORMAT_BINARY,
+	/** A human-readable JSON format. */
+	CCS_SERIALIZE_FORMAT_JSON,
 	/** Guard */
 	CCS_SERIALIZE_FORMAT_MAX,
 	/** Try forcing 32 bits value for bindings */

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -11,8 +11,10 @@ if THREAD_SAFE
 AM_CFLAGS += -DTHREAD_SAFE
 endif
 
+SUBDIRS = cjson
+
 lib_LTLIBRARIES = libcconfigspace.la
-libcconfigspace_la_LIBADD = $(CODE_COVERAGE_LIBS)
+libcconfigspace_la_LIBADD = cjson/libcjson.la $(CODE_COVERAGE_LIBS)
 
 version.h: $(srcdir)/version.h.subst .version_timestamp
 	@echo Processing $@; sh $(top_srcdir)/build-aux/version-subst $(CURVER) $< $@
@@ -36,6 +38,7 @@ libcconfigspace_la_SOURCES = \
 	cconfigspace.c \
 	cconfigspace_internal.h \
 	cconfigspace_deserialize.h \
+	cconfigspace_json.h \
 	error_stack.c \
 	error_stack_internal.h \
 	interval.c \

--- a/src/cconfigspace.c
+++ b/src/cconfigspace.c
@@ -358,9 +358,52 @@ _ccs_object_header_serialize_size_with_opts(
 	size_t                          *buffer_size,
 	_ccs_object_serialize_options_t *opts)
 {
-	*buffer_size = _ccs_serialize_header_size(format);
-	CCS_VALIDATE(_ccs_object_serialize_size_with_opts(
-		object, format, buffer_size, opts));
+	switch (format) {
+	case CCS_SERIALIZE_FORMAT_BINARY:
+		*buffer_size = _ccs_serialize_header_size(format);
+		CCS_VALIDATE(_ccs_object_serialize_size_with_opts(
+			object, format, buffer_size, opts));
+		break;
+	case CCS_SERIALIZE_FORMAT_JSON: {
+		ccs_result_t err      = CCS_RESULT_SUCCESS;
+		cJSON       *root     = NULL;
+		cJSON       *obj_node = NULL;
+		char        *str      = NULL;
+		char        *bp       = NULL;
+		size_t       dummy    = 0;
+		root                  = cJSON_CreateObject();
+		CCS_REFUTE(!root, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		bp = (char *)root;
+		CCS_VALIDATE_ERR_GOTO(
+			err, _ccs_serialize_header(format, NULL, &bp, 0),
+			err_json_size);
+		obj_node = cJSON_AddObjectToObject(root, "object");
+		CCS_REFUTE_ERR_GOTO(
+			err, !obj_node, CCS_RESULT_ERROR_OUT_OF_MEMORY,
+			err_json_size);
+		bp = (char *)obj_node;
+		CCS_VALIDATE_ERR_GOTO(
+			err,
+			_ccs_object_serialize_with_opts(
+				object, format, &dummy, &bp, opts),
+			err_json_size);
+		str = cJSON_PrintUnformatted(root);
+		cJSON_Delete(root);
+		root = NULL;
+		CCS_REFUTE(!str, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		*buffer_size = strlen(str) + 1;
+		free(str);
+		break;
+	err_json_size:
+		if (root)
+			cJSON_Delete(root);
+		return err;
+	}
+	default:
+		CCS_RAISE(
+			CCS_RESULT_ERROR_INVALID_VALUE,
+			"Unsupported serialization format: %d", format);
+	}
 	return CCS_RESULT_SUCCESS;
 }
 

--- a/src/cconfigspace.c
+++ b/src/cconfigspace.c
@@ -231,6 +231,16 @@ _ccs_serialize_header(
 		CCS_VALIDATE(CCS_SERIALIZATION_API_VERSION_SERIALIZE_BIN(
 			CCS_SERIALIZATION_API_VERSION, buffer_size, buffer));
 	} break;
+	case CCS_SERIALIZE_FORMAT_JSON: {
+		cJSON *json   = *(cJSON **)buffer;
+		cJSON *header = cJSON_AddObjectToObject(json, "header");
+		CCS_REFUTE(!header, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		CCS_REFUTE(
+			!cJSON_AddNumberToObject(
+				header, "version",
+				CCS_SERIALIZATION_API_VERSION),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	} break;
 	default:
 		CCS_RAISE(
 			CCS_RESULT_ERROR_INVALID_VALUE,
@@ -349,13 +359,66 @@ _ccs_object_serialize_memory_with_opts(
 	char                            *buffer,
 	_ccs_object_serialize_options_t *opts)
 {
-	size_t total_size   = buffer_size;
-	char  *buffer_start = buffer;
-	CCS_VALIDATE(_ccs_serialize_header(format, &buffer_size, &buffer, 0));
-	CCS_VALIDATE(_ccs_object_serialize_with_opts(
-		object, format, &buffer_size, &buffer, opts));
-	CCS_VALIDATE(_ccs_serialize_header(
-		format, &total_size, &buffer_start, total_size - buffer_size));
+	switch (format) {
+	case CCS_SERIALIZE_FORMAT_BINARY: {
+		size_t total_size   = buffer_size;
+		char  *buffer_start = buffer;
+		CCS_VALIDATE(_ccs_serialize_header(
+			format, &buffer_size, &buffer, 0));
+		CCS_VALIDATE(_ccs_object_serialize_with_opts(
+			object, format, &buffer_size, &buffer, opts));
+		CCS_VALIDATE(_ccs_serialize_header(
+			format, &total_size, &buffer_start,
+			total_size - buffer_size));
+	} break;
+	case CCS_SERIALIZE_FORMAT_JSON: {
+		ccs_result_t err      = CCS_RESULT_SUCCESS;
+		cJSON       *root     = NULL;
+		cJSON       *obj_node = NULL;
+		char        *str      = NULL;
+		char        *bp       = NULL;
+		size_t       dummy    = 0;
+		size_t       sz       = 0;
+		root                  = cJSON_CreateObject();
+		CCS_REFUTE(!root, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		bp = (char *)root;
+		CCS_VALIDATE_ERR_GOTO(
+			err, _ccs_serialize_header(format, NULL, &bp, 0),
+			err_json_mem);
+		obj_node = cJSON_AddObjectToObject(root, "object");
+		CCS_REFUTE_ERR_GOTO(
+			err, !obj_node, CCS_RESULT_ERROR_OUT_OF_MEMORY,
+			err_json_mem);
+		bp = (char *)obj_node;
+		CCS_VALIDATE_ERR_GOTO(
+			err,
+			_ccs_object_serialize_with_opts(
+				object, format, &dummy, &bp, opts),
+			err_json_mem);
+		str = cJSON_PrintUnformatted(root);
+		cJSON_Delete(root);
+		root = NULL;
+		CCS_REFUTE(!str, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		sz = strlen(str) + 1;
+		if (sz > buffer_size) {
+			free(str);
+			CCS_RAISE(
+				CCS_RESULT_ERROR_NOT_ENOUGH_DATA,
+				"Buffer too small for JSON");
+		}
+		memcpy(buffer, str, sz);
+		free(str);
+		return CCS_RESULT_SUCCESS;
+	err_json_mem:
+		if (root)
+			cJSON_Delete(root);
+		return err;
+	}
+	default:
+		CCS_RAISE(
+			CCS_RESULT_ERROR_INVALID_VALUE,
+			"Unsupported serialization format: %d", format);
+	}
 	return CCS_RESULT_SUCCESS;
 }
 

--- a/src/cconfigspace.c
+++ b/src/cconfigspace.c
@@ -706,7 +706,7 @@ ccs_object_serialize(
 	...)
 {
 	_ccs_object_internal_t *obj = (_ccs_object_internal_t *)object;
-	ccs_result_t            res = CCS_RESULT_SUCCESS;
+	ccs_result_t            res;
 	va_list                 args;
 
 	CCS_REFUTE(!obj || !obj->ops, CCS_RESULT_ERROR_INVALID_OBJECT);

--- a/src/cconfigspace.c
+++ b/src/cconfigspace.c
@@ -232,9 +232,7 @@ _ccs_serialize_header(
 			CCS_SERIALIZATION_API_VERSION, buffer_size, buffer));
 	} break;
 	case CCS_SERIALIZE_FORMAT_JSON: {
-		cJSON *json   = *(cJSON **)buffer;
-		cJSON *header = cJSON_AddObjectToObject(json, "header");
-		CCS_REFUTE(!header, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		cJSON *header = *(cJSON **)buffer;
 		CCS_REFUTE(
 			!cJSON_AddNumberToObject(
 				header, "version",
@@ -371,9 +369,14 @@ _ccs_object_header_serialize_size_with_opts(
 		char        *str      = NULL;
 		char        *bp       = NULL;
 		size_t       dummy    = 0;
+		cJSON       *hdr_node = NULL;
 		root                  = cJSON_CreateObject();
 		CCS_REFUTE(!root, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		bp = (char *)root;
+		hdr_node = cJSON_AddObjectToObject(root, "header");
+		CCS_REFUTE_ERR_GOTO(
+			err, !hdr_node, CCS_RESULT_ERROR_OUT_OF_MEMORY,
+			err_json_size);
+		bp = (char *)hdr_node;
 		CCS_VALIDATE_ERR_GOTO(
 			err, _ccs_serialize_header(format, NULL, &bp, 0),
 			err_json_size);
@@ -455,9 +458,14 @@ _ccs_object_serialize_memory_with_opts(
 		size_t       dummy    = 0;
 		size_t       sz       = 0;
 		size_t       hex_len  = sizeof(size_t) * 2;
+		cJSON       *hdr_node = NULL;
 		root                  = cJSON_CreateObject();
 		CCS_REFUTE(!root, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		bp = (char *)root;
+		hdr_node = cJSON_AddObjectToObject(root, "header");
+		CCS_REFUTE_ERR_GOTO(
+			err, !hdr_node, CCS_RESULT_ERROR_OUT_OF_MEMORY,
+			err_json_mem);
+		bp = (char *)hdr_node;
 		CCS_VALIDATE_ERR_GOTO(
 			err, _ccs_serialize_header(format, NULL, &bp, 0),
 			err_json_mem);
@@ -1137,9 +1145,11 @@ _ccs_object_deserialize_file_descriptor_header(
 	_ccs_object_deserialize_options_t *opts)
 {
 	ccs_result_t res = CCS_RESULT_SUCCESS;
-	res              = _ccs_object_deserialize_file_descriptor_header_read(
-                format, non_blocking, fd, header_size, pstate_ptr, opts);
-	if (res != CCS_RESULT_SUCCESS)
+	CCS_VALIDATE_ERR(
+		res, _ccs_object_deserialize_file_descriptor_header_read(
+			     format, non_blocking, fd, header_size, pstate_ptr,
+			     opts));
+	if (res == CCS_RESULT_AGAIN)
 		return res;
 	return _ccs_object_deserialize_file_descriptor_header_decode(
 		format, non_blocking, header_size, pstate_ptr, opts);
@@ -1177,11 +1187,12 @@ _ccs_object_deserialize_file_descriptor(
 		}
 	} else
 		pstate = &state;
-	res = _ccs_object_deserialize_file_descriptor_header(
-		format, non_blocking, fd, header_size, &pstate, &opts);
+	CCS_VALIDATE_ERR(
+		res,
+		_ccs_object_deserialize_file_descriptor_header(
+			format, non_blocking, fd, header_size, &pstate, &opts));
 	if (res == CCS_RESULT_AGAIN)
 		return res;
-	CCS_VALIDATE(res);
 	/* read rest of object */
 	FD_READ_LOOP(pstate, non_blocking);
 	/* rewind to start of buffer (including header) */

--- a/src/cconfigspace.c
+++ b/src/cconfigspace.c
@@ -808,7 +808,9 @@ _ccs_object_deserialize_file_descriptor(
 						    NULL, NULL,      NULL};
 	_ccs_file_descriptor_state_t      state  = {NULL, 0, NULL, 0, -1, 0};
 	_ccs_file_descriptor_state_t     *pstate = NULL;
-	int                               fd     = va_arg(args, int);
+	va_list                           args_copy;
+	int fd = va_arg(args, int);
+	va_copy(args_copy, args);
 	CCS_VALIDATE(_ccs_object_deserialize_options(
 		format, CCS_DESERIALIZE_OPERATION_FILE_DESCRIPTOR, args,
 		&opts));
@@ -895,21 +897,23 @@ _ccs_object_deserialize_file_descriptor(
 	}
 	/* read rest of object */
 	FD_READ_LOOP(pstate, non_blocking);
-	/* rewind */
-	offset = header_size;
+	/* rewind to start of buffer (including header) */
+	offset = 0;
 	if (non_blocking)
 		offset += sizeof(_ccs_file_descriptor_state_t);
 	pstate->buffer_size = pstate->base_size - offset;
 	pstate->buffer      = pstate->base + offset;
-	/* decode object */
+	/* decode via _ccs_object_deserialize (header + object) */
 	CCS_VALIDATE_ERR_GOTO(
 		res,
-		_ccs_object_deserialize_with_opts(
-			object_ret, format, pstate->version,
+		_ccs_object_deserialize(
+			object_ret, format,
+			CCS_DESERIALIZE_OPERATION_FILE_DESCRIPTOR,
 			&pstate->buffer_size, (const char **)&pstate->buffer,
-			&opts),
+			args_copy),
 		err_fd_buffer);
 err_fd_buffer:
+	va_end(args_copy);
 	free(pstate->base);
 	if (opts.ppfd_state)
 		*(opts.ppfd_state) = NULL;

--- a/src/cconfigspace.c
+++ b/src/cconfigspace.c
@@ -1225,7 +1225,7 @@ ccs_object_deserialize(
 	ccs_deserialize_operation_t operation,
 	...)
 {
-	ccs_result_t res = CCS_RESULT_SUCCESS;
+	ccs_result_t res;
 	va_list      args;
 
 	CCS_CHECK_PTR(object_ret);

--- a/src/cconfigspace.c
+++ b/src/cconfigspace.c
@@ -541,7 +541,7 @@ _ccs_object_serialize_file(
 	size_t                          buffer_size = 0;
 	const char                     *path;
 	int                             fd;
-	ccs_result_t                    res;
+	ccs_result_t                    res  = CCS_RESULT_SUCCESS;
 	_ccs_object_serialize_options_t opts = {NULL, NULL, NULL};
 	path                                 = va_arg(args, const char *);
 	CCS_CHECK_PTR(path);
@@ -615,7 +615,7 @@ _ccs_object_serialize_file_descriptor(
 	va_list                args)
 {
 	int                             fd;
-	ccs_result_t                    res;
+	ccs_result_t                    res    = CCS_RESULT_SUCCESS;
 	_ccs_object_serialize_options_t opts   = {NULL, NULL, NULL};
 	_ccs_file_descriptor_state_t    state  = {NULL, 0, NULL, 0, -1, 0};
 	_ccs_file_descriptor_state_t   *pstate = NULL;
@@ -698,7 +698,7 @@ ccs_object_serialize(
 	...)
 {
 	_ccs_object_internal_t *obj = (_ccs_object_internal_t *)object;
-	ccs_result_t            res;
+	ccs_result_t            res = CCS_RESULT_SUCCESS;
 	va_list                 args;
 
 	CCS_REFUTE(!obj || !obj->ops, CCS_RESULT_ERROR_INVALID_OBJECT);
@@ -1136,9 +1136,9 @@ _ccs_object_deserialize_file_descriptor_header(
 	_ccs_file_descriptor_state_t     **pstate_ptr,
 	_ccs_object_deserialize_options_t *opts)
 {
-	ccs_result_t res;
-	res = _ccs_object_deserialize_file_descriptor_header_read(
-		format, non_blocking, fd, header_size, pstate_ptr, opts);
+	ccs_result_t res = CCS_RESULT_SUCCESS;
+	res              = _ccs_object_deserialize_file_descriptor_header_read(
+                format, non_blocking, fd, header_size, pstate_ptr, opts);
 	if (res != CCS_RESULT_SUCCESS)
 		return res;
 	return _ccs_object_deserialize_file_descriptor_header_decode(
@@ -1214,7 +1214,7 @@ ccs_object_deserialize(
 	ccs_deserialize_operation_t operation,
 	...)
 {
-	ccs_result_t res;
+	ccs_result_t res = CCS_RESULT_SUCCESS;
 	va_list      args;
 
 	CCS_CHECK_PTR(object_ret);

--- a/src/cconfigspace.c
+++ b/src/cconfigspace.c
@@ -549,7 +549,7 @@ _ccs_object_serialize_file(
 	size_t                          buffer_size = 0;
 	const char                     *path;
 	int                             fd;
-	ccs_result_t                    res  = CCS_RESULT_SUCCESS;
+	ccs_result_t                    res;
 	_ccs_object_serialize_options_t opts = {NULL, NULL, NULL};
 	path                                 = va_arg(args, const char *);
 	CCS_CHECK_PTR(path);

--- a/src/cconfigspace.c
+++ b/src/cconfigspace.c
@@ -623,7 +623,7 @@ _ccs_object_serialize_file_descriptor(
 	va_list                args)
 {
 	int                             fd;
-	ccs_result_t                    res;
+	ccs_result_t                    res    = CCS_RESULT_SUCCESS;
 	_ccs_object_serialize_options_t opts   = {NULL, NULL, NULL};
 	_ccs_file_descriptor_state_t    state  = {NULL, 0, NULL, 0, -1, 0};
 	_ccs_file_descriptor_state_t   *pstate = NULL;

--- a/src/cconfigspace.c
+++ b/src/cconfigspace.c
@@ -623,7 +623,7 @@ _ccs_object_serialize_file_descriptor(
 	va_list                args)
 {
 	int                             fd;
-	ccs_result_t                    res    = CCS_RESULT_SUCCESS;
+	ccs_result_t                    res;
 	_ccs_object_serialize_options_t opts   = {NULL, NULL, NULL};
 	_ccs_file_descriptor_state_t    state  = {NULL, 0, NULL, 0, -1, 0};
 	_ccs_file_descriptor_state_t   *pstate = NULL;

--- a/src/cconfigspace.c
+++ b/src/cconfigspace.c
@@ -240,6 +240,11 @@ _ccs_serialize_header(
 				header, "version",
 				CCS_SERIALIZATION_API_VERSION),
 			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		char *hex = _ccs_json_hex_encode(&size, sizeof(size_t));
+		CCS_REFUTE(!hex, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		cJSON *s = cJSON_AddStringToObject(header, "size", hex);
+		free(hex);
+		CCS_REFUTE(!s, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	} break;
 	default:
 		CCS_RAISE(
@@ -275,6 +280,31 @@ _ccs_deserialize_header(
 		CCS_REFUTE(
 			*version > CCS_SERIALIZATION_API_VERSION,
 			CCS_RESULT_ERROR_INVALID_VALUE);
+	} break;
+	case CCS_SERIALIZE_FORMAT_JSON: {
+		cJSON *j_header = *(cJSON **)buffer;
+		cJSON *j_version =
+			cJSON_GetObjectItemCaseSensitive(j_header, "version");
+		cJSON *j_size =
+			cJSON_GetObjectItemCaseSensitive(j_header, "size");
+		CCS_REFUTE(
+			!j_version || !cJSON_IsNumber(j_version),
+			CCS_RESULT_ERROR_INVALID_VALUE);
+		*version = (uint32_t)j_version->valuedouble;
+		CCS_REFUTE(
+			*version > CCS_SERIALIZATION_API_VERSION,
+			CCS_RESULT_ERROR_INVALID_VALUE);
+		CCS_REFUTE(
+			!j_size || !cJSON_IsString(j_size),
+			CCS_RESULT_ERROR_INVALID_VALUE);
+		size_t         sz_len;
+		unsigned char *sz_bytes =
+			_ccs_json_hex_decode(j_size->valuestring, &sz_len);
+		CCS_REFUTE(
+			!sz_bytes || sz_len != sizeof(size_t),
+			CCS_RESULT_ERROR_INVALID_VALUE);
+		memcpy(size, sz_bytes, sizeof(size_t));
+		free(sz_bytes);
 	} break;
 	default:
 		CCS_RAISE(
@@ -377,8 +407,11 @@ _ccs_object_serialize_memory_with_opts(
 		cJSON       *obj_node = NULL;
 		char        *str      = NULL;
 		char        *bp       = NULL;
+		char        *size_hex = NULL;
+		char        *size_loc = NULL;
 		size_t       dummy    = 0;
 		size_t       sz       = 0;
+		size_t       hex_len  = sizeof(size_t) * 2;
 		root                  = cJSON_CreateObject();
 		CCS_REFUTE(!root, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 		bp = (char *)root;
@@ -399,7 +432,21 @@ _ccs_object_serialize_memory_with_opts(
 		cJSON_Delete(root);
 		root = NULL;
 		CCS_REFUTE(!str, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		sz = strlen(str) + 1;
+		sz       = strlen(str) + 1;
+		/* patch the size placeholder in the printed string */
+		size_hex = _ccs_json_hex_encode(&sz, sizeof(size_t));
+		if (!size_hex) {
+			free(str);
+			CCS_RAISE(
+				CCS_RESULT_ERROR_OUT_OF_MEMORY,
+				"hex encode failed");
+		}
+		size_loc = strstr(str, "\"size\":\"");
+		if (size_loc) {
+			size_loc += strlen("\"size\":\"");
+			memcpy(size_loc, size_hex, hex_len);
+		}
+		free(size_hex);
 		if (sz > buffer_size) {
 			free(str);
 			CCS_RAISE(
@@ -668,22 +715,74 @@ _ccs_object_deserialize(
 						  NULL, NULL,      NULL};
 	CCS_VALIDATE(_ccs_object_deserialize_options(
 		format, operation, args, &opts));
-	CCS_VALIDATE(_ccs_deserialize_header(
-		format, buffer_size, buffer, &size, &version));
-	if (opts.map_values)
-		CCS_VALIDATE(_ccs_map_get_checkpoint(
-			opts.handle_map, &map_checkpoint));
-	CCS_VALIDATE_ERR_GOTO(
-		err,
-		_ccs_object_deserialize_with_opts(
-			object_ret, format, version, buffer_size, buffer,
-			&opts),
-		error);
-	return CCS_RESULT_SUCCESS;
-error:
-	if (opts.map_values)
-		_ccs_map_rewind(opts.handle_map, map_checkpoint);
-	return err;
+	switch (format) {
+	case CCS_SERIALIZE_FORMAT_BINARY:
+		CCS_VALIDATE(_ccs_deserialize_header(
+			format, buffer_size, buffer, &size, &version));
+		if (opts.map_values)
+			CCS_VALIDATE(_ccs_map_get_checkpoint(
+				opts.handle_map, &map_checkpoint));
+		CCS_VALIDATE_ERR_GOTO(
+			err,
+			_ccs_object_deserialize_with_opts(
+				object_ret, format, version, buffer_size,
+				buffer, &opts),
+			error);
+		return CCS_RESULT_SUCCESS;
+	error:
+		if (opts.map_values)
+			_ccs_map_rewind(opts.handle_map, map_checkpoint);
+		return err;
+	case CCS_SERIALIZE_FORMAT_JSON: {
+		cJSON      *root     = NULL;
+		cJSON      *j_header = NULL;
+		cJSON      *j_obj    = NULL;
+		const char *hdr_buf  = NULL;
+		const char *obj_buf  = NULL;
+		size_t      dummy    = 0;
+		root = cJSON_ParseWithLength(*buffer, *buffer_size);
+		CCS_REFUTE(!root, CCS_RESULT_ERROR_INVALID_VALUE);
+		j_header = cJSON_GetObjectItemCaseSensitive(root, "header");
+		CCS_REFUTE_ERR_GOTO(
+			err, !j_header || !cJSON_IsObject(j_header),
+			CCS_RESULT_ERROR_INVALID_VALUE, err_json);
+		j_obj = cJSON_GetObjectItemCaseSensitive(root, "object");
+		CCS_REFUTE_ERR_GOTO(
+			err, !j_obj || !cJSON_IsObject(j_obj),
+			CCS_RESULT_ERROR_INVALID_VALUE, err_json);
+		hdr_buf = (const char *)j_header;
+		CCS_VALIDATE_ERR_GOTO(
+			err,
+			_ccs_deserialize_header(
+				format, &dummy, &hdr_buf, &size, &version),
+			err_json);
+		if (opts.map_values)
+			CCS_VALIDATE_ERR_GOTO(
+				err,
+				_ccs_map_get_checkpoint(
+					opts.handle_map, &map_checkpoint),
+				err_json);
+		obj_buf = (const char *)j_obj;
+		CCS_VALIDATE_ERR_GOTO(
+			err,
+			_ccs_object_deserialize_with_opts(
+				object_ret, format, version, &dummy, &obj_buf,
+				&opts),
+			err_json_map);
+		cJSON_Delete(root);
+		return CCS_RESULT_SUCCESS;
+	err_json_map:
+		if (opts.map_values)
+			_ccs_map_rewind(opts.handle_map, map_checkpoint);
+	err_json:
+		cJSON_Delete(root);
+		return err;
+	}
+	default:
+		CCS_RAISE(
+			CCS_RESULT_ERROR_INVALID_VALUE,
+			"Unsupported serialization format: %d", format);
+	}
 }
 
 static inline ccs_result_t
@@ -809,7 +908,7 @@ _ccs_object_deserialize_file_descriptor(
 	_ccs_file_descriptor_state_t      state  = {NULL, 0, NULL, 0, -1, 0};
 	_ccs_file_descriptor_state_t     *pstate = NULL;
 	va_list                           args_copy;
-	int fd = va_arg(args, int);
+	int                               fd = va_arg(args, int);
 	va_copy(args_copy, args);
 	CCS_VALIDATE(_ccs_object_deserialize_options(
 		format, CCS_DESERIALIZE_OPERATION_FILE_DESCRIPTOR, args,

--- a/src/cconfigspace.c
+++ b/src/cconfigspace.c
@@ -893,6 +893,215 @@ _ccs_object_deserialize_file_descriptor_read_loop(
 			return res;                                            \
 	} while (0)
 
+/* Allocate header buffer and read header bytes from fd.
+ * May return CCS_RESULT_AGAIN for non-blocking fds. */
+static inline ccs_result_t
+_ccs_object_deserialize_file_descriptor_header_read(
+	ccs_serialize_format_t             format,
+	int                                non_blocking,
+	int                                fd,
+	size_t                             header_size,
+	_ccs_file_descriptor_state_t     **pstate_ptr,
+	_ccs_object_deserialize_options_t *opts)
+{
+	ccs_result_t                  res    = CCS_RESULT_SUCCESS;
+	_ccs_file_descriptor_state_t *pstate = *pstate_ptr;
+	ssize_t                       offset;
+	switch (format) {
+	case CCS_SERIALIZE_FORMAT_BINARY:
+		if (!pstate || !pstate->base) {
+			offset = 0;
+			if (non_blocking)
+				offset += sizeof(_ccs_file_descriptor_state_t);
+			char *mem = (char *)malloc(offset + header_size);
+			CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+			if (non_blocking) {
+				*(opts->ppfd_state) = pstate =
+					(_ccs_file_descriptor_state_t *)mem;
+				pstate->base_size = 0;
+			} else
+				pstate->base_size = header_size;
+			pstate->base        = mem;
+			pstate->buffer      = mem + offset;
+			pstate->buffer_size = header_size;
+			pstate->fd          = fd;
+		}
+		if (!non_blocking || !pstate->base_size) {
+			FD_READ_LOOP(pstate, non_blocking);
+			/* rewind to start of header */
+			pstate->buffer_size += header_size;
+			pstate->buffer -= header_size;
+		}
+		break;
+	case CCS_SERIALIZE_FORMAT_JSON: {
+		size_t len;
+		offset = 0;
+		if (non_blocking)
+			offset += sizeof(_ccs_file_descriptor_state_t);
+		if (!pstate || !pstate->base) {
+			char *mem = (char *)malloc(offset + 256);
+			CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+			if (non_blocking) {
+				*(opts->ppfd_state) = pstate =
+					(_ccs_file_descriptor_state_t *)mem;
+			}
+			pstate->base        = mem;
+			pstate->base_size   = 0; /* header phase */
+			pstate->buffer      = mem + offset;
+			pstate->buffer_size = 1;
+			pstate->fd          = fd;
+		}
+		if (!pstate->base_size) {
+			for (;;) {
+				FD_READ_LOOP(pstate, non_blocking);
+				if (*(pstate->buffer - 1) == '}')
+					break;
+				len = pstate->buffer - (pstate->base + offset);
+				CCS_REFUTE_ERR_GOTO(
+					res, len >= 256,
+					CCS_RESULT_ERROR_INVALID_VALUE,
+					err_fd_buffer);
+				pstate->buffer_size = 1;
+			}
+			len = pstate->buffer - (pstate->base + offset);
+			pstate->buffer      = pstate->base + offset;
+			pstate->buffer_size = len;
+		}
+	} break;
+	default:
+		CCS_RAISE(
+			CCS_RESULT_ERROR_INVALID_VALUE,
+			"Unsupported serialization format: %d", format);
+	}
+	*pstate_ptr = pstate;
+	return CCS_RESULT_SUCCESS;
+err_fd_buffer:
+	free(pstate->base);
+	if (opts->ppfd_state)
+		*(opts->ppfd_state) = NULL;
+	return res;
+}
+
+/* Parse the header bytes in pstate, extract object_size and version,
+ * then reallocate the buffer to hold the full object.
+ * Sets pstate->buffer/buffer_size to the region after the header. */
+static inline ccs_result_t
+_ccs_object_deserialize_file_descriptor_header_decode(
+	ccs_serialize_format_t             format,
+	int                                non_blocking,
+	size_t                             header_size,
+	_ccs_file_descriptor_state_t     **pstate_ptr,
+	_ccs_object_deserialize_options_t *opts)
+{
+	ccs_result_t                  res    = CCS_RESULT_SUCCESS;
+	_ccs_file_descriptor_state_t *pstate = *pstate_ptr;
+	size_t                        object_size;
+	char                         *new_buffer;
+	ssize_t                       offset;
+	switch (format) {
+	case CCS_SERIALIZE_FORMAT_BINARY:
+		CCS_VALIDATE_ERR_GOTO(
+			res,
+			_ccs_deserialize_header(
+				format, &pstate->buffer_size,
+				(const char **)&pstate->buffer, &object_size,
+				&pstate->version),
+			err_fd_buffer);
+		break;
+	case CCS_SERIALIZE_FORMAT_JSON: {
+		char       *first_brace  = NULL;
+		char       *second_brace = NULL;
+		size_t      remaining    = 0;
+		size_t      inner_len    = 0;
+		cJSON      *j_header     = NULL;
+		const char *hdr_buf      = NULL;
+		size_t      dummy        = 0;
+		first_brace              = (char *)memchr(
+                        pstate->buffer, '{', pstate->buffer_size);
+		CCS_REFUTE_ERR_GOTO(
+			res, !first_brace, CCS_RESULT_ERROR_INVALID_VALUE,
+			err_fd_buffer);
+		remaining = pstate->buffer_size -
+			    (first_brace + 1 - pstate->buffer);
+		second_brace = (char *)memchr(first_brace + 1, '{', remaining);
+		CCS_REFUTE_ERR_GOTO(
+			res, !second_brace, CCS_RESULT_ERROR_INVALID_VALUE,
+			err_fd_buffer);
+		inner_len =
+			pstate->buffer_size - (second_brace - pstate->buffer);
+		j_header = cJSON_ParseWithLength(second_brace, inner_len);
+		CCS_REFUTE_ERR_GOTO(
+			res, !j_header, CCS_RESULT_ERROR_INVALID_VALUE,
+			err_fd_buffer);
+		hdr_buf = (const char *)j_header;
+		CCS_VALIDATE_ERR_GOTO(
+			res,
+			_ccs_deserialize_header(
+				format, &dummy, &hdr_buf, &object_size,
+				&pstate->version),
+			err_fd_json_header);
+		cJSON_Delete(j_header);
+		break;
+	err_fd_json_header:
+		cJSON_Delete(j_header);
+		goto err_fd_buffer;
+	}
+	default:
+		CCS_RAISE_ERR_GOTO(
+			res, CCS_RESULT_ERROR_INVALID_VALUE, err_fd_buffer,
+			"Unsupported serialization format: %d", format);
+	}
+	if (non_blocking) {
+		size_t new_size =
+			sizeof(_ccs_file_descriptor_state_t) + object_size;
+		new_buffer = (char *)realloc(pstate->base, new_size);
+		CCS_REFUTE_ERR_GOTO(
+			res, !new_buffer, CCS_RESULT_ERROR_OUT_OF_MEMORY,
+			err_fd_buffer);
+		pstate = (_ccs_file_descriptor_state_t *)new_buffer;
+		*(opts->ppfd_state) = pstate;
+		pstate->base        = new_buffer;
+		pstate->base_size   = new_size;
+	} else {
+		pstate->base_size = object_size;
+		new_buffer = (char *)realloc(pstate->base, pstate->base_size);
+		CCS_REFUTE_ERR_GOTO(
+			res, !new_buffer, CCS_RESULT_ERROR_OUT_OF_MEMORY,
+			err_fd_buffer);
+		pstate->base = new_buffer;
+	}
+	offset = header_size;
+	if (non_blocking)
+		offset += sizeof(_ccs_file_descriptor_state_t);
+	pstate->buffer_size = pstate->base_size - offset;
+	pstate->buffer      = pstate->base + offset;
+	*pstate_ptr         = pstate;
+	return CCS_RESULT_SUCCESS;
+err_fd_buffer:
+	free(pstate->base);
+	if (opts->ppfd_state)
+		*(opts->ppfd_state) = NULL;
+	return res;
+}
+
+static inline ccs_result_t
+_ccs_object_deserialize_file_descriptor_header(
+	ccs_serialize_format_t             format,
+	int                                non_blocking,
+	int                                fd,
+	size_t                             header_size,
+	_ccs_file_descriptor_state_t     **pstate_ptr,
+	_ccs_object_deserialize_options_t *opts)
+{
+	ccs_result_t res;
+	res = _ccs_object_deserialize_file_descriptor_header_read(
+		format, non_blocking, fd, header_size, pstate_ptr, opts);
+	if (res != CCS_RESULT_SUCCESS)
+		return res;
+	return _ccs_object_deserialize_file_descriptor_header_decode(
+		format, non_blocking, header_size, pstate_ptr, opts);
+}
+
 static inline ccs_result_t
 _ccs_object_deserialize_file_descriptor(
 	ccs_object_t          *object_ret,
@@ -917,9 +1126,7 @@ _ccs_object_deserialize_file_descriptor(
 	header_size  = _ccs_serialize_header_size(format);
 	/* non blocking */
 	if (non_blocking) {
-		/* restart */
 		if (*(opts.ppfd_state)) {
-			/* check coherency */
 			CCS_REFUTE(
 				(*(opts.ppfd_state))->fd != fd,
 				CCS_RESULT_ERROR_INVALID_VALUE);
@@ -927,73 +1134,11 @@ _ccs_object_deserialize_file_descriptor(
 		}
 	} else
 		pstate = &state;
-	/* if non blocking start or blocking, allocate buffer for header */
-	if (!pstate || !pstate->base) {
-		offset = 0;
-		if (non_blocking)
-			offset += sizeof(_ccs_file_descriptor_state_t);
-		char *mem = (char *)malloc(offset + header_size);
-		CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		if (non_blocking) {
-			*(opts.ppfd_state) = pstate =
-				(_ccs_file_descriptor_state_t *)mem;
-			pstate->base_size = 0; /* Use zero as header phase
-						  marker */
-		} else
-			pstate->base_size = header_size;
-		pstate->base        = mem;
-		pstate->buffer      = mem + offset;
-		pstate->buffer_size = header_size;
-		pstate->fd          = fd;
-	}
-	/* if blocking or in first phase non blocking, read header to query
-	 * total read size */
-	if (!non_blocking || !pstate->base_size) {
-		size_t object_size;
-		char  *new_buffer;
-		FD_READ_LOOP(pstate, non_blocking);
-		/* rewind */
-		pstate->buffer_size += header_size;
-		pstate->buffer -= header_size;
-		/* decode header */
-		CCS_VALIDATE_ERR_GOTO(
-			res,
-			_ccs_deserialize_header(
-				format, &pstate->buffer_size,
-				(const char **)&pstate->buffer, &object_size,
-				&pstate->version),
-			err_fd_buffer);
-		/* reallocate buffer to account for whole size */
-		if (non_blocking) {
-			size_t new_size = sizeof(_ccs_file_descriptor_state_t) +
-					  object_size;
-			new_buffer = (char *)realloc(pstate->base, new_size);
-			CCS_REFUTE_ERR_GOTO(
-				res, !new_buffer,
-				CCS_RESULT_ERROR_OUT_OF_MEMORY, err_fd_buffer);
-			/* pstate is embedded at the start of the
-			 * allocation — update it after realloc may
-			 * have moved the block. */
-			pstate = (_ccs_file_descriptor_state_t *)new_buffer;
-			*(opts.ppfd_state) = pstate;
-			pstate->base       = new_buffer;
-			pstate->base_size  = new_size;
-		} else {
-			pstate->base_size = object_size;
-			new_buffer        = (char *)realloc(
-                                pstate->base, pstate->base_size);
-			CCS_REFUTE_ERR_GOTO(
-				res, !new_buffer,
-				CCS_RESULT_ERROR_OUT_OF_MEMORY, err_fd_buffer);
-			pstate->base = new_buffer;
-		}
-		/* seek to after the header */
-		offset = header_size;
-		if (non_blocking)
-			offset += sizeof(_ccs_file_descriptor_state_t);
-		pstate->buffer_size = pstate->base_size - offset;
-		pstate->buffer      = pstate->base + offset;
-	}
+	res = _ccs_object_deserialize_file_descriptor_header(
+		format, non_blocking, fd, header_size, &pstate, &opts);
+	if (res == CCS_RESULT_AGAIN)
+		return res;
+	CCS_VALIDATE(res);
 	/* read rest of object */
 	FD_READ_LOOP(pstate, non_blocking);
 	/* rewind to start of buffer (including header) */

--- a/src/cconfigspace_deserialize.h
+++ b/src/cconfigspace_deserialize.h
@@ -211,6 +211,21 @@ _ccs_object_deserialize_with_opts_check(
 			object_ret, format, version, buffer_size, buffer,
 			opts));
 	} break;
+	case CCS_SERIALIZE_FORMAT_JSON: {
+		cJSON *json   = *(cJSON **)buffer;
+		cJSON *j_type = cJSON_GetObjectItemCaseSensitive(json, "type");
+		CCS_REFUTE(
+			!j_type || !cJSON_IsString(j_type),
+			CCS_RESULT_ERROR_INVALID_VALUE);
+		ccs_object_type_t otype;
+		CCS_VALIDATE(_ccs_json_object_type_from_string(
+			j_type->valuestring, &otype));
+		CCS_REFUTE(
+			otype != expected_type, CCS_RESULT_ERROR_INVALID_TYPE);
+		CCS_VALIDATE(_ccs_object_deserialize_with_opts(
+			object_ret, format, version, buffer_size, buffer,
+			opts));
+	} break;
 	default:
 		CCS_RAISE(
 			CCS_RESULT_ERROR_INVALID_VALUE,

--- a/src/cconfigspace_internal.h
+++ b/src/cconfigspace_internal.h
@@ -5,6 +5,17 @@
 #include <stdarg.h>
 #include <pthread.h>
 #include "utarray.h"
+#include "cjson/cJSON.h"
+
+/* Forward declarations — defined in cconfigspace_json.h, included at end */
+static inline const char *
+_ccs_json_object_type_to_string(ccs_object_type_t type);
+static inline ccs_result_t
+_ccs_json_object_type_from_string(const char *str, ccs_object_type_t *type_ret);
+static inline char *
+_ccs_json_hex_encode(const void *data, size_t len);
+static inline unsigned char *
+_ccs_json_hex_decode(const char *hex_str, size_t *out_len);
 
 static inline ccs_bool_t
 _ccs_interval_include(ccs_interval_t *interval, ccs_numeric_t value)
@@ -1329,6 +1340,15 @@ _ccs_serialize_ccs_object_internal(
 		CCS_VALIDATE(_ccs_serialize_bin_ccs_object_internal(
 			obj, buffer_size, buffer));
 	} break;
+	case CCS_SERIALIZE_FORMAT_JSON: {
+		const char *type_str =
+			_ccs_json_object_type_to_string(obj->type);
+		CCS_REFUTE(!type_str, CCS_RESULT_ERROR_INVALID_VALUE);
+		CCS_REFUTE(
+			!cJSON_AddStringToObject(
+				*(cJSON **)buffer, "type", type_str),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	} break;
 	default:
 		CCS_RAISE(
 			CCS_RESULT_ERROR_INVALID_VALUE,
@@ -1393,6 +1413,16 @@ _ccs_deserialize_ccs_object_internal(
 	case CCS_SERIALIZE_FORMAT_BINARY: {
 		CCS_VALIDATE(_ccs_deserialize_bin_ccs_object_internal(
 			obj, buffer_size, buffer, handle_ret));
+	} break;
+	case CCS_SERIALIZE_FORMAT_JSON: {
+		cJSON *json   = *(cJSON **)buffer;
+		cJSON *j_type = cJSON_GetObjectItemCaseSensitive(json, "type");
+		CCS_REFUTE(
+			!j_type || !cJSON_IsString(j_type),
+			CCS_RESULT_ERROR_INVALID_VALUE);
+		CCS_VALIDATE(_ccs_json_object_type_from_string(
+			j_type->valuestring, &obj->type));
+		*handle_ret = NULL;
 	} break;
 	default:
 		CCS_RAISE(
@@ -1495,6 +1525,52 @@ _ccs_object_serialize_user_data(
 		}
 		break;
 	}
+	case CCS_SERIALIZE_FORMAT_JSON: {
+		_ccs_object_internal_t *obj = (_ccs_object_internal_t *)object;
+		size_t                  serialize_data_size = 0;
+		if (obj->user_data) {
+			ccs_object_serialize_callback_t cb =
+				obj->serialize_callback ?
+					obj->serialize_callback :
+					opts->serialize_callback;
+			void *cb_data = obj->serialize_callback ?
+						obj->serialize_user_data :
+						opts->serialize_user_data;
+			if (cb) {
+				CCS_VALIDATE(
+					cb(object, 0, NULL,
+					   &serialize_data_size, cb_data));
+				if (serialize_data_size) {
+					char *tmp = (char *)malloc(
+						serialize_data_size);
+					CCS_REFUTE(
+						!tmp,
+						CCS_RESULT_ERROR_OUT_OF_MEMORY);
+					ccs_result_t err =
+						cb(object, serialize_data_size,
+						   tmp, NULL, cb_data);
+					if (err != CCS_RESULT_SUCCESS) {
+						free(tmp);
+						return err;
+					}
+					char *hex = _ccs_json_hex_encode(
+						tmp, serialize_data_size);
+					free(tmp);
+					CCS_REFUTE(
+						!hex,
+						CCS_RESULT_ERROR_OUT_OF_MEMORY);
+					cJSON *ud = cJSON_AddStringToObject(
+						*(cJSON **)buffer, "user_data",
+						hex);
+					free(hex);
+					CCS_REFUTE(
+						!ud,
+						CCS_RESULT_ERROR_OUT_OF_MEMORY);
+				}
+			}
+		}
+		break;
+	}
 	default:
 		CCS_RAISE(
 			CCS_RESULT_ERROR_INVALID_VALUE,
@@ -1528,6 +1604,24 @@ _ccs_object_deserialize_user_data(
 					opts->deserialize_data_user_data));
 			*buffer_size -= serialize_data_size;
 			*buffer += serialize_data_size;
+		}
+		break;
+	}
+	case CCS_SERIALIZE_FORMAT_JSON: {
+		cJSON *json = *(cJSON **)buffer;
+		cJSON *j_user_data =
+			cJSON_GetObjectItemCaseSensitive(json, "user_data");
+		if (j_user_data && cJSON_IsString(j_user_data) &&
+		    opts->deserialize_data_callback) {
+			size_t         data_len;
+			unsigned char *data_bytes = _ccs_json_hex_decode(
+				j_user_data->valuestring, &data_len);
+			CCS_REFUTE(!data_bytes, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+			ccs_result_t err = opts->deserialize_data_callback(
+				object, data_len, (const char *)data_bytes,
+				opts->deserialize_data_user_data);
+			free(data_bytes);
+			CCS_VALIDATE(err);
 		}
 		break;
 	}
@@ -1574,5 +1668,7 @@ _ccs_object_serialize_with_opts(
 		object, format, buffer_size, buffer, opts));
 	return CCS_RESULT_SUCCESS;
 }
+
+#include "cconfigspace_json.h"
 
 #endif //_CONFIGSPACE_INTERNAL_H

--- a/src/cconfigspace_internal.h
+++ b/src/cconfigspace_internal.h
@@ -1344,10 +1344,15 @@ _ccs_serialize_ccs_object_internal(
 		const char *type_str =
 			_ccs_json_object_type_to_string(obj->type);
 		CCS_REFUTE(!type_str, CCS_RESULT_ERROR_INVALID_VALUE);
+		cJSON *json = *(cJSON **)buffer;
 		CCS_REFUTE(
-			!cJSON_AddStringToObject(
-				*(cJSON **)buffer, "type", type_str),
+			!cJSON_AddStringToObject(json, "type", type_str),
 			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		char *hex = _ccs_json_hex_encode(&obj, sizeof(ccs_object_t));
+		CCS_REFUTE(!hex, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		cJSON *h = cJSON_AddStringToObject(json, "handle", hex);
+		free(hex);
+		CCS_REFUTE(!h, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	} break;
 	default:
 		CCS_RAISE(
@@ -1422,7 +1427,19 @@ _ccs_deserialize_ccs_object_internal(
 			CCS_RESULT_ERROR_INVALID_VALUE);
 		CCS_VALIDATE(_ccs_json_object_type_from_string(
 			j_type->valuestring, &obj->type));
-		*handle_ret = NULL;
+		cJSON *j_handle =
+			cJSON_GetObjectItemCaseSensitive(json, "handle");
+		CCS_REFUTE(
+			!j_handle || !cJSON_IsString(j_handle),
+			CCS_RESULT_ERROR_INVALID_VALUE);
+		size_t         handle_len;
+		unsigned char *handle_bytes = _ccs_json_hex_decode(
+			j_handle->valuestring, &handle_len);
+		CCS_REFUTE(
+			!handle_bytes || handle_len != sizeof(ccs_object_t),
+			CCS_RESULT_ERROR_INVALID_VALUE);
+		memcpy(handle_ret, handle_bytes, sizeof(ccs_object_t));
+		free(handle_bytes);
 	} break;
 	default:
 		CCS_RAISE(

--- a/src/cconfigspace_json.h
+++ b/src/cconfigspace_json.h
@@ -91,4 +91,101 @@ _ccs_json_object_type_from_string(const char *str, ccs_object_type_t *type_ret)
 		"Unknown object type string: %s", str);
 }
 
+/*============================================================================
+ * Distribution type string conversion
+ *============================================================================*/
+
+static const char *_ccs_json_distribution_type_strings[] = {
+	"uniform", "normal", "roulette", "mixture", "multivariate",
+};
+
+static inline const char *
+_ccs_json_distribution_type_to_string(ccs_distribution_type_t type)
+{
+	if (type >= 0 && type < CCS_DISTRIBUTION_TYPE_MAX)
+		return _ccs_json_distribution_type_strings[type];
+	return NULL;
+}
+
+static inline ccs_result_t
+_ccs_json_distribution_type_from_string(
+	const char              *str,
+	ccs_distribution_type_t *type_ret)
+{
+	for (int i = 0; i < CCS_DISTRIBUTION_TYPE_MAX; i++)
+		if (!strcmp(str, _ccs_json_distribution_type_strings[i])) {
+			*type_ret = (ccs_distribution_type_t)i;
+			return CCS_RESULT_SUCCESS;
+		}
+	CCS_RAISE(
+		CCS_RESULT_ERROR_INVALID_VALUE,
+		"Unknown distribution type string: %s", str);
+}
+
+/*============================================================================
+ * Numeric type string conversion
+ *============================================================================*/
+
+static inline const char *
+_ccs_json_numeric_type_to_string(ccs_numeric_type_t type)
+{
+	switch (type) {
+	case CCS_NUMERIC_TYPE_INT:
+		return "int";
+	case CCS_NUMERIC_TYPE_FLOAT:
+		return "float";
+	default:
+		return NULL;
+	}
+}
+
+static inline ccs_result_t
+_ccs_json_numeric_type_from_string(const char *str, ccs_numeric_type_t *type_ret)
+{
+	if (!strcmp(str, "int")) {
+		*type_ret = CCS_NUMERIC_TYPE_INT;
+		return CCS_RESULT_SUCCESS;
+	}
+	if (!strcmp(str, "float")) {
+		*type_ret = CCS_NUMERIC_TYPE_FLOAT;
+		return CCS_RESULT_SUCCESS;
+	}
+	CCS_RAISE(
+		CCS_RESULT_ERROR_INVALID_VALUE,
+		"Unknown numeric type string: %s", str);
+}
+
+/*============================================================================
+ * Scale type string conversion
+ *============================================================================*/
+
+static inline const char *
+_ccs_json_scale_type_to_string(ccs_scale_type_t type)
+{
+	switch (type) {
+	case CCS_SCALE_TYPE_LINEAR:
+		return "linear";
+	case CCS_SCALE_TYPE_LOGARITHMIC:
+		return "logarithmic";
+	default:
+		return NULL;
+	}
+}
+
+static inline ccs_result_t
+_ccs_json_scale_type_from_string(const char *str, ccs_scale_type_t *type_ret)
+{
+	if (!strcmp(str, "linear")) {
+		*type_ret = CCS_SCALE_TYPE_LINEAR;
+		return CCS_RESULT_SUCCESS;
+	}
+	if (!strcmp(str, "logarithmic")) {
+		*type_ret = CCS_SCALE_TYPE_LOGARITHMIC;
+		return CCS_RESULT_SUCCESS;
+	}
+	CCS_RAISE(
+		CCS_RESULT_ERROR_INVALID_VALUE, "Unknown scale type string: %s",
+		str);
+}
+
 #endif /* _CCONFIGSPACE_JSON_H */

--- a/src/cconfigspace_json.h
+++ b/src/cconfigspace_json.h
@@ -1,0 +1,94 @@
+#ifndef _CCONFIGSPACE_JSON_H
+#define _CCONFIGSPACE_JSON_H
+#include "cjson/cJSON.h"
+#include <string.h>
+
+/*============================================================================
+ * Hex encode/decode helpers
+ *============================================================================*/
+
+static inline char *
+_ccs_json_hex_encode(const void *data, size_t len)
+{
+	static const char hex[] = "0123456789abcdef";
+	char             *out   = (char *)malloc(len * 2 + 1);
+	if (!out)
+		return NULL;
+	const unsigned char *p = (const unsigned char *)data;
+	for (size_t i = 0; i < len; i++) {
+		out[i * 2]     = hex[p[i] >> 4];
+		out[i * 2 + 1] = hex[p[i] & 0x0f];
+	}
+	out[len * 2] = '\0';
+	return out;
+}
+
+static inline unsigned char *
+_ccs_json_hex_decode(const char *hex_str, size_t *out_len)
+{
+	size_t         slen = strlen(hex_str);
+	unsigned char *out;
+	if (slen % 2 != 0)
+		return NULL;
+	*out_len = slen / 2;
+	out      = (unsigned char *)malloc(*out_len);
+	if (!out)
+		return NULL;
+	for (size_t i = 0; i < *out_len; i++) {
+		unsigned int byte;
+		char tmp[3] = {hex_str[i * 2], hex_str[i * 2 + 1], '\0'};
+		if (sscanf(tmp, "%02x", &byte) != 1) {
+			free(out);
+			return NULL;
+		}
+		out[i] = (unsigned char)byte;
+	}
+	return out;
+}
+
+/*============================================================================
+ * Object type string conversion
+ *============================================================================*/
+
+static const char *_ccs_json_object_type_strings[] = {
+	"rng",
+	"distribution",
+	"parameter",
+	"expression",
+	"configuration_space",
+	"configuration",
+	"objective_space",
+	"evaluation",
+	"tuner",
+	"feature_space",
+	"features",
+	"map",
+	"error_stack",
+	"tree",
+	"tree_space",
+	"tree_configuration",
+	"distribution_space",
+};
+
+static inline const char *
+_ccs_json_object_type_to_string(ccs_object_type_t type)
+{
+	if (type >= 0 && type < CCS_OBJECT_TYPE_MAX)
+		return _ccs_json_object_type_strings[type];
+	return NULL;
+}
+
+static inline ccs_result_t
+_ccs_json_object_type_from_string(const char *str, ccs_object_type_t *type_ret)
+{
+	for (int i = 0; i < CCS_OBJECT_TYPE_MAX; i++)
+		if (!strcmp(str, _ccs_json_object_type_strings[i])) {
+			*type_ret = (ccs_object_type_t)i;
+			return CCS_RESULT_SUCCESS;
+		}
+	CCS_RAISE(
+		CCS_RESULT_ERROR_INVALID_VALUE,
+		"Unknown object type string: %s", str);
+}
+
+#endif /* _CCONFIGSPACE_JSON_H */

--- a/src/cjson/LICENSE
+++ b/src/cjson/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2009-2017 Dave Gamble and cJSON contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+

--- a/src/cjson/Makefile.am
+++ b/src/cjson/Makefile.am
@@ -1,0 +1,11 @@
+noinst_LTLIBRARIES = libcjson.la
+
+libcjson_la_SOURCES = \
+	cJSON.c \
+	cJSON.h
+
+# Suppress warnings for vendored code — cJSON is C89 and may trigger
+# warnings under CCS's -Wpedantic / -Werror flags
+AM_CFLAGS = -w
+
+EXTRA_DIST = LICENSE

--- a/src/cjson/cJSON.c
+++ b/src/cjson/cJSON.c
@@ -1,0 +1,3143 @@
+/*
+  Copyright (c) 2009-2017 Dave Gamble and cJSON contributors
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+
+/* cJSON */
+/* JSON parser in C. */
+
+/* disable warnings about old C89 functions in MSVC */
+#if !defined(_CRT_SECURE_NO_DEPRECATE) && defined(_MSC_VER)
+#define _CRT_SECURE_NO_DEPRECATE
+#endif
+
+#ifdef __GNUC__
+#pragma GCC visibility push(default)
+#endif
+#if defined(_MSC_VER)
+#pragma warning (push)
+/* disable warning about single line comments in system headers */
+#pragma warning (disable : 4001)
+#endif
+
+#include <string.h>
+#include <stdio.h>
+#include <math.h>
+#include <stdlib.h>
+#include <limits.h>
+#include <ctype.h>
+#include <float.h>
+
+#ifdef ENABLE_LOCALES
+#include <locale.h>
+#endif
+
+#if defined(_MSC_VER)
+#pragma warning (pop)
+#endif
+#ifdef __GNUC__
+#pragma GCC visibility pop
+#endif
+
+#include "cJSON.h"
+
+/* define our own boolean type */
+#ifdef true
+#undef true
+#endif
+#define true ((cJSON_bool)1)
+
+#ifdef false
+#undef false
+#endif
+#define false ((cJSON_bool)0)
+
+/* define isnan and isinf for ANSI C, if in C99 or above, isnan and isinf has been defined in math.h */
+#ifndef isinf
+#define isinf(d) (isnan((d - d)) && !isnan(d))
+#endif
+#ifndef isnan
+#define isnan(d) (d != d)
+#endif
+
+#ifndef NAN
+#ifdef _WIN32
+#define NAN sqrt(-1.0)
+#else
+#define NAN 0.0/0.0
+#endif
+#endif
+
+typedef struct {
+    const unsigned char *json;
+    size_t position;
+} error;
+static error global_error = { NULL, 0 };
+
+CJSON_PUBLIC(const char *) cJSON_GetErrorPtr(void)
+{
+    return (const char*) (global_error.json + global_error.position);
+}
+
+CJSON_PUBLIC(char *) cJSON_GetStringValue(const cJSON * const item)
+{
+    if (!cJSON_IsString(item))
+    {
+        return NULL;
+    }
+
+    return item->valuestring;
+}
+
+CJSON_PUBLIC(double) cJSON_GetNumberValue(const cJSON * const item)
+{
+    if (!cJSON_IsNumber(item))
+    {
+        return (double) NAN;
+    }
+
+    return item->valuedouble;
+}
+
+/* This is a safeguard to prevent copy-pasters from using incompatible C and header files */
+#if (CJSON_VERSION_MAJOR != 1) || (CJSON_VERSION_MINOR != 7) || (CJSON_VERSION_PATCH != 18)
+    #error cJSON.h and cJSON.c have different versions. Make sure that both have the same.
+#endif
+
+CJSON_PUBLIC(const char*) cJSON_Version(void)
+{
+    static char version[15];
+    sprintf(version, "%i.%i.%i", CJSON_VERSION_MAJOR, CJSON_VERSION_MINOR, CJSON_VERSION_PATCH);
+
+    return version;
+}
+
+/* Case insensitive string comparison, doesn't consider two NULL pointers equal though */
+static int case_insensitive_strcmp(const unsigned char *string1, const unsigned char *string2)
+{
+    if ((string1 == NULL) || (string2 == NULL))
+    {
+        return 1;
+    }
+
+    if (string1 == string2)
+    {
+        return 0;
+    }
+
+    for(; tolower(*string1) == tolower(*string2); (void)string1++, string2++)
+    {
+        if (*string1 == '\0')
+        {
+            return 0;
+        }
+    }
+
+    return tolower(*string1) - tolower(*string2);
+}
+
+typedef struct internal_hooks
+{
+    void *(CJSON_CDECL *allocate)(size_t size);
+    void (CJSON_CDECL *deallocate)(void *pointer);
+    void *(CJSON_CDECL *reallocate)(void *pointer, size_t size);
+} internal_hooks;
+
+#if defined(_MSC_VER)
+/* work around MSVC error C2322: '...' address of dllimport '...' is not static */
+static void * CJSON_CDECL internal_malloc(size_t size)
+{
+    return malloc(size);
+}
+static void CJSON_CDECL internal_free(void *pointer)
+{
+    free(pointer);
+}
+static void * CJSON_CDECL internal_realloc(void *pointer, size_t size)
+{
+    return realloc(pointer, size);
+}
+#else
+#define internal_malloc malloc
+#define internal_free free
+#define internal_realloc realloc
+#endif
+
+/* strlen of character literals resolved at compile time */
+#define static_strlen(string_literal) (sizeof(string_literal) - sizeof(""))
+
+static internal_hooks global_hooks = { internal_malloc, internal_free, internal_realloc };
+
+static unsigned char* cJSON_strdup(const unsigned char* string, const internal_hooks * const hooks)
+{
+    size_t length = 0;
+    unsigned char *copy = NULL;
+
+    if (string == NULL)
+    {
+        return NULL;
+    }
+
+    length = strlen((const char*)string) + sizeof("");
+    copy = (unsigned char*)hooks->allocate(length);
+    if (copy == NULL)
+    {
+        return NULL;
+    }
+    memcpy(copy, string, length);
+
+    return copy;
+}
+
+CJSON_PUBLIC(void) cJSON_InitHooks(cJSON_Hooks* hooks)
+{
+    if (hooks == NULL)
+    {
+        /* Reset hooks */
+        global_hooks.allocate = malloc;
+        global_hooks.deallocate = free;
+        global_hooks.reallocate = realloc;
+        return;
+    }
+
+    global_hooks.allocate = malloc;
+    if (hooks->malloc_fn != NULL)
+    {
+        global_hooks.allocate = hooks->malloc_fn;
+    }
+
+    global_hooks.deallocate = free;
+    if (hooks->free_fn != NULL)
+    {
+        global_hooks.deallocate = hooks->free_fn;
+    }
+
+    /* use realloc only if both free and malloc are used */
+    global_hooks.reallocate = NULL;
+    if ((global_hooks.allocate == malloc) && (global_hooks.deallocate == free))
+    {
+        global_hooks.reallocate = realloc;
+    }
+}
+
+/* Internal constructor. */
+static cJSON *cJSON_New_Item(const internal_hooks * const hooks)
+{
+    cJSON* node = (cJSON*)hooks->allocate(sizeof(cJSON));
+    if (node)
+    {
+        memset(node, '\0', sizeof(cJSON));
+    }
+
+    return node;
+}
+
+/* Delete a cJSON structure. */
+CJSON_PUBLIC(void) cJSON_Delete(cJSON *item)
+{
+    cJSON *next = NULL;
+    while (item != NULL)
+    {
+        next = item->next;
+        if (!(item->type & cJSON_IsReference) && (item->child != NULL))
+        {
+            cJSON_Delete(item->child);
+        }
+        if (!(item->type & cJSON_IsReference) && (item->valuestring != NULL))
+        {
+            global_hooks.deallocate(item->valuestring);
+            item->valuestring = NULL;
+        }
+        if (!(item->type & cJSON_StringIsConst) && (item->string != NULL))
+        {
+            global_hooks.deallocate(item->string);
+            item->string = NULL;
+        }
+        global_hooks.deallocate(item);
+        item = next;
+    }
+}
+
+/* get the decimal point character of the current locale */
+static unsigned char get_decimal_point(void)
+{
+#ifdef ENABLE_LOCALES
+    struct lconv *lconv = localeconv();
+    return (unsigned char) lconv->decimal_point[0];
+#else
+    return '.';
+#endif
+}
+
+typedef struct
+{
+    const unsigned char *content;
+    size_t length;
+    size_t offset;
+    size_t depth; /* How deeply nested (in arrays/objects) is the input at the current offset. */
+    internal_hooks hooks;
+} parse_buffer;
+
+/* check if the given size is left to read in a given parse buffer (starting with 1) */
+#define can_read(buffer, size) ((buffer != NULL) && (((buffer)->offset + size) <= (buffer)->length))
+/* check if the buffer can be accessed at the given index (starting with 0) */
+#define can_access_at_index(buffer, index) ((buffer != NULL) && (((buffer)->offset + index) < (buffer)->length))
+#define cannot_access_at_index(buffer, index) (!can_access_at_index(buffer, index))
+/* get a pointer to the buffer at the position */
+#define buffer_at_offset(buffer) ((buffer)->content + (buffer)->offset)
+
+/* Parse the input text to generate a number, and populate the result into item. */
+static cJSON_bool parse_number(cJSON * const item, parse_buffer * const input_buffer)
+{
+    double number = 0;
+    unsigned char *after_end = NULL;
+    unsigned char number_c_string[64];
+    unsigned char decimal_point = get_decimal_point();
+    size_t i = 0;
+
+    if ((input_buffer == NULL) || (input_buffer->content == NULL))
+    {
+        return false;
+    }
+
+    /* copy the number into a temporary buffer and replace '.' with the decimal point
+     * of the current locale (for strtod)
+     * This also takes care of '\0' not necessarily being available for marking the end of the input */
+    for (i = 0; (i < (sizeof(number_c_string) - 1)) && can_access_at_index(input_buffer, i); i++)
+    {
+        switch (buffer_at_offset(input_buffer)[i])
+        {
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+            case '+':
+            case '-':
+            case 'e':
+            case 'E':
+                number_c_string[i] = buffer_at_offset(input_buffer)[i];
+                break;
+
+            case '.':
+                number_c_string[i] = decimal_point;
+                break;
+
+            default:
+                goto loop_end;
+        }
+    }
+loop_end:
+    number_c_string[i] = '\0';
+
+    number = strtod((const char*)number_c_string, (char**)&after_end);
+    if (number_c_string == after_end)
+    {
+        return false; /* parse_error */
+    }
+
+    item->valuedouble = number;
+
+    /* use saturation in case of overflow */
+    if (number >= INT_MAX)
+    {
+        item->valueint = INT_MAX;
+    }
+    else if (number <= (double)INT_MIN)
+    {
+        item->valueint = INT_MIN;
+    }
+    else
+    {
+        item->valueint = (int)number;
+    }
+
+    item->type = cJSON_Number;
+
+    input_buffer->offset += (size_t)(after_end - number_c_string);
+    return true;
+}
+
+/* don't ask me, but the original cJSON_SetNumberValue returns an integer or double */
+CJSON_PUBLIC(double) cJSON_SetNumberHelper(cJSON *object, double number)
+{
+    if (number >= INT_MAX)
+    {
+        object->valueint = INT_MAX;
+    }
+    else if (number <= (double)INT_MIN)
+    {
+        object->valueint = INT_MIN;
+    }
+    else
+    {
+        object->valueint = (int)number;
+    }
+
+    return object->valuedouble = number;
+}
+
+/* Note: when passing a NULL valuestring, cJSON_SetValuestring treats this as an error and return NULL */
+CJSON_PUBLIC(char*) cJSON_SetValuestring(cJSON *object, const char *valuestring)
+{
+    char *copy = NULL;
+    /* if object's type is not cJSON_String or is cJSON_IsReference, it should not set valuestring */
+    if ((object == NULL) || !(object->type & cJSON_String) || (object->type & cJSON_IsReference))
+    {
+        return NULL;
+    }
+    /* return NULL if the object is corrupted or valuestring is NULL */
+    if (object->valuestring == NULL || valuestring == NULL)
+    {
+        return NULL;
+    }
+    if (strlen(valuestring) <= strlen(object->valuestring))
+    {
+        strcpy(object->valuestring, valuestring);
+        return object->valuestring;
+    }
+    copy = (char*) cJSON_strdup((const unsigned char*)valuestring, &global_hooks);
+    if (copy == NULL)
+    {
+        return NULL;
+    }
+    if (object->valuestring != NULL)
+    {
+        cJSON_free(object->valuestring);
+    }
+    object->valuestring = copy;
+
+    return copy;
+}
+
+typedef struct
+{
+    unsigned char *buffer;
+    size_t length;
+    size_t offset;
+    size_t depth; /* current nesting depth (for formatted printing) */
+    cJSON_bool noalloc;
+    cJSON_bool format; /* is this print a formatted print */
+    internal_hooks hooks;
+} printbuffer;
+
+/* realloc printbuffer if necessary to have at least "needed" bytes more */
+static unsigned char* ensure(printbuffer * const p, size_t needed)
+{
+    unsigned char *newbuffer = NULL;
+    size_t newsize = 0;
+
+    if ((p == NULL) || (p->buffer == NULL))
+    {
+        return NULL;
+    }
+
+    if ((p->length > 0) && (p->offset >= p->length))
+    {
+        /* make sure that offset is valid */
+        return NULL;
+    }
+
+    if (needed > INT_MAX)
+    {
+        /* sizes bigger than INT_MAX are currently not supported */
+        return NULL;
+    }
+
+    needed += p->offset + 1;
+    if (needed <= p->length)
+    {
+        return p->buffer + p->offset;
+    }
+
+    if (p->noalloc) {
+        return NULL;
+    }
+
+    /* calculate new buffer size */
+    if (needed > (INT_MAX / 2))
+    {
+        /* overflow of int, use INT_MAX if possible */
+        if (needed <= INT_MAX)
+        {
+            newsize = INT_MAX;
+        }
+        else
+        {
+            return NULL;
+        }
+    }
+    else
+    {
+        newsize = needed * 2;
+    }
+
+    if (p->hooks.reallocate != NULL)
+    {
+        /* reallocate with realloc if available */
+        newbuffer = (unsigned char*)p->hooks.reallocate(p->buffer, newsize);
+        if (newbuffer == NULL)
+        {
+            p->hooks.deallocate(p->buffer);
+            p->length = 0;
+            p->buffer = NULL;
+
+            return NULL;
+        }
+    }
+    else
+    {
+        /* otherwise reallocate manually */
+        newbuffer = (unsigned char*)p->hooks.allocate(newsize);
+        if (!newbuffer)
+        {
+            p->hooks.deallocate(p->buffer);
+            p->length = 0;
+            p->buffer = NULL;
+
+            return NULL;
+        }
+
+        memcpy(newbuffer, p->buffer, p->offset + 1);
+        p->hooks.deallocate(p->buffer);
+    }
+    p->length = newsize;
+    p->buffer = newbuffer;
+
+    return newbuffer + p->offset;
+}
+
+/* calculate the new length of the string in a printbuffer and update the offset */
+static void update_offset(printbuffer * const buffer)
+{
+    const unsigned char *buffer_pointer = NULL;
+    if ((buffer == NULL) || (buffer->buffer == NULL))
+    {
+        return;
+    }
+    buffer_pointer = buffer->buffer + buffer->offset;
+
+    buffer->offset += strlen((const char*)buffer_pointer);
+}
+
+/* securely comparison of floating-point variables */
+static cJSON_bool compare_double(double a, double b)
+{
+    double maxVal = fabs(a) > fabs(b) ? fabs(a) : fabs(b);
+    return (fabs(a - b) <= maxVal * DBL_EPSILON);
+}
+
+/* Render the number nicely from the given item into a string. */
+static cJSON_bool print_number(const cJSON * const item, printbuffer * const output_buffer)
+{
+    unsigned char *output_pointer = NULL;
+    double d = item->valuedouble;
+    int length = 0;
+    size_t i = 0;
+    unsigned char number_buffer[26] = {0}; /* temporary buffer to print the number into */
+    unsigned char decimal_point = get_decimal_point();
+    double test = 0.0;
+
+    if (output_buffer == NULL)
+    {
+        return false;
+    }
+
+    /* This checks for NaN and Infinity */
+    if (isnan(d) || isinf(d))
+    {
+        length = sprintf((char*)number_buffer, "null");
+    }
+	else if(d == (double)item->valueint)
+	{
+		length = sprintf((char*)number_buffer, "%d", item->valueint);
+	}
+    else
+    {
+        /* Try 15 decimal places of precision to avoid nonsignificant nonzero digits */
+        length = sprintf((char*)number_buffer, "%1.15g", d);
+
+        /* Check whether the original double can be recovered */
+        if ((sscanf((char*)number_buffer, "%lg", &test) != 1) || !compare_double((double)test, d))
+        {
+            /* If not, print with 17 decimal places of precision */
+            length = sprintf((char*)number_buffer, "%1.17g", d);
+        }
+    }
+
+    /* sprintf failed or buffer overrun occurred */
+    if ((length < 0) || (length > (int)(sizeof(number_buffer) - 1)))
+    {
+        return false;
+    }
+
+    /* reserve appropriate space in the output */
+    output_pointer = ensure(output_buffer, (size_t)length + sizeof(""));
+    if (output_pointer == NULL)
+    {
+        return false;
+    }
+
+    /* copy the printed number to the output and replace locale
+     * dependent decimal point with '.' */
+    for (i = 0; i < ((size_t)length); i++)
+    {
+        if (number_buffer[i] == decimal_point)
+        {
+            output_pointer[i] = '.';
+            continue;
+        }
+
+        output_pointer[i] = number_buffer[i];
+    }
+    output_pointer[i] = '\0';
+
+    output_buffer->offset += (size_t)length;
+
+    return true;
+}
+
+/* parse 4 digit hexadecimal number */
+static unsigned parse_hex4(const unsigned char * const input)
+{
+    unsigned int h = 0;
+    size_t i = 0;
+
+    for (i = 0; i < 4; i++)
+    {
+        /* parse digit */
+        if ((input[i] >= '0') && (input[i] <= '9'))
+        {
+            h += (unsigned int) input[i] - '0';
+        }
+        else if ((input[i] >= 'A') && (input[i] <= 'F'))
+        {
+            h += (unsigned int) 10 + input[i] - 'A';
+        }
+        else if ((input[i] >= 'a') && (input[i] <= 'f'))
+        {
+            h += (unsigned int) 10 + input[i] - 'a';
+        }
+        else /* invalid */
+        {
+            return 0;
+        }
+
+        if (i < 3)
+        {
+            /* shift left to make place for the next nibble */
+            h = h << 4;
+        }
+    }
+
+    return h;
+}
+
+/* converts a UTF-16 literal to UTF-8
+ * A literal can be one or two sequences of the form \uXXXX */
+static unsigned char utf16_literal_to_utf8(const unsigned char * const input_pointer, const unsigned char * const input_end, unsigned char **output_pointer)
+{
+    long unsigned int codepoint = 0;
+    unsigned int first_code = 0;
+    const unsigned char *first_sequence = input_pointer;
+    unsigned char utf8_length = 0;
+    unsigned char utf8_position = 0;
+    unsigned char sequence_length = 0;
+    unsigned char first_byte_mark = 0;
+
+    if ((input_end - first_sequence) < 6)
+    {
+        /* input ends unexpectedly */
+        goto fail;
+    }
+
+    /* get the first utf16 sequence */
+    first_code = parse_hex4(first_sequence + 2);
+
+    /* check that the code is valid */
+    if (((first_code >= 0xDC00) && (first_code <= 0xDFFF)))
+    {
+        goto fail;
+    }
+
+    /* UTF16 surrogate pair */
+    if ((first_code >= 0xD800) && (first_code <= 0xDBFF))
+    {
+        const unsigned char *second_sequence = first_sequence + 6;
+        unsigned int second_code = 0;
+        sequence_length = 12; /* \uXXXX\uXXXX */
+
+        if ((input_end - second_sequence) < 6)
+        {
+            /* input ends unexpectedly */
+            goto fail;
+        }
+
+        if ((second_sequence[0] != '\\') || (second_sequence[1] != 'u'))
+        {
+            /* missing second half of the surrogate pair */
+            goto fail;
+        }
+
+        /* get the second utf16 sequence */
+        second_code = parse_hex4(second_sequence + 2);
+        /* check that the code is valid */
+        if ((second_code < 0xDC00) || (second_code > 0xDFFF))
+        {
+            /* invalid second half of the surrogate pair */
+            goto fail;
+        }
+
+
+        /* calculate the unicode codepoint from the surrogate pair */
+        codepoint = 0x10000 + (((first_code & 0x3FF) << 10) | (second_code & 0x3FF));
+    }
+    else
+    {
+        sequence_length = 6; /* \uXXXX */
+        codepoint = first_code;
+    }
+
+    /* encode as UTF-8
+     * takes at maximum 4 bytes to encode:
+     * 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx */
+    if (codepoint < 0x80)
+    {
+        /* normal ascii, encoding 0xxxxxxx */
+        utf8_length = 1;
+    }
+    else if (codepoint < 0x800)
+    {
+        /* two bytes, encoding 110xxxxx 10xxxxxx */
+        utf8_length = 2;
+        first_byte_mark = 0xC0; /* 11000000 */
+    }
+    else if (codepoint < 0x10000)
+    {
+        /* three bytes, encoding 1110xxxx 10xxxxxx 10xxxxxx */
+        utf8_length = 3;
+        first_byte_mark = 0xE0; /* 11100000 */
+    }
+    else if (codepoint <= 0x10FFFF)
+    {
+        /* four bytes, encoding 1110xxxx 10xxxxxx 10xxxxxx 10xxxxxx */
+        utf8_length = 4;
+        first_byte_mark = 0xF0; /* 11110000 */
+    }
+    else
+    {
+        /* invalid unicode codepoint */
+        goto fail;
+    }
+
+    /* encode as utf8 */
+    for (utf8_position = (unsigned char)(utf8_length - 1); utf8_position > 0; utf8_position--)
+    {
+        /* 10xxxxxx */
+        (*output_pointer)[utf8_position] = (unsigned char)((codepoint | 0x80) & 0xBF);
+        codepoint >>= 6;
+    }
+    /* encode first byte */
+    if (utf8_length > 1)
+    {
+        (*output_pointer)[0] = (unsigned char)((codepoint | first_byte_mark) & 0xFF);
+    }
+    else
+    {
+        (*output_pointer)[0] = (unsigned char)(codepoint & 0x7F);
+    }
+
+    *output_pointer += utf8_length;
+
+    return sequence_length;
+
+fail:
+    return 0;
+}
+
+/* Parse the input text into an unescaped cinput, and populate item. */
+static cJSON_bool parse_string(cJSON * const item, parse_buffer * const input_buffer)
+{
+    const unsigned char *input_pointer = buffer_at_offset(input_buffer) + 1;
+    const unsigned char *input_end = buffer_at_offset(input_buffer) + 1;
+    unsigned char *output_pointer = NULL;
+    unsigned char *output = NULL;
+
+    /* not a string */
+    if (buffer_at_offset(input_buffer)[0] != '\"')
+    {
+        goto fail;
+    }
+
+    {
+        /* calculate approximate size of the output (overestimate) */
+        size_t allocation_length = 0;
+        size_t skipped_bytes = 0;
+        while (((size_t)(input_end - input_buffer->content) < input_buffer->length) && (*input_end != '\"'))
+        {
+            /* is escape sequence */
+            if (input_end[0] == '\\')
+            {
+                if ((size_t)(input_end + 1 - input_buffer->content) >= input_buffer->length)
+                {
+                    /* prevent buffer overflow when last input character is a backslash */
+                    goto fail;
+                }
+                skipped_bytes++;
+                input_end++;
+            }
+            input_end++;
+        }
+        if (((size_t)(input_end - input_buffer->content) >= input_buffer->length) || (*input_end != '\"'))
+        {
+            goto fail; /* string ended unexpectedly */
+        }
+
+        /* This is at most how much we need for the output */
+        allocation_length = (size_t) (input_end - buffer_at_offset(input_buffer)) - skipped_bytes;
+        output = (unsigned char*)input_buffer->hooks.allocate(allocation_length + sizeof(""));
+        if (output == NULL)
+        {
+            goto fail; /* allocation failure */
+        }
+    }
+
+    output_pointer = output;
+    /* loop through the string literal */
+    while (input_pointer < input_end)
+    {
+        if (*input_pointer != '\\')
+        {
+            *output_pointer++ = *input_pointer++;
+        }
+        /* escape sequence */
+        else
+        {
+            unsigned char sequence_length = 2;
+            if ((input_end - input_pointer) < 1)
+            {
+                goto fail;
+            }
+
+            switch (input_pointer[1])
+            {
+                case 'b':
+                    *output_pointer++ = '\b';
+                    break;
+                case 'f':
+                    *output_pointer++ = '\f';
+                    break;
+                case 'n':
+                    *output_pointer++ = '\n';
+                    break;
+                case 'r':
+                    *output_pointer++ = '\r';
+                    break;
+                case 't':
+                    *output_pointer++ = '\t';
+                    break;
+                case '\"':
+                case '\\':
+                case '/':
+                    *output_pointer++ = input_pointer[1];
+                    break;
+
+                /* UTF-16 literal */
+                case 'u':
+                    sequence_length = utf16_literal_to_utf8(input_pointer, input_end, &output_pointer);
+                    if (sequence_length == 0)
+                    {
+                        /* failed to convert UTF16-literal to UTF-8 */
+                        goto fail;
+                    }
+                    break;
+
+                default:
+                    goto fail;
+            }
+            input_pointer += sequence_length;
+        }
+    }
+
+    /* zero terminate the output */
+    *output_pointer = '\0';
+
+    item->type = cJSON_String;
+    item->valuestring = (char*)output;
+
+    input_buffer->offset = (size_t) (input_end - input_buffer->content);
+    input_buffer->offset++;
+
+    return true;
+
+fail:
+    if (output != NULL)
+    {
+        input_buffer->hooks.deallocate(output);
+        output = NULL;
+    }
+
+    if (input_pointer != NULL)
+    {
+        input_buffer->offset = (size_t)(input_pointer - input_buffer->content);
+    }
+
+    return false;
+}
+
+/* Render the cstring provided to an escaped version that can be printed. */
+static cJSON_bool print_string_ptr(const unsigned char * const input, printbuffer * const output_buffer)
+{
+    const unsigned char *input_pointer = NULL;
+    unsigned char *output = NULL;
+    unsigned char *output_pointer = NULL;
+    size_t output_length = 0;
+    /* numbers of additional characters needed for escaping */
+    size_t escape_characters = 0;
+
+    if (output_buffer == NULL)
+    {
+        return false;
+    }
+
+    /* empty string */
+    if (input == NULL)
+    {
+        output = ensure(output_buffer, sizeof("\"\""));
+        if (output == NULL)
+        {
+            return false;
+        }
+        strcpy((char*)output, "\"\"");
+
+        return true;
+    }
+
+    /* set "flag" to 1 if something needs to be escaped */
+    for (input_pointer = input; *input_pointer; input_pointer++)
+    {
+        switch (*input_pointer)
+        {
+            case '\"':
+            case '\\':
+            case '\b':
+            case '\f':
+            case '\n':
+            case '\r':
+            case '\t':
+                /* one character escape sequence */
+                escape_characters++;
+                break;
+            default:
+                if (*input_pointer < 32)
+                {
+                    /* UTF-16 escape sequence uXXXX */
+                    escape_characters += 5;
+                }
+                break;
+        }
+    }
+    output_length = (size_t)(input_pointer - input) + escape_characters;
+
+    output = ensure(output_buffer, output_length + sizeof("\"\""));
+    if (output == NULL)
+    {
+        return false;
+    }
+
+    /* no characters have to be escaped */
+    if (escape_characters == 0)
+    {
+        output[0] = '\"';
+        memcpy(output + 1, input, output_length);
+        output[output_length + 1] = '\"';
+        output[output_length + 2] = '\0';
+
+        return true;
+    }
+
+    output[0] = '\"';
+    output_pointer = output + 1;
+    /* copy the string */
+    for (input_pointer = input; *input_pointer != '\0'; (void)input_pointer++, output_pointer++)
+    {
+        if ((*input_pointer > 31) && (*input_pointer != '\"') && (*input_pointer != '\\'))
+        {
+            /* normal character, copy */
+            *output_pointer = *input_pointer;
+        }
+        else
+        {
+            /* character needs to be escaped */
+            *output_pointer++ = '\\';
+            switch (*input_pointer)
+            {
+                case '\\':
+                    *output_pointer = '\\';
+                    break;
+                case '\"':
+                    *output_pointer = '\"';
+                    break;
+                case '\b':
+                    *output_pointer = 'b';
+                    break;
+                case '\f':
+                    *output_pointer = 'f';
+                    break;
+                case '\n':
+                    *output_pointer = 'n';
+                    break;
+                case '\r':
+                    *output_pointer = 'r';
+                    break;
+                case '\t':
+                    *output_pointer = 't';
+                    break;
+                default:
+                    /* escape and print as unicode codepoint */
+                    sprintf((char*)output_pointer, "u%04x", *input_pointer);
+                    output_pointer += 4;
+                    break;
+            }
+        }
+    }
+    output[output_length + 1] = '\"';
+    output[output_length + 2] = '\0';
+
+    return true;
+}
+
+/* Invoke print_string_ptr (which is useful) on an item. */
+static cJSON_bool print_string(const cJSON * const item, printbuffer * const p)
+{
+    return print_string_ptr((unsigned char*)item->valuestring, p);
+}
+
+/* Predeclare these prototypes. */
+static cJSON_bool parse_value(cJSON * const item, parse_buffer * const input_buffer);
+static cJSON_bool print_value(const cJSON * const item, printbuffer * const output_buffer);
+static cJSON_bool parse_array(cJSON * const item, parse_buffer * const input_buffer);
+static cJSON_bool print_array(const cJSON * const item, printbuffer * const output_buffer);
+static cJSON_bool parse_object(cJSON * const item, parse_buffer * const input_buffer);
+static cJSON_bool print_object(const cJSON * const item, printbuffer * const output_buffer);
+
+/* Utility to jump whitespace and cr/lf */
+static parse_buffer *buffer_skip_whitespace(parse_buffer * const buffer)
+{
+    if ((buffer == NULL) || (buffer->content == NULL))
+    {
+        return NULL;
+    }
+
+    if (cannot_access_at_index(buffer, 0))
+    {
+        return buffer;
+    }
+
+    while (can_access_at_index(buffer, 0) && (buffer_at_offset(buffer)[0] <= 32))
+    {
+       buffer->offset++;
+    }
+
+    if (buffer->offset == buffer->length)
+    {
+        buffer->offset--;
+    }
+
+    return buffer;
+}
+
+/* skip the UTF-8 BOM (byte order mark) if it is at the beginning of a buffer */
+static parse_buffer *skip_utf8_bom(parse_buffer * const buffer)
+{
+    if ((buffer == NULL) || (buffer->content == NULL) || (buffer->offset != 0))
+    {
+        return NULL;
+    }
+
+    if (can_access_at_index(buffer, 4) && (strncmp((const char*)buffer_at_offset(buffer), "\xEF\xBB\xBF", 3) == 0))
+    {
+        buffer->offset += 3;
+    }
+
+    return buffer;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_ParseWithOpts(const char *value, const char **return_parse_end, cJSON_bool require_null_terminated)
+{
+    size_t buffer_length;
+
+    if (NULL == value)
+    {
+        return NULL;
+    }
+
+    /* Adding null character size due to require_null_terminated. */
+    buffer_length = strlen(value) + sizeof("");
+
+    return cJSON_ParseWithLengthOpts(value, buffer_length, return_parse_end, require_null_terminated);
+}
+
+/* Parse an object - create a new root, and populate. */
+CJSON_PUBLIC(cJSON *) cJSON_ParseWithLengthOpts(const char *value, size_t buffer_length, const char **return_parse_end, cJSON_bool require_null_terminated)
+{
+    parse_buffer buffer = { 0, 0, 0, 0, { 0, 0, 0 } };
+    cJSON *item = NULL;
+
+    /* reset error position */
+    global_error.json = NULL;
+    global_error.position = 0;
+
+    if (value == NULL || 0 == buffer_length)
+    {
+        goto fail;
+    }
+
+    buffer.content = (const unsigned char*)value;
+    buffer.length = buffer_length;
+    buffer.offset = 0;
+    buffer.hooks = global_hooks;
+
+    item = cJSON_New_Item(&global_hooks);
+    if (item == NULL) /* memory fail */
+    {
+        goto fail;
+    }
+
+    if (!parse_value(item, buffer_skip_whitespace(skip_utf8_bom(&buffer))))
+    {
+        /* parse failure. ep is set. */
+        goto fail;
+    }
+
+    /* if we require null-terminated JSON without appended garbage, skip and then check for a null terminator */
+    if (require_null_terminated)
+    {
+        buffer_skip_whitespace(&buffer);
+        if ((buffer.offset >= buffer.length) || buffer_at_offset(&buffer)[0] != '\0')
+        {
+            goto fail;
+        }
+    }
+    if (return_parse_end)
+    {
+        *return_parse_end = (const char*)buffer_at_offset(&buffer);
+    }
+
+    return item;
+
+fail:
+    if (item != NULL)
+    {
+        cJSON_Delete(item);
+    }
+
+    if (value != NULL)
+    {
+        error local_error;
+        local_error.json = (const unsigned char*)value;
+        local_error.position = 0;
+
+        if (buffer.offset < buffer.length)
+        {
+            local_error.position = buffer.offset;
+        }
+        else if (buffer.length > 0)
+        {
+            local_error.position = buffer.length - 1;
+        }
+
+        if (return_parse_end != NULL)
+        {
+            *return_parse_end = (const char*)local_error.json + local_error.position;
+        }
+
+        global_error = local_error;
+    }
+
+    return NULL;
+}
+
+/* Default options for cJSON_Parse */
+CJSON_PUBLIC(cJSON *) cJSON_Parse(const char *value)
+{
+    return cJSON_ParseWithOpts(value, 0, 0);
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_ParseWithLength(const char *value, size_t buffer_length)
+{
+    return cJSON_ParseWithLengthOpts(value, buffer_length, 0, 0);
+}
+
+#define cjson_min(a, b) (((a) < (b)) ? (a) : (b))
+
+static unsigned char *print(const cJSON * const item, cJSON_bool format, const internal_hooks * const hooks)
+{
+    static const size_t default_buffer_size = 256;
+    printbuffer buffer[1];
+    unsigned char *printed = NULL;
+
+    memset(buffer, 0, sizeof(buffer));
+
+    /* create buffer */
+    buffer->buffer = (unsigned char*) hooks->allocate(default_buffer_size);
+    buffer->length = default_buffer_size;
+    buffer->format = format;
+    buffer->hooks = *hooks;
+    if (buffer->buffer == NULL)
+    {
+        goto fail;
+    }
+
+    /* print the value */
+    if (!print_value(item, buffer))
+    {
+        goto fail;
+    }
+    update_offset(buffer);
+
+    /* check if reallocate is available */
+    if (hooks->reallocate != NULL)
+    {
+        printed = (unsigned char*) hooks->reallocate(buffer->buffer, buffer->offset + 1);
+        if (printed == NULL) {
+            goto fail;
+        }
+        buffer->buffer = NULL;
+    }
+    else /* otherwise copy the JSON over to a new buffer */
+    {
+        printed = (unsigned char*) hooks->allocate(buffer->offset + 1);
+        if (printed == NULL)
+        {
+            goto fail;
+        }
+        memcpy(printed, buffer->buffer, cjson_min(buffer->length, buffer->offset + 1));
+        printed[buffer->offset] = '\0'; /* just to be sure */
+
+        /* free the buffer */
+        hooks->deallocate(buffer->buffer);
+        buffer->buffer = NULL;
+    }
+
+    return printed;
+
+fail:
+    if (buffer->buffer != NULL)
+    {
+        hooks->deallocate(buffer->buffer);
+        buffer->buffer = NULL;
+    }
+
+    if (printed != NULL)
+    {
+        hooks->deallocate(printed);
+        printed = NULL;
+    }
+
+    return NULL;
+}
+
+/* Render a cJSON item/entity/structure to text. */
+CJSON_PUBLIC(char *) cJSON_Print(const cJSON *item)
+{
+    return (char*)print(item, true, &global_hooks);
+}
+
+CJSON_PUBLIC(char *) cJSON_PrintUnformatted(const cJSON *item)
+{
+    return (char*)print(item, false, &global_hooks);
+}
+
+CJSON_PUBLIC(char *) cJSON_PrintBuffered(const cJSON *item, int prebuffer, cJSON_bool fmt)
+{
+    printbuffer p = { 0, 0, 0, 0, 0, 0, { 0, 0, 0 } };
+
+    if (prebuffer < 0)
+    {
+        return NULL;
+    }
+
+    p.buffer = (unsigned char*)global_hooks.allocate((size_t)prebuffer);
+    if (!p.buffer)
+    {
+        return NULL;
+    }
+
+    p.length = (size_t)prebuffer;
+    p.offset = 0;
+    p.noalloc = false;
+    p.format = fmt;
+    p.hooks = global_hooks;
+
+    if (!print_value(item, &p))
+    {
+        global_hooks.deallocate(p.buffer);
+        p.buffer = NULL;
+        return NULL;
+    }
+
+    return (char*)p.buffer;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_PrintPreallocated(cJSON *item, char *buffer, const int length, const cJSON_bool format)
+{
+    printbuffer p = { 0, 0, 0, 0, 0, 0, { 0, 0, 0 } };
+
+    if ((length < 0) || (buffer == NULL))
+    {
+        return false;
+    }
+
+    p.buffer = (unsigned char*)buffer;
+    p.length = (size_t)length;
+    p.offset = 0;
+    p.noalloc = true;
+    p.format = format;
+    p.hooks = global_hooks;
+
+    return print_value(item, &p);
+}
+
+/* Parser core - when encountering text, process appropriately. */
+static cJSON_bool parse_value(cJSON * const item, parse_buffer * const input_buffer)
+{
+    if ((input_buffer == NULL) || (input_buffer->content == NULL))
+    {
+        return false; /* no input */
+    }
+
+    /* parse the different types of values */
+    /* null */
+    if (can_read(input_buffer, 4) && (strncmp((const char*)buffer_at_offset(input_buffer), "null", 4) == 0))
+    {
+        item->type = cJSON_NULL;
+        input_buffer->offset += 4;
+        return true;
+    }
+    /* false */
+    if (can_read(input_buffer, 5) && (strncmp((const char*)buffer_at_offset(input_buffer), "false", 5) == 0))
+    {
+        item->type = cJSON_False;
+        input_buffer->offset += 5;
+        return true;
+    }
+    /* true */
+    if (can_read(input_buffer, 4) && (strncmp((const char*)buffer_at_offset(input_buffer), "true", 4) == 0))
+    {
+        item->type = cJSON_True;
+        item->valueint = 1;
+        input_buffer->offset += 4;
+        return true;
+    }
+    /* string */
+    if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '\"'))
+    {
+        return parse_string(item, input_buffer);
+    }
+    /* number */
+    if (can_access_at_index(input_buffer, 0) && ((buffer_at_offset(input_buffer)[0] == '-') || ((buffer_at_offset(input_buffer)[0] >= '0') && (buffer_at_offset(input_buffer)[0] <= '9'))))
+    {
+        return parse_number(item, input_buffer);
+    }
+    /* array */
+    if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '['))
+    {
+        return parse_array(item, input_buffer);
+    }
+    /* object */
+    if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '{'))
+    {
+        return parse_object(item, input_buffer);
+    }
+
+    return false;
+}
+
+/* Render a value to text. */
+static cJSON_bool print_value(const cJSON * const item, printbuffer * const output_buffer)
+{
+    unsigned char *output = NULL;
+
+    if ((item == NULL) || (output_buffer == NULL))
+    {
+        return false;
+    }
+
+    switch ((item->type) & 0xFF)
+    {
+        case cJSON_NULL:
+            output = ensure(output_buffer, 5);
+            if (output == NULL)
+            {
+                return false;
+            }
+            strcpy((char*)output, "null");
+            return true;
+
+        case cJSON_False:
+            output = ensure(output_buffer, 6);
+            if (output == NULL)
+            {
+                return false;
+            }
+            strcpy((char*)output, "false");
+            return true;
+
+        case cJSON_True:
+            output = ensure(output_buffer, 5);
+            if (output == NULL)
+            {
+                return false;
+            }
+            strcpy((char*)output, "true");
+            return true;
+
+        case cJSON_Number:
+            return print_number(item, output_buffer);
+
+        case cJSON_Raw:
+        {
+            size_t raw_length = 0;
+            if (item->valuestring == NULL)
+            {
+                return false;
+            }
+
+            raw_length = strlen(item->valuestring) + sizeof("");
+            output = ensure(output_buffer, raw_length);
+            if (output == NULL)
+            {
+                return false;
+            }
+            memcpy(output, item->valuestring, raw_length);
+            return true;
+        }
+
+        case cJSON_String:
+            return print_string(item, output_buffer);
+
+        case cJSON_Array:
+            return print_array(item, output_buffer);
+
+        case cJSON_Object:
+            return print_object(item, output_buffer);
+
+        default:
+            return false;
+    }
+}
+
+/* Build an array from input text. */
+static cJSON_bool parse_array(cJSON * const item, parse_buffer * const input_buffer)
+{
+    cJSON *head = NULL; /* head of the linked list */
+    cJSON *current_item = NULL;
+
+    if (input_buffer->depth >= CJSON_NESTING_LIMIT)
+    {
+        return false; /* to deeply nested */
+    }
+    input_buffer->depth++;
+
+    if (buffer_at_offset(input_buffer)[0] != '[')
+    {
+        /* not an array */
+        goto fail;
+    }
+
+    input_buffer->offset++;
+    buffer_skip_whitespace(input_buffer);
+    if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == ']'))
+    {
+        /* empty array */
+        goto success;
+    }
+
+    /* check if we skipped to the end of the buffer */
+    if (cannot_access_at_index(input_buffer, 0))
+    {
+        input_buffer->offset--;
+        goto fail;
+    }
+
+    /* step back to character in front of the first element */
+    input_buffer->offset--;
+    /* loop through the comma separated array elements */
+    do
+    {
+        /* allocate next item */
+        cJSON *new_item = cJSON_New_Item(&(input_buffer->hooks));
+        if (new_item == NULL)
+        {
+            goto fail; /* allocation failure */
+        }
+
+        /* attach next item to list */
+        if (head == NULL)
+        {
+            /* start the linked list */
+            current_item = head = new_item;
+        }
+        else
+        {
+            /* add to the end and advance */
+            current_item->next = new_item;
+            new_item->prev = current_item;
+            current_item = new_item;
+        }
+
+        /* parse next value */
+        input_buffer->offset++;
+        buffer_skip_whitespace(input_buffer);
+        if (!parse_value(current_item, input_buffer))
+        {
+            goto fail; /* failed to parse value */
+        }
+        buffer_skip_whitespace(input_buffer);
+    }
+    while (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == ','));
+
+    if (cannot_access_at_index(input_buffer, 0) || buffer_at_offset(input_buffer)[0] != ']')
+    {
+        goto fail; /* expected end of array */
+    }
+
+success:
+    input_buffer->depth--;
+
+    if (head != NULL) {
+        head->prev = current_item;
+    }
+
+    item->type = cJSON_Array;
+    item->child = head;
+
+    input_buffer->offset++;
+
+    return true;
+
+fail:
+    if (head != NULL)
+    {
+        cJSON_Delete(head);
+    }
+
+    return false;
+}
+
+/* Render an array to text */
+static cJSON_bool print_array(const cJSON * const item, printbuffer * const output_buffer)
+{
+    unsigned char *output_pointer = NULL;
+    size_t length = 0;
+    cJSON *current_element = item->child;
+
+    if (output_buffer == NULL)
+    {
+        return false;
+    }
+
+    /* Compose the output array. */
+    /* opening square bracket */
+    output_pointer = ensure(output_buffer, 1);
+    if (output_pointer == NULL)
+    {
+        return false;
+    }
+
+    *output_pointer = '[';
+    output_buffer->offset++;
+    output_buffer->depth++;
+
+    while (current_element != NULL)
+    {
+        if (!print_value(current_element, output_buffer))
+        {
+            return false;
+        }
+        update_offset(output_buffer);
+        if (current_element->next)
+        {
+            length = (size_t) (output_buffer->format ? 2 : 1);
+            output_pointer = ensure(output_buffer, length + 1);
+            if (output_pointer == NULL)
+            {
+                return false;
+            }
+            *output_pointer++ = ',';
+            if(output_buffer->format)
+            {
+                *output_pointer++ = ' ';
+            }
+            *output_pointer = '\0';
+            output_buffer->offset += length;
+        }
+        current_element = current_element->next;
+    }
+
+    output_pointer = ensure(output_buffer, 2);
+    if (output_pointer == NULL)
+    {
+        return false;
+    }
+    *output_pointer++ = ']';
+    *output_pointer = '\0';
+    output_buffer->depth--;
+
+    return true;
+}
+
+/* Build an object from the text. */
+static cJSON_bool parse_object(cJSON * const item, parse_buffer * const input_buffer)
+{
+    cJSON *head = NULL; /* linked list head */
+    cJSON *current_item = NULL;
+
+    if (input_buffer->depth >= CJSON_NESTING_LIMIT)
+    {
+        return false; /* to deeply nested */
+    }
+    input_buffer->depth++;
+
+    if (cannot_access_at_index(input_buffer, 0) || (buffer_at_offset(input_buffer)[0] != '{'))
+    {
+        goto fail; /* not an object */
+    }
+
+    input_buffer->offset++;
+    buffer_skip_whitespace(input_buffer);
+    if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '}'))
+    {
+        goto success; /* empty object */
+    }
+
+    /* check if we skipped to the end of the buffer */
+    if (cannot_access_at_index(input_buffer, 0))
+    {
+        input_buffer->offset--;
+        goto fail;
+    }
+
+    /* step back to character in front of the first element */
+    input_buffer->offset--;
+    /* loop through the comma separated array elements */
+    do
+    {
+        /* allocate next item */
+        cJSON *new_item = cJSON_New_Item(&(input_buffer->hooks));
+        if (new_item == NULL)
+        {
+            goto fail; /* allocation failure */
+        }
+
+        /* attach next item to list */
+        if (head == NULL)
+        {
+            /* start the linked list */
+            current_item = head = new_item;
+        }
+        else
+        {
+            /* add to the end and advance */
+            current_item->next = new_item;
+            new_item->prev = current_item;
+            current_item = new_item;
+        }
+
+        if (cannot_access_at_index(input_buffer, 1))
+        {
+            goto fail; /* nothing comes after the comma */
+        }
+
+        /* parse the name of the child */
+        input_buffer->offset++;
+        buffer_skip_whitespace(input_buffer);
+        if (!parse_string(current_item, input_buffer))
+        {
+            goto fail; /* failed to parse name */
+        }
+        buffer_skip_whitespace(input_buffer);
+
+        /* swap valuestring and string, because we parsed the name */
+        current_item->string = current_item->valuestring;
+        current_item->valuestring = NULL;
+
+        if (cannot_access_at_index(input_buffer, 0) || (buffer_at_offset(input_buffer)[0] != ':'))
+        {
+            goto fail; /* invalid object */
+        }
+
+        /* parse the value */
+        input_buffer->offset++;
+        buffer_skip_whitespace(input_buffer);
+        if (!parse_value(current_item, input_buffer))
+        {
+            goto fail; /* failed to parse value */
+        }
+        buffer_skip_whitespace(input_buffer);
+    }
+    while (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == ','));
+
+    if (cannot_access_at_index(input_buffer, 0) || (buffer_at_offset(input_buffer)[0] != '}'))
+    {
+        goto fail; /* expected end of object */
+    }
+
+success:
+    input_buffer->depth--;
+
+    if (head != NULL) {
+        head->prev = current_item;
+    }
+
+    item->type = cJSON_Object;
+    item->child = head;
+
+    input_buffer->offset++;
+    return true;
+
+fail:
+    if (head != NULL)
+    {
+        cJSON_Delete(head);
+    }
+
+    return false;
+}
+
+/* Render an object to text. */
+static cJSON_bool print_object(const cJSON * const item, printbuffer * const output_buffer)
+{
+    unsigned char *output_pointer = NULL;
+    size_t length = 0;
+    cJSON *current_item = item->child;
+
+    if (output_buffer == NULL)
+    {
+        return false;
+    }
+
+    /* Compose the output: */
+    length = (size_t) (output_buffer->format ? 2 : 1); /* fmt: {\n */
+    output_pointer = ensure(output_buffer, length + 1);
+    if (output_pointer == NULL)
+    {
+        return false;
+    }
+
+    *output_pointer++ = '{';
+    output_buffer->depth++;
+    if (output_buffer->format)
+    {
+        *output_pointer++ = '\n';
+    }
+    output_buffer->offset += length;
+
+    while (current_item)
+    {
+        if (output_buffer->format)
+        {
+            size_t i;
+            output_pointer = ensure(output_buffer, output_buffer->depth);
+            if (output_pointer == NULL)
+            {
+                return false;
+            }
+            for (i = 0; i < output_buffer->depth; i++)
+            {
+                *output_pointer++ = '\t';
+            }
+            output_buffer->offset += output_buffer->depth;
+        }
+
+        /* print key */
+        if (!print_string_ptr((unsigned char*)current_item->string, output_buffer))
+        {
+            return false;
+        }
+        update_offset(output_buffer);
+
+        length = (size_t) (output_buffer->format ? 2 : 1);
+        output_pointer = ensure(output_buffer, length);
+        if (output_pointer == NULL)
+        {
+            return false;
+        }
+        *output_pointer++ = ':';
+        if (output_buffer->format)
+        {
+            *output_pointer++ = '\t';
+        }
+        output_buffer->offset += length;
+
+        /* print value */
+        if (!print_value(current_item, output_buffer))
+        {
+            return false;
+        }
+        update_offset(output_buffer);
+
+        /* print comma if not last */
+        length = ((size_t)(output_buffer->format ? 1 : 0) + (size_t)(current_item->next ? 1 : 0));
+        output_pointer = ensure(output_buffer, length + 1);
+        if (output_pointer == NULL)
+        {
+            return false;
+        }
+        if (current_item->next)
+        {
+            *output_pointer++ = ',';
+        }
+
+        if (output_buffer->format)
+        {
+            *output_pointer++ = '\n';
+        }
+        *output_pointer = '\0';
+        output_buffer->offset += length;
+
+        current_item = current_item->next;
+    }
+
+    output_pointer = ensure(output_buffer, output_buffer->format ? (output_buffer->depth + 1) : 2);
+    if (output_pointer == NULL)
+    {
+        return false;
+    }
+    if (output_buffer->format)
+    {
+        size_t i;
+        for (i = 0; i < (output_buffer->depth - 1); i++)
+        {
+            *output_pointer++ = '\t';
+        }
+    }
+    *output_pointer++ = '}';
+    *output_pointer = '\0';
+    output_buffer->depth--;
+
+    return true;
+}
+
+/* Get Array size/item / object item. */
+CJSON_PUBLIC(int) cJSON_GetArraySize(const cJSON *array)
+{
+    cJSON *child = NULL;
+    size_t size = 0;
+
+    if (array == NULL)
+    {
+        return 0;
+    }
+
+    child = array->child;
+
+    while(child != NULL)
+    {
+        size++;
+        child = child->next;
+    }
+
+    /* FIXME: Can overflow here. Cannot be fixed without breaking the API */
+
+    return (int)size;
+}
+
+static cJSON* get_array_item(const cJSON *array, size_t index)
+{
+    cJSON *current_child = NULL;
+
+    if (array == NULL)
+    {
+        return NULL;
+    }
+
+    current_child = array->child;
+    while ((current_child != NULL) && (index > 0))
+    {
+        index--;
+        current_child = current_child->next;
+    }
+
+    return current_child;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_GetArrayItem(const cJSON *array, int index)
+{
+    if (index < 0)
+    {
+        return NULL;
+    }
+
+    return get_array_item(array, (size_t)index);
+}
+
+static cJSON *get_object_item(const cJSON * const object, const char * const name, const cJSON_bool case_sensitive)
+{
+    cJSON *current_element = NULL;
+
+    if ((object == NULL) || (name == NULL))
+    {
+        return NULL;
+    }
+
+    current_element = object->child;
+    if (case_sensitive)
+    {
+        while ((current_element != NULL) && (current_element->string != NULL) && (strcmp(name, current_element->string) != 0))
+        {
+            current_element = current_element->next;
+        }
+    }
+    else
+    {
+        while ((current_element != NULL) && (case_insensitive_strcmp((const unsigned char*)name, (const unsigned char*)(current_element->string)) != 0))
+        {
+            current_element = current_element->next;
+        }
+    }
+
+    if ((current_element == NULL) || (current_element->string == NULL)) {
+        return NULL;
+    }
+
+    return current_element;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_GetObjectItem(const cJSON * const object, const char * const string)
+{
+    return get_object_item(object, string, false);
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_GetObjectItemCaseSensitive(const cJSON * const object, const char * const string)
+{
+    return get_object_item(object, string, true);
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_HasObjectItem(const cJSON *object, const char *string)
+{
+    return cJSON_GetObjectItem(object, string) ? 1 : 0;
+}
+
+/* Utility for array list handling. */
+static void suffix_object(cJSON *prev, cJSON *item)
+{
+    prev->next = item;
+    item->prev = prev;
+}
+
+/* Utility for handling references. */
+static cJSON *create_reference(const cJSON *item, const internal_hooks * const hooks)
+{
+    cJSON *reference = NULL;
+    if (item == NULL)
+    {
+        return NULL;
+    }
+
+    reference = cJSON_New_Item(hooks);
+    if (reference == NULL)
+    {
+        return NULL;
+    }
+
+    memcpy(reference, item, sizeof(cJSON));
+    reference->string = NULL;
+    reference->type |= cJSON_IsReference;
+    reference->next = reference->prev = NULL;
+    return reference;
+}
+
+static cJSON_bool add_item_to_array(cJSON *array, cJSON *item)
+{
+    cJSON *child = NULL;
+
+    if ((item == NULL) || (array == NULL) || (array == item))
+    {
+        return false;
+    }
+
+    child = array->child;
+    /*
+     * To find the last item in array quickly, we use prev in array
+     */
+    if (child == NULL)
+    {
+        /* list is empty, start new one */
+        array->child = item;
+        item->prev = item;
+        item->next = NULL;
+    }
+    else
+    {
+        /* append to the end */
+        if (child->prev)
+        {
+            suffix_object(child->prev, item);
+            array->child->prev = item;
+        }
+    }
+
+    return true;
+}
+
+/* Add item to array/object. */
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemToArray(cJSON *array, cJSON *item)
+{
+    return add_item_to_array(array, item);
+}
+
+#if defined(__clang__) || (defined(__GNUC__)  && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ > 5))))
+    #pragma GCC diagnostic push
+#endif
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wcast-qual"
+#endif
+/* helper function to cast away const */
+static void* cast_away_const(const void* string)
+{
+    return (void*)string;
+}
+#if defined(__clang__) || (defined(__GNUC__)  && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ > 5))))
+    #pragma GCC diagnostic pop
+#endif
+
+
+static cJSON_bool add_item_to_object(cJSON * const object, const char * const string, cJSON * const item, const internal_hooks * const hooks, const cJSON_bool constant_key)
+{
+    char *new_key = NULL;
+    int new_type = cJSON_Invalid;
+
+    if ((object == NULL) || (string == NULL) || (item == NULL) || (object == item))
+    {
+        return false;
+    }
+
+    if (constant_key)
+    {
+        new_key = (char*)cast_away_const(string);
+        new_type = item->type | cJSON_StringIsConst;
+    }
+    else
+    {
+        new_key = (char*)cJSON_strdup((const unsigned char*)string, hooks);
+        if (new_key == NULL)
+        {
+            return false;
+        }
+
+        new_type = item->type & ~cJSON_StringIsConst;
+    }
+
+    if (!(item->type & cJSON_StringIsConst) && (item->string != NULL))
+    {
+        hooks->deallocate(item->string);
+    }
+
+    item->string = new_key;
+    item->type = new_type;
+
+    return add_item_to_array(object, item);
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemToObject(cJSON *object, const char *string, cJSON *item)
+{
+    return add_item_to_object(object, string, item, &global_hooks, false);
+}
+
+/* Add an item to an object with constant string as key */
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemToObjectCS(cJSON *object, const char *string, cJSON *item)
+{
+    return add_item_to_object(object, string, item, &global_hooks, true);
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemReferenceToArray(cJSON *array, cJSON *item)
+{
+    if (array == NULL)
+    {
+        return false;
+    }
+
+    return add_item_to_array(array, create_reference(item, &global_hooks));
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemReferenceToObject(cJSON *object, const char *string, cJSON *item)
+{
+    if ((object == NULL) || (string == NULL))
+    {
+        return false;
+    }
+
+    return add_item_to_object(object, string, create_reference(item, &global_hooks), &global_hooks, false);
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddNullToObject(cJSON * const object, const char * const name)
+{
+    cJSON *null = cJSON_CreateNull();
+    if (add_item_to_object(object, name, null, &global_hooks, false))
+    {
+        return null;
+    }
+
+    cJSON_Delete(null);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddTrueToObject(cJSON * const object, const char * const name)
+{
+    cJSON *true_item = cJSON_CreateTrue();
+    if (add_item_to_object(object, name, true_item, &global_hooks, false))
+    {
+        return true_item;
+    }
+
+    cJSON_Delete(true_item);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddFalseToObject(cJSON * const object, const char * const name)
+{
+    cJSON *false_item = cJSON_CreateFalse();
+    if (add_item_to_object(object, name, false_item, &global_hooks, false))
+    {
+        return false_item;
+    }
+
+    cJSON_Delete(false_item);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddBoolToObject(cJSON * const object, const char * const name, const cJSON_bool boolean)
+{
+    cJSON *bool_item = cJSON_CreateBool(boolean);
+    if (add_item_to_object(object, name, bool_item, &global_hooks, false))
+    {
+        return bool_item;
+    }
+
+    cJSON_Delete(bool_item);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddNumberToObject(cJSON * const object, const char * const name, const double number)
+{
+    cJSON *number_item = cJSON_CreateNumber(number);
+    if (add_item_to_object(object, name, number_item, &global_hooks, false))
+    {
+        return number_item;
+    }
+
+    cJSON_Delete(number_item);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddStringToObject(cJSON * const object, const char * const name, const char * const string)
+{
+    cJSON *string_item = cJSON_CreateString(string);
+    if (add_item_to_object(object, name, string_item, &global_hooks, false))
+    {
+        return string_item;
+    }
+
+    cJSON_Delete(string_item);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddRawToObject(cJSON * const object, const char * const name, const char * const raw)
+{
+    cJSON *raw_item = cJSON_CreateRaw(raw);
+    if (add_item_to_object(object, name, raw_item, &global_hooks, false))
+    {
+        return raw_item;
+    }
+
+    cJSON_Delete(raw_item);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddObjectToObject(cJSON * const object, const char * const name)
+{
+    cJSON *object_item = cJSON_CreateObject();
+    if (add_item_to_object(object, name, object_item, &global_hooks, false))
+    {
+        return object_item;
+    }
+
+    cJSON_Delete(object_item);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddArrayToObject(cJSON * const object, const char * const name)
+{
+    cJSON *array = cJSON_CreateArray();
+    if (add_item_to_object(object, name, array, &global_hooks, false))
+    {
+        return array;
+    }
+
+    cJSON_Delete(array);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_DetachItemViaPointer(cJSON *parent, cJSON * const item)
+{
+    if ((parent == NULL) || (item == NULL))
+    {
+        return NULL;
+    }
+
+    if (item != parent->child)
+    {
+        /* not the first element */
+        item->prev->next = item->next;
+    }
+    if (item->next != NULL)
+    {
+        /* not the last element */
+        item->next->prev = item->prev;
+    }
+
+    if (item == parent->child)
+    {
+        /* first element */
+        parent->child = item->next;
+    }
+    else if (item->next == NULL)
+    {
+        /* last element */
+        parent->child->prev = item->prev;
+    }
+
+    /* make sure the detached item doesn't point anywhere anymore */
+    item->prev = NULL;
+    item->next = NULL;
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_DetachItemFromArray(cJSON *array, int which)
+{
+    if (which < 0)
+    {
+        return NULL;
+    }
+
+    return cJSON_DetachItemViaPointer(array, get_array_item(array, (size_t)which));
+}
+
+CJSON_PUBLIC(void) cJSON_DeleteItemFromArray(cJSON *array, int which)
+{
+    cJSON_Delete(cJSON_DetachItemFromArray(array, which));
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_DetachItemFromObject(cJSON *object, const char *string)
+{
+    cJSON *to_detach = cJSON_GetObjectItem(object, string);
+
+    return cJSON_DetachItemViaPointer(object, to_detach);
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_DetachItemFromObjectCaseSensitive(cJSON *object, const char *string)
+{
+    cJSON *to_detach = cJSON_GetObjectItemCaseSensitive(object, string);
+
+    return cJSON_DetachItemViaPointer(object, to_detach);
+}
+
+CJSON_PUBLIC(void) cJSON_DeleteItemFromObject(cJSON *object, const char *string)
+{
+    cJSON_Delete(cJSON_DetachItemFromObject(object, string));
+}
+
+CJSON_PUBLIC(void) cJSON_DeleteItemFromObjectCaseSensitive(cJSON *object, const char *string)
+{
+    cJSON_Delete(cJSON_DetachItemFromObjectCaseSensitive(object, string));
+}
+
+/* Replace array/object items with new ones. */
+CJSON_PUBLIC(cJSON_bool) cJSON_InsertItemInArray(cJSON *array, int which, cJSON *newitem)
+{
+    cJSON *after_inserted = NULL;
+
+    if (which < 0 || newitem == NULL)
+    {
+        return false;
+    }
+
+    after_inserted = get_array_item(array, (size_t)which);
+    if (after_inserted == NULL)
+    {
+        return add_item_to_array(array, newitem);
+    }
+
+    if (after_inserted != array->child && after_inserted->prev == NULL) {
+        /* return false if after_inserted is a corrupted array item */
+        return false;
+    }
+
+    newitem->next = after_inserted;
+    newitem->prev = after_inserted->prev;
+    after_inserted->prev = newitem;
+    if (after_inserted == array->child)
+    {
+        array->child = newitem;
+    }
+    else
+    {
+        newitem->prev->next = newitem;
+    }
+    return true;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemViaPointer(cJSON * const parent, cJSON * const item, cJSON * replacement)
+{
+    if ((parent == NULL) || (parent->child == NULL) || (replacement == NULL) || (item == NULL))
+    {
+        return false;
+    }
+
+    if (replacement == item)
+    {
+        return true;
+    }
+
+    replacement->next = item->next;
+    replacement->prev = item->prev;
+
+    if (replacement->next != NULL)
+    {
+        replacement->next->prev = replacement;
+    }
+    if (parent->child == item)
+    {
+        if (parent->child->prev == parent->child)
+        {
+            replacement->prev = replacement;
+        }
+        parent->child = replacement;
+    }
+    else
+    {   /*
+         * To find the last item in array quickly, we use prev in array.
+         * We can't modify the last item's next pointer where this item was the parent's child
+         */
+        if (replacement->prev != NULL)
+        {
+            replacement->prev->next = replacement;
+        }
+        if (replacement->next == NULL)
+        {
+            parent->child->prev = replacement;
+        }
+    }
+
+    item->next = NULL;
+    item->prev = NULL;
+    cJSON_Delete(item);
+
+    return true;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemInArray(cJSON *array, int which, cJSON *newitem)
+{
+    if (which < 0)
+    {
+        return false;
+    }
+
+    return cJSON_ReplaceItemViaPointer(array, get_array_item(array, (size_t)which), newitem);
+}
+
+static cJSON_bool replace_item_in_object(cJSON *object, const char *string, cJSON *replacement, cJSON_bool case_sensitive)
+{
+    if ((replacement == NULL) || (string == NULL))
+    {
+        return false;
+    }
+
+    /* replace the name in the replacement */
+    if (!(replacement->type & cJSON_StringIsConst) && (replacement->string != NULL))
+    {
+        cJSON_free(replacement->string);
+    }
+    replacement->string = (char*)cJSON_strdup((const unsigned char*)string, &global_hooks);
+    if (replacement->string == NULL)
+    {
+        return false;
+    }
+
+    replacement->type &= ~cJSON_StringIsConst;
+
+    return cJSON_ReplaceItemViaPointer(object, get_object_item(object, string, case_sensitive), replacement);
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemInObject(cJSON *object, const char *string, cJSON *newitem)
+{
+    return replace_item_in_object(object, string, newitem, false);
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemInObjectCaseSensitive(cJSON *object, const char *string, cJSON *newitem)
+{
+    return replace_item_in_object(object, string, newitem, true);
+}
+
+/* Create basic types: */
+CJSON_PUBLIC(cJSON *) cJSON_CreateNull(void)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if(item)
+    {
+        item->type = cJSON_NULL;
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateTrue(void)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if(item)
+    {
+        item->type = cJSON_True;
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateFalse(void)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if(item)
+    {
+        item->type = cJSON_False;
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateBool(cJSON_bool boolean)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if(item)
+    {
+        item->type = boolean ? cJSON_True : cJSON_False;
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateNumber(double num)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if(item)
+    {
+        item->type = cJSON_Number;
+        item->valuedouble = num;
+
+        /* use saturation in case of overflow */
+        if (num >= INT_MAX)
+        {
+            item->valueint = INT_MAX;
+        }
+        else if (num <= (double)INT_MIN)
+        {
+            item->valueint = INT_MIN;
+        }
+        else
+        {
+            item->valueint = (int)num;
+        }
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateString(const char *string)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if(item)
+    {
+        item->type = cJSON_String;
+        item->valuestring = (char*)cJSON_strdup((const unsigned char*)string, &global_hooks);
+        if(!item->valuestring)
+        {
+            cJSON_Delete(item);
+            return NULL;
+        }
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateStringReference(const char *string)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if (item != NULL)
+    {
+        item->type = cJSON_String | cJSON_IsReference;
+        item->valuestring = (char*)cast_away_const(string);
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateObjectReference(const cJSON *child)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if (item != NULL) {
+        item->type = cJSON_Object | cJSON_IsReference;
+        item->child = (cJSON*)cast_away_const(child);
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateArrayReference(const cJSON *child) {
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if (item != NULL) {
+        item->type = cJSON_Array | cJSON_IsReference;
+        item->child = (cJSON*)cast_away_const(child);
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateRaw(const char *raw)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if(item)
+    {
+        item->type = cJSON_Raw;
+        item->valuestring = (char*)cJSON_strdup((const unsigned char*)raw, &global_hooks);
+        if(!item->valuestring)
+        {
+            cJSON_Delete(item);
+            return NULL;
+        }
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateArray(void)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if(item)
+    {
+        item->type=cJSON_Array;
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateObject(void)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if (item)
+    {
+        item->type = cJSON_Object;
+    }
+
+    return item;
+}
+
+/* Create Arrays: */
+CJSON_PUBLIC(cJSON *) cJSON_CreateIntArray(const int *numbers, int count)
+{
+    size_t i = 0;
+    cJSON *n = NULL;
+    cJSON *p = NULL;
+    cJSON *a = NULL;
+
+    if ((count < 0) || (numbers == NULL))
+    {
+        return NULL;
+    }
+
+    a = cJSON_CreateArray();
+
+    for(i = 0; a && (i < (size_t)count); i++)
+    {
+        n = cJSON_CreateNumber(numbers[i]);
+        if (!n)
+        {
+            cJSON_Delete(a);
+            return NULL;
+        }
+        if(!i)
+        {
+            a->child = n;
+        }
+        else
+        {
+            suffix_object(p, n);
+        }
+        p = n;
+    }
+
+    if (a && a->child) {
+        a->child->prev = n;
+    }
+
+    return a;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateFloatArray(const float *numbers, int count)
+{
+    size_t i = 0;
+    cJSON *n = NULL;
+    cJSON *p = NULL;
+    cJSON *a = NULL;
+
+    if ((count < 0) || (numbers == NULL))
+    {
+        return NULL;
+    }
+
+    a = cJSON_CreateArray();
+
+    for(i = 0; a && (i < (size_t)count); i++)
+    {
+        n = cJSON_CreateNumber((double)numbers[i]);
+        if(!n)
+        {
+            cJSON_Delete(a);
+            return NULL;
+        }
+        if(!i)
+        {
+            a->child = n;
+        }
+        else
+        {
+            suffix_object(p, n);
+        }
+        p = n;
+    }
+
+    if (a && a->child) {
+        a->child->prev = n;
+    }
+
+    return a;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateDoubleArray(const double *numbers, int count)
+{
+    size_t i = 0;
+    cJSON *n = NULL;
+    cJSON *p = NULL;
+    cJSON *a = NULL;
+
+    if ((count < 0) || (numbers == NULL))
+    {
+        return NULL;
+    }
+
+    a = cJSON_CreateArray();
+
+    for(i = 0; a && (i < (size_t)count); i++)
+    {
+        n = cJSON_CreateNumber(numbers[i]);
+        if(!n)
+        {
+            cJSON_Delete(a);
+            return NULL;
+        }
+        if(!i)
+        {
+            a->child = n;
+        }
+        else
+        {
+            suffix_object(p, n);
+        }
+        p = n;
+    }
+
+    if (a && a->child) {
+        a->child->prev = n;
+    }
+
+    return a;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateStringArray(const char *const *strings, int count)
+{
+    size_t i = 0;
+    cJSON *n = NULL;
+    cJSON *p = NULL;
+    cJSON *a = NULL;
+
+    if ((count < 0) || (strings == NULL))
+    {
+        return NULL;
+    }
+
+    a = cJSON_CreateArray();
+
+    for (i = 0; a && (i < (size_t)count); i++)
+    {
+        n = cJSON_CreateString(strings[i]);
+        if(!n)
+        {
+            cJSON_Delete(a);
+            return NULL;
+        }
+        if(!i)
+        {
+            a->child = n;
+        }
+        else
+        {
+            suffix_object(p,n);
+        }
+        p = n;
+    }
+
+    if (a && a->child) {
+        a->child->prev = n;
+    }
+
+    return a;
+}
+
+/* Duplication */
+CJSON_PUBLIC(cJSON *) cJSON_Duplicate(const cJSON *item, cJSON_bool recurse)
+{
+    cJSON *newitem = NULL;
+    cJSON *child = NULL;
+    cJSON *next = NULL;
+    cJSON *newchild = NULL;
+
+    /* Bail on bad ptr */
+    if (!item)
+    {
+        goto fail;
+    }
+    /* Create new item */
+    newitem = cJSON_New_Item(&global_hooks);
+    if (!newitem)
+    {
+        goto fail;
+    }
+    /* Copy over all vars */
+    newitem->type = item->type & (~cJSON_IsReference);
+    newitem->valueint = item->valueint;
+    newitem->valuedouble = item->valuedouble;
+    if (item->valuestring)
+    {
+        newitem->valuestring = (char*)cJSON_strdup((unsigned char*)item->valuestring, &global_hooks);
+        if (!newitem->valuestring)
+        {
+            goto fail;
+        }
+    }
+    if (item->string)
+    {
+        newitem->string = (item->type&cJSON_StringIsConst) ? item->string : (char*)cJSON_strdup((unsigned char*)item->string, &global_hooks);
+        if (!newitem->string)
+        {
+            goto fail;
+        }
+    }
+    /* If non-recursive, then we're done! */
+    if (!recurse)
+    {
+        return newitem;
+    }
+    /* Walk the ->next chain for the child. */
+    child = item->child;
+    while (child != NULL)
+    {
+        newchild = cJSON_Duplicate(child, true); /* Duplicate (with recurse) each item in the ->next chain */
+        if (!newchild)
+        {
+            goto fail;
+        }
+        if (next != NULL)
+        {
+            /* If newitem->child already set, then crosswire ->prev and ->next and move on */
+            next->next = newchild;
+            newchild->prev = next;
+            next = newchild;
+        }
+        else
+        {
+            /* Set newitem->child and move to it */
+            newitem->child = newchild;
+            next = newchild;
+        }
+        child = child->next;
+    }
+    if (newitem && newitem->child)
+    {
+        newitem->child->prev = newchild;
+    }
+
+    return newitem;
+
+fail:
+    if (newitem != NULL)
+    {
+        cJSON_Delete(newitem);
+    }
+
+    return NULL;
+}
+
+static void skip_oneline_comment(char **input)
+{
+    *input += static_strlen("//");
+
+    for (; (*input)[0] != '\0'; ++(*input))
+    {
+        if ((*input)[0] == '\n') {
+            *input += static_strlen("\n");
+            return;
+        }
+    }
+}
+
+static void skip_multiline_comment(char **input)
+{
+    *input += static_strlen("/*");
+
+    for (; (*input)[0] != '\0'; ++(*input))
+    {
+        if (((*input)[0] == '*') && ((*input)[1] == '/'))
+        {
+            *input += static_strlen("*/");
+            return;
+        }
+    }
+}
+
+static void minify_string(char **input, char **output) {
+    (*output)[0] = (*input)[0];
+    *input += static_strlen("\"");
+    *output += static_strlen("\"");
+
+
+    for (; (*input)[0] != '\0'; (void)++(*input), ++(*output)) {
+        (*output)[0] = (*input)[0];
+
+        if ((*input)[0] == '\"') {
+            (*output)[0] = '\"';
+            *input += static_strlen("\"");
+            *output += static_strlen("\"");
+            return;
+        } else if (((*input)[0] == '\\') && ((*input)[1] == '\"')) {
+            (*output)[1] = (*input)[1];
+            *input += static_strlen("\"");
+            *output += static_strlen("\"");
+        }
+    }
+}
+
+CJSON_PUBLIC(void) cJSON_Minify(char *json)
+{
+    char *into = json;
+
+    if (json == NULL)
+    {
+        return;
+    }
+
+    while (json[0] != '\0')
+    {
+        switch (json[0])
+        {
+            case ' ':
+            case '\t':
+            case '\r':
+            case '\n':
+                json++;
+                break;
+
+            case '/':
+                if (json[1] == '/')
+                {
+                    skip_oneline_comment(&json);
+                }
+                else if (json[1] == '*')
+                {
+                    skip_multiline_comment(&json);
+                } else {
+                    json++;
+                }
+                break;
+
+            case '\"':
+                minify_string(&json, (char**)&into);
+                break;
+
+            default:
+                into[0] = json[0];
+                json++;
+                into++;
+        }
+    }
+
+    /* and null-terminate. */
+    *into = '\0';
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_IsInvalid(const cJSON * const item)
+{
+    if (item == NULL)
+    {
+        return false;
+    }
+
+    return (item->type & 0xFF) == cJSON_Invalid;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_IsFalse(const cJSON * const item)
+{
+    if (item == NULL)
+    {
+        return false;
+    }
+
+    return (item->type & 0xFF) == cJSON_False;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_IsTrue(const cJSON * const item)
+{
+    if (item == NULL)
+    {
+        return false;
+    }
+
+    return (item->type & 0xff) == cJSON_True;
+}
+
+
+CJSON_PUBLIC(cJSON_bool) cJSON_IsBool(const cJSON * const item)
+{
+    if (item == NULL)
+    {
+        return false;
+    }
+
+    return (item->type & (cJSON_True | cJSON_False)) != 0;
+}
+CJSON_PUBLIC(cJSON_bool) cJSON_IsNull(const cJSON * const item)
+{
+    if (item == NULL)
+    {
+        return false;
+    }
+
+    return (item->type & 0xFF) == cJSON_NULL;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_IsNumber(const cJSON * const item)
+{
+    if (item == NULL)
+    {
+        return false;
+    }
+
+    return (item->type & 0xFF) == cJSON_Number;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_IsString(const cJSON * const item)
+{
+    if (item == NULL)
+    {
+        return false;
+    }
+
+    return (item->type & 0xFF) == cJSON_String;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_IsArray(const cJSON * const item)
+{
+    if (item == NULL)
+    {
+        return false;
+    }
+
+    return (item->type & 0xFF) == cJSON_Array;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_IsObject(const cJSON * const item)
+{
+    if (item == NULL)
+    {
+        return false;
+    }
+
+    return (item->type & 0xFF) == cJSON_Object;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_IsRaw(const cJSON * const item)
+{
+    if (item == NULL)
+    {
+        return false;
+    }
+
+    return (item->type & 0xFF) == cJSON_Raw;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_Compare(const cJSON * const a, const cJSON * const b, const cJSON_bool case_sensitive)
+{
+    if ((a == NULL) || (b == NULL) || ((a->type & 0xFF) != (b->type & 0xFF)))
+    {
+        return false;
+    }
+
+    /* check if type is valid */
+    switch (a->type & 0xFF)
+    {
+        case cJSON_False:
+        case cJSON_True:
+        case cJSON_NULL:
+        case cJSON_Number:
+        case cJSON_String:
+        case cJSON_Raw:
+        case cJSON_Array:
+        case cJSON_Object:
+            break;
+
+        default:
+            return false;
+    }
+
+    /* identical objects are equal */
+    if (a == b)
+    {
+        return true;
+    }
+
+    switch (a->type & 0xFF)
+    {
+        /* in these cases and equal type is enough */
+        case cJSON_False:
+        case cJSON_True:
+        case cJSON_NULL:
+            return true;
+
+        case cJSON_Number:
+            if (compare_double(a->valuedouble, b->valuedouble))
+            {
+                return true;
+            }
+            return false;
+
+        case cJSON_String:
+        case cJSON_Raw:
+            if ((a->valuestring == NULL) || (b->valuestring == NULL))
+            {
+                return false;
+            }
+            if (strcmp(a->valuestring, b->valuestring) == 0)
+            {
+                return true;
+            }
+
+            return false;
+
+        case cJSON_Array:
+        {
+            cJSON *a_element = a->child;
+            cJSON *b_element = b->child;
+
+            for (; (a_element != NULL) && (b_element != NULL);)
+            {
+                if (!cJSON_Compare(a_element, b_element, case_sensitive))
+                {
+                    return false;
+                }
+
+                a_element = a_element->next;
+                b_element = b_element->next;
+            }
+
+            /* one of the arrays is longer than the other */
+            if (a_element != b_element) {
+                return false;
+            }
+
+            return true;
+        }
+
+        case cJSON_Object:
+        {
+            cJSON *a_element = NULL;
+            cJSON *b_element = NULL;
+            cJSON_ArrayForEach(a_element, a)
+            {
+                /* TODO This has O(n^2) runtime, which is horrible! */
+                b_element = get_object_item(b, a_element->string, case_sensitive);
+                if (b_element == NULL)
+                {
+                    return false;
+                }
+
+                if (!cJSON_Compare(a_element, b_element, case_sensitive))
+                {
+                    return false;
+                }
+            }
+
+            /* doing this twice, once on a and b to prevent true comparison if a subset of b
+             * TODO: Do this the proper way, this is just a fix for now */
+            cJSON_ArrayForEach(b_element, b)
+            {
+                a_element = get_object_item(a, b_element->string, case_sensitive);
+                if (a_element == NULL)
+                {
+                    return false;
+                }
+
+                if (!cJSON_Compare(b_element, a_element, case_sensitive))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        default:
+            return false;
+    }
+}
+
+CJSON_PUBLIC(void *) cJSON_malloc(size_t size)
+{
+    return global_hooks.allocate(size);
+}
+
+CJSON_PUBLIC(void) cJSON_free(void *object)
+{
+    global_hooks.deallocate(object);
+    object = NULL;
+}

--- a/src/cjson/cJSON.h
+++ b/src/cjson/cJSON.h
@@ -1,0 +1,300 @@
+/*
+  Copyright (c) 2009-2017 Dave Gamble and cJSON contributors
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+
+#ifndef cJSON__h
+#define cJSON__h
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#if !defined(__WINDOWS__) && (defined(WIN32) || defined(WIN64) || defined(_MSC_VER) || defined(_WIN32))
+#define __WINDOWS__
+#endif
+
+#ifdef __WINDOWS__
+
+/* When compiling for windows, we specify a specific calling convention to avoid issues where we are being called from a project with a different default calling convention.  For windows you have 3 define options:
+
+CJSON_HIDE_SYMBOLS - Define this in the case where you don't want to ever dllexport symbols
+CJSON_EXPORT_SYMBOLS - Define this on library build when you want to dllexport symbols (default)
+CJSON_IMPORT_SYMBOLS - Define this if you want to dllimport symbol
+
+For *nix builds that support visibility attribute, you can define similar behavior by
+
+setting default visibility to hidden by adding
+-fvisibility=hidden (for gcc)
+or
+-xldscope=hidden (for sun cc)
+to CFLAGS
+
+then using the CJSON_API_VISIBILITY flag to "export" the same symbols the way CJSON_EXPORT_SYMBOLS does
+
+*/
+
+#define CJSON_CDECL __cdecl
+#define CJSON_STDCALL __stdcall
+
+/* export symbols by default, this is necessary for copy pasting the C and header file */
+#if !defined(CJSON_HIDE_SYMBOLS) && !defined(CJSON_IMPORT_SYMBOLS) && !defined(CJSON_EXPORT_SYMBOLS)
+#define CJSON_EXPORT_SYMBOLS
+#endif
+
+#if defined(CJSON_HIDE_SYMBOLS)
+#define CJSON_PUBLIC(type)   type CJSON_STDCALL
+#elif defined(CJSON_EXPORT_SYMBOLS)
+#define CJSON_PUBLIC(type)   __declspec(dllexport) type CJSON_STDCALL
+#elif defined(CJSON_IMPORT_SYMBOLS)
+#define CJSON_PUBLIC(type)   __declspec(dllimport) type CJSON_STDCALL
+#endif
+#else /* !__WINDOWS__ */
+#define CJSON_CDECL
+#define CJSON_STDCALL
+
+#if (defined(__GNUC__) || defined(__SUNPRO_CC) || defined (__SUNPRO_C)) && defined(CJSON_API_VISIBILITY)
+#define CJSON_PUBLIC(type)   __attribute__((visibility("default"))) type
+#else
+#define CJSON_PUBLIC(type) type
+#endif
+#endif
+
+/* project version */
+#define CJSON_VERSION_MAJOR 1
+#define CJSON_VERSION_MINOR 7
+#define CJSON_VERSION_PATCH 18
+
+#include <stddef.h>
+
+/* cJSON Types: */
+#define cJSON_Invalid (0)
+#define cJSON_False  (1 << 0)
+#define cJSON_True   (1 << 1)
+#define cJSON_NULL   (1 << 2)
+#define cJSON_Number (1 << 3)
+#define cJSON_String (1 << 4)
+#define cJSON_Array  (1 << 5)
+#define cJSON_Object (1 << 6)
+#define cJSON_Raw    (1 << 7) /* raw json */
+
+#define cJSON_IsReference 256
+#define cJSON_StringIsConst 512
+
+/* The cJSON structure: */
+typedef struct cJSON
+{
+    /* next/prev allow you to walk array/object chains. Alternatively, use GetArraySize/GetArrayItem/GetObjectItem */
+    struct cJSON *next;
+    struct cJSON *prev;
+    /* An array or object item will have a child pointer pointing to a chain of the items in the array/object. */
+    struct cJSON *child;
+
+    /* The type of the item, as above. */
+    int type;
+
+    /* The item's string, if type==cJSON_String  and type == cJSON_Raw */
+    char *valuestring;
+    /* writing to valueint is DEPRECATED, use cJSON_SetNumberValue instead */
+    int valueint;
+    /* The item's number, if type==cJSON_Number */
+    double valuedouble;
+
+    /* The item's name string, if this item is the child of, or is in the list of subitems of an object. */
+    char *string;
+} cJSON;
+
+typedef struct cJSON_Hooks
+{
+      /* malloc/free are CDECL on Windows regardless of the default calling convention of the compiler, so ensure the hooks allow passing those functions directly. */
+      void *(CJSON_CDECL *malloc_fn)(size_t sz);
+      void (CJSON_CDECL *free_fn)(void *ptr);
+} cJSON_Hooks;
+
+typedef int cJSON_bool;
+
+/* Limits how deeply nested arrays/objects can be before cJSON rejects to parse them.
+ * This is to prevent stack overflows. */
+#ifndef CJSON_NESTING_LIMIT
+#define CJSON_NESTING_LIMIT 1000
+#endif
+
+/* returns the version of cJSON as a string */
+CJSON_PUBLIC(const char*) cJSON_Version(void);
+
+/* Supply malloc, realloc and free functions to cJSON */
+CJSON_PUBLIC(void) cJSON_InitHooks(cJSON_Hooks* hooks);
+
+/* Memory Management: the caller is always responsible to free the results from all variants of cJSON_Parse (with cJSON_Delete) and cJSON_Print (with stdlib free, cJSON_Hooks.free_fn, or cJSON_free as appropriate). The exception is cJSON_PrintPreallocated, where the caller has full responsibility of the buffer. */
+/* Supply a block of JSON, and this returns a cJSON object you can interrogate. */
+CJSON_PUBLIC(cJSON *) cJSON_Parse(const char *value);
+CJSON_PUBLIC(cJSON *) cJSON_ParseWithLength(const char *value, size_t buffer_length);
+/* ParseWithOpts allows you to require (and check) that the JSON is null terminated, and to retrieve the pointer to the final byte parsed. */
+/* If you supply a ptr in return_parse_end and parsing fails, then return_parse_end will contain a pointer to the error so will match cJSON_GetErrorPtr(). */
+CJSON_PUBLIC(cJSON *) cJSON_ParseWithOpts(const char *value, const char **return_parse_end, cJSON_bool require_null_terminated);
+CJSON_PUBLIC(cJSON *) cJSON_ParseWithLengthOpts(const char *value, size_t buffer_length, const char **return_parse_end, cJSON_bool require_null_terminated);
+
+/* Render a cJSON entity to text for transfer/storage. */
+CJSON_PUBLIC(char *) cJSON_Print(const cJSON *item);
+/* Render a cJSON entity to text for transfer/storage without any formatting. */
+CJSON_PUBLIC(char *) cJSON_PrintUnformatted(const cJSON *item);
+/* Render a cJSON entity to text using a buffered strategy. prebuffer is a guess at the final size. guessing well reduces reallocation. fmt=0 gives unformatted, =1 gives formatted */
+CJSON_PUBLIC(char *) cJSON_PrintBuffered(const cJSON *item, int prebuffer, cJSON_bool fmt);
+/* Render a cJSON entity to text using a buffer already allocated in memory with given length. Returns 1 on success and 0 on failure. */
+/* NOTE: cJSON is not always 100% accurate in estimating how much memory it will use, so to be safe allocate 5 bytes more than you actually need */
+CJSON_PUBLIC(cJSON_bool) cJSON_PrintPreallocated(cJSON *item, char *buffer, const int length, const cJSON_bool format);
+/* Delete a cJSON entity and all subentities. */
+CJSON_PUBLIC(void) cJSON_Delete(cJSON *item);
+
+/* Returns the number of items in an array (or object). */
+CJSON_PUBLIC(int) cJSON_GetArraySize(const cJSON *array);
+/* Retrieve item number "index" from array "array". Returns NULL if unsuccessful. */
+CJSON_PUBLIC(cJSON *) cJSON_GetArrayItem(const cJSON *array, int index);
+/* Get item "string" from object. Case insensitive. */
+CJSON_PUBLIC(cJSON *) cJSON_GetObjectItem(const cJSON * const object, const char * const string);
+CJSON_PUBLIC(cJSON *) cJSON_GetObjectItemCaseSensitive(const cJSON * const object, const char * const string);
+CJSON_PUBLIC(cJSON_bool) cJSON_HasObjectItem(const cJSON *object, const char *string);
+/* For analysing failed parses. This returns a pointer to the parse error. You'll probably need to look a few chars back to make sense of it. Defined when cJSON_Parse() returns 0. 0 when cJSON_Parse() succeeds. */
+CJSON_PUBLIC(const char *) cJSON_GetErrorPtr(void);
+
+/* Check item type and return its value */
+CJSON_PUBLIC(char *) cJSON_GetStringValue(const cJSON * const item);
+CJSON_PUBLIC(double) cJSON_GetNumberValue(const cJSON * const item);
+
+/* These functions check the type of an item */
+CJSON_PUBLIC(cJSON_bool) cJSON_IsInvalid(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsFalse(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsTrue(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsBool(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsNull(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsNumber(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsString(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsArray(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsObject(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsRaw(const cJSON * const item);
+
+/* These calls create a cJSON item of the appropriate type. */
+CJSON_PUBLIC(cJSON *) cJSON_CreateNull(void);
+CJSON_PUBLIC(cJSON *) cJSON_CreateTrue(void);
+CJSON_PUBLIC(cJSON *) cJSON_CreateFalse(void);
+CJSON_PUBLIC(cJSON *) cJSON_CreateBool(cJSON_bool boolean);
+CJSON_PUBLIC(cJSON *) cJSON_CreateNumber(double num);
+CJSON_PUBLIC(cJSON *) cJSON_CreateString(const char *string);
+/* raw json */
+CJSON_PUBLIC(cJSON *) cJSON_CreateRaw(const char *raw);
+CJSON_PUBLIC(cJSON *) cJSON_CreateArray(void);
+CJSON_PUBLIC(cJSON *) cJSON_CreateObject(void);
+
+/* Create a string where valuestring references a string so
+ * it will not be freed by cJSON_Delete */
+CJSON_PUBLIC(cJSON *) cJSON_CreateStringReference(const char *string);
+/* Create an object/array that only references it's elements so
+ * they will not be freed by cJSON_Delete */
+CJSON_PUBLIC(cJSON *) cJSON_CreateObjectReference(const cJSON *child);
+CJSON_PUBLIC(cJSON *) cJSON_CreateArrayReference(const cJSON *child);
+
+/* These utilities create an Array of count items.
+ * The parameter count cannot be greater than the number of elements in the number array, otherwise array access will be out of bounds.*/
+CJSON_PUBLIC(cJSON *) cJSON_CreateIntArray(const int *numbers, int count);
+CJSON_PUBLIC(cJSON *) cJSON_CreateFloatArray(const float *numbers, int count);
+CJSON_PUBLIC(cJSON *) cJSON_CreateDoubleArray(const double *numbers, int count);
+CJSON_PUBLIC(cJSON *) cJSON_CreateStringArray(const char *const *strings, int count);
+
+/* Append item to the specified array/object. */
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemToArray(cJSON *array, cJSON *item);
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemToObject(cJSON *object, const char *string, cJSON *item);
+/* Use this when string is definitely const (i.e. a literal, or as good as), and will definitely survive the cJSON object.
+ * WARNING: When this function was used, make sure to always check that (item->type & cJSON_StringIsConst) is zero before
+ * writing to `item->string` */
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemToObjectCS(cJSON *object, const char *string, cJSON *item);
+/* Append reference to item to the specified array/object. Use this when you want to add an existing cJSON to a new cJSON, but don't want to corrupt your existing cJSON. */
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemReferenceToArray(cJSON *array, cJSON *item);
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemReferenceToObject(cJSON *object, const char *string, cJSON *item);
+
+/* Remove/Detach items from Arrays/Objects. */
+CJSON_PUBLIC(cJSON *) cJSON_DetachItemViaPointer(cJSON *parent, cJSON * const item);
+CJSON_PUBLIC(cJSON *) cJSON_DetachItemFromArray(cJSON *array, int which);
+CJSON_PUBLIC(void) cJSON_DeleteItemFromArray(cJSON *array, int which);
+CJSON_PUBLIC(cJSON *) cJSON_DetachItemFromObject(cJSON *object, const char *string);
+CJSON_PUBLIC(cJSON *) cJSON_DetachItemFromObjectCaseSensitive(cJSON *object, const char *string);
+CJSON_PUBLIC(void) cJSON_DeleteItemFromObject(cJSON *object, const char *string);
+CJSON_PUBLIC(void) cJSON_DeleteItemFromObjectCaseSensitive(cJSON *object, const char *string);
+
+/* Update array items. */
+CJSON_PUBLIC(cJSON_bool) cJSON_InsertItemInArray(cJSON *array, int which, cJSON *newitem); /* Shifts pre-existing items to the right. */
+CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemViaPointer(cJSON * const parent, cJSON * const item, cJSON * replacement);
+CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemInArray(cJSON *array, int which, cJSON *newitem);
+CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemInObject(cJSON *object,const char *string,cJSON *newitem);
+CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemInObjectCaseSensitive(cJSON *object,const char *string,cJSON *newitem);
+
+/* Duplicate a cJSON item */
+CJSON_PUBLIC(cJSON *) cJSON_Duplicate(const cJSON *item, cJSON_bool recurse);
+/* Duplicate will create a new, identical cJSON item to the one you pass, in new memory that will
+ * need to be released. With recurse!=0, it will duplicate any children connected to the item.
+ * The item->next and ->prev pointers are always zero on return from Duplicate. */
+/* Recursively compare two cJSON items for equality. If either a or b is NULL or invalid, they will be considered unequal.
+ * case_sensitive determines if object keys are treated case sensitive (1) or case insensitive (0) */
+CJSON_PUBLIC(cJSON_bool) cJSON_Compare(const cJSON * const a, const cJSON * const b, const cJSON_bool case_sensitive);
+
+/* Minify a strings, remove blank characters(such as ' ', '\t', '\r', '\n') from strings.
+ * The input pointer json cannot point to a read-only address area, such as a string constant, 
+ * but should point to a readable and writable address area. */
+CJSON_PUBLIC(void) cJSON_Minify(char *json);
+
+/* Helper functions for creating and adding items to an object at the same time.
+ * They return the added item or NULL on failure. */
+CJSON_PUBLIC(cJSON*) cJSON_AddNullToObject(cJSON * const object, const char * const name);
+CJSON_PUBLIC(cJSON*) cJSON_AddTrueToObject(cJSON * const object, const char * const name);
+CJSON_PUBLIC(cJSON*) cJSON_AddFalseToObject(cJSON * const object, const char * const name);
+CJSON_PUBLIC(cJSON*) cJSON_AddBoolToObject(cJSON * const object, const char * const name, const cJSON_bool boolean);
+CJSON_PUBLIC(cJSON*) cJSON_AddNumberToObject(cJSON * const object, const char * const name, const double number);
+CJSON_PUBLIC(cJSON*) cJSON_AddStringToObject(cJSON * const object, const char * const name, const char * const string);
+CJSON_PUBLIC(cJSON*) cJSON_AddRawToObject(cJSON * const object, const char * const name, const char * const raw);
+CJSON_PUBLIC(cJSON*) cJSON_AddObjectToObject(cJSON * const object, const char * const name);
+CJSON_PUBLIC(cJSON*) cJSON_AddArrayToObject(cJSON * const object, const char * const name);
+
+/* When assigning an integer value, it needs to be propagated to valuedouble too. */
+#define cJSON_SetIntValue(object, number) ((object) ? (object)->valueint = (object)->valuedouble = (number) : (number))
+/* helper for the cJSON_SetNumberValue macro */
+CJSON_PUBLIC(double) cJSON_SetNumberHelper(cJSON *object, double number);
+#define cJSON_SetNumberValue(object, number) ((object != NULL) ? cJSON_SetNumberHelper(object, (double)number) : (number))
+/* Change the valuestring of a cJSON_String object, only takes effect when type of object is cJSON_String */
+CJSON_PUBLIC(char*) cJSON_SetValuestring(cJSON *object, const char *valuestring);
+
+/* If the object is not a boolean type this does nothing and returns cJSON_Invalid else it returns the new type*/
+#define cJSON_SetBoolValue(object, boolValue) ( \
+    (object != NULL && ((object)->type & (cJSON_False|cJSON_True))) ? \
+    (object)->type=((object)->type &(~(cJSON_False|cJSON_True)))|((boolValue)?cJSON_True:cJSON_False) : \
+    cJSON_Invalid\
+)
+
+/* Macro for iterating over an array or object */
+#define cJSON_ArrayForEach(element, array) for(element = (array != NULL) ? (array)->child : NULL; element != NULL; element = element->next)
+
+/* malloc/free objects using the malloc/free functions that have been set with cJSON_InitHooks */
+CJSON_PUBLIC(void *) cJSON_malloc(size_t size);
+CJSON_PUBLIC(void) cJSON_free(void *object);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/distribution_deserialize.h
+++ b/src/distribution_deserialize.h
@@ -1,6 +1,7 @@
 #ifndef _DISTRIBUTION_DESERIALIZE_H
 #define _DISTRIBUTION_DESERIALIZE_H
 #include "distribution_internal.h"
+#include "cconfigspace_json.h"
 
 struct _ccs_distribution_uniform_data_mock_s {
 	_ccs_distribution_common_data_t common_data;
@@ -324,6 +325,319 @@ end:
 	return res;
 }
 
+/*============================================================================
+ * JSON deserialization
+ *============================================================================*/
+
+static inline ccs_result_t
+_ccs_deserialize_json_distribution_uniform(
+	ccs_distribution_t *distribution_ret,
+	cJSON              *json)
+{
+	cJSON *j_data_type =
+		cJSON_GetObjectItemCaseSensitive(json, "data_type");
+	cJSON *j_scale_type =
+		cJSON_GetObjectItemCaseSensitive(json, "scale_type");
+	cJSON *j_lower = cJSON_GetObjectItemCaseSensitive(json, "lower");
+	cJSON *j_upper = cJSON_GetObjectItemCaseSensitive(json, "upper");
+	cJSON *j_quantization =
+		cJSON_GetObjectItemCaseSensitive(json, "quantization");
+
+	CCS_REFUTE(
+		!j_data_type || !cJSON_IsString(j_data_type),
+		CCS_RESULT_ERROR_INVALID_VALUE);
+	CCS_REFUTE(
+		!j_scale_type || !cJSON_IsString(j_scale_type),
+		CCS_RESULT_ERROR_INVALID_VALUE);
+	CCS_REFUTE(
+		!j_lower || !cJSON_IsNumber(j_lower),
+		CCS_RESULT_ERROR_INVALID_VALUE);
+	CCS_REFUTE(
+		!j_upper || !cJSON_IsNumber(j_upper),
+		CCS_RESULT_ERROR_INVALID_VALUE);
+	CCS_REFUTE(
+		!j_quantization || !cJSON_IsNumber(j_quantization),
+		CCS_RESULT_ERROR_INVALID_VALUE);
+
+	ccs_numeric_type_t data_type;
+	ccs_scale_type_t   scale_type;
+	CCS_VALIDATE(_ccs_json_numeric_type_from_string(
+		j_data_type->valuestring, &data_type));
+	CCS_VALIDATE(_ccs_json_scale_type_from_string(
+		j_scale_type->valuestring, &scale_type));
+
+	ccs_numeric_t lower, upper, quantization;
+	if (data_type == CCS_NUMERIC_TYPE_FLOAT) {
+		lower.f        = j_lower->valuedouble;
+		upper.f        = j_upper->valuedouble;
+		quantization.f = j_quantization->valuedouble;
+	} else {
+		lower.i        = (ccs_int_t)j_lower->valuedouble;
+		upper.i        = (ccs_int_t)j_upper->valuedouble;
+		quantization.i = (ccs_int_t)j_quantization->valuedouble;
+	}
+	CCS_VALIDATE(ccs_create_uniform_distribution(
+		data_type, lower, upper, scale_type, quantization,
+		distribution_ret));
+	return CCS_RESULT_SUCCESS;
+}
+
+static inline ccs_result_t
+_ccs_deserialize_json_distribution_normal(
+	ccs_distribution_t *distribution_ret,
+	cJSON              *json)
+{
+	cJSON *j_data_type =
+		cJSON_GetObjectItemCaseSensitive(json, "data_type");
+	cJSON *j_scale_type =
+		cJSON_GetObjectItemCaseSensitive(json, "scale_type");
+	cJSON *j_mu    = cJSON_GetObjectItemCaseSensitive(json, "mu");
+	cJSON *j_sigma = cJSON_GetObjectItemCaseSensitive(json, "sigma");
+	cJSON *j_quantization =
+		cJSON_GetObjectItemCaseSensitive(json, "quantization");
+
+	CCS_REFUTE(
+		!j_data_type || !cJSON_IsString(j_data_type),
+		CCS_RESULT_ERROR_INVALID_VALUE);
+	CCS_REFUTE(
+		!j_scale_type || !cJSON_IsString(j_scale_type),
+		CCS_RESULT_ERROR_INVALID_VALUE);
+	CCS_REFUTE(
+		!j_mu || !cJSON_IsNumber(j_mu), CCS_RESULT_ERROR_INVALID_VALUE);
+	CCS_REFUTE(
+		!j_sigma || !cJSON_IsNumber(j_sigma),
+		CCS_RESULT_ERROR_INVALID_VALUE);
+	CCS_REFUTE(
+		!j_quantization || !cJSON_IsNumber(j_quantization),
+		CCS_RESULT_ERROR_INVALID_VALUE);
+
+	ccs_numeric_type_t data_type;
+	ccs_scale_type_t   scale_type;
+	CCS_VALIDATE(_ccs_json_numeric_type_from_string(
+		j_data_type->valuestring, &data_type));
+	CCS_VALIDATE(_ccs_json_scale_type_from_string(
+		j_scale_type->valuestring, &scale_type));
+
+	ccs_numeric_t quantization;
+	if (data_type == CCS_NUMERIC_TYPE_FLOAT)
+		quantization.f = j_quantization->valuedouble;
+	else
+		quantization.i = (ccs_int_t)j_quantization->valuedouble;
+	CCS_VALIDATE(ccs_create_normal_distribution(
+		data_type, j_mu->valuedouble, j_sigma->valuedouble, scale_type,
+		quantization, distribution_ret));
+	return CCS_RESULT_SUCCESS;
+}
+
+static inline ccs_result_t
+_ccs_deserialize_json_distribution_roulette(
+	ccs_distribution_t *distribution_ret,
+	cJSON              *json)
+{
+	ccs_result_t res     = CCS_RESULT_SUCCESS;
+	ccs_float_t *areas   = NULL;
+	cJSON       *j_areas = cJSON_GetObjectItemCaseSensitive(json, "areas");
+	CCS_REFUTE(
+		!j_areas || !cJSON_IsArray(j_areas),
+		CCS_RESULT_ERROR_INVALID_VALUE);
+	size_t num_areas = (size_t)cJSON_GetArraySize(j_areas);
+	areas = (ccs_float_t *)calloc(num_areas, sizeof(ccs_float_t));
+	CCS_REFUTE(!areas, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	for (size_t i = 0; i < num_areas; i++) {
+		cJSON *item = cJSON_GetArrayItem(j_areas, (int)i);
+		CCS_REFUTE_ERR_GOTO(
+			res, !item || !cJSON_IsNumber(item),
+			CCS_RESULT_ERROR_INVALID_VALUE, end);
+		areas[i] = item->valuedouble;
+	}
+	CCS_VALIDATE_ERR_GOTO(
+		res,
+		ccs_create_roulette_distribution(
+			num_areas, areas, distribution_ret),
+		end);
+end:
+	free(areas);
+	return res;
+}
+
+static inline ccs_result_t
+_ccs_deserialize_json_distribution_mixture(
+	ccs_distribution_t                *distribution_ret,
+	uint32_t                           version,
+	cJSON                             *json,
+	_ccs_object_deserialize_options_t *opts)
+{
+	ccs_result_t                      res           = CCS_RESULT_SUCCESS;
+	ccs_distribution_t               *distributions = NULL;
+	ccs_float_t                      *weights       = NULL;
+
+	_ccs_object_deserialize_options_t new_opts      = *opts;
+	new_opts.handle_map                             = NULL;
+
+	cJSON *j_weights = cJSON_GetObjectItemCaseSensitive(json, "weights");
+	cJSON *j_distributions =
+		cJSON_GetObjectItemCaseSensitive(json, "distributions");
+	CCS_REFUTE(
+		!j_weights || !cJSON_IsArray(j_weights),
+		CCS_RESULT_ERROR_INVALID_VALUE);
+	CCS_REFUTE(
+		!j_distributions || !cJSON_IsArray(j_distributions),
+		CCS_RESULT_ERROR_INVALID_VALUE);
+
+	size_t num = (size_t)cJSON_GetArraySize(j_distributions);
+	CCS_REFUTE(
+		(size_t)cJSON_GetArraySize(j_weights) != num,
+		CCS_RESULT_ERROR_INVALID_VALUE);
+
+	distributions =
+		(ccs_distribution_t *)calloc(num, sizeof(ccs_distribution_t));
+	CCS_REFUTE(!distributions, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	weights = (ccs_float_t *)calloc(num, sizeof(ccs_float_t));
+	if (!weights) {
+		free(distributions);
+		CCS_RAISE(CCS_RESULT_ERROR_OUT_OF_MEMORY, "calloc failed");
+	}
+
+	for (size_t i = 0; i < num; i++) {
+		cJSON *w = cJSON_GetArrayItem(j_weights, (int)i);
+		CCS_REFUTE_ERR_GOTO(
+			res, !w || !cJSON_IsNumber(w),
+			CCS_RESULT_ERROR_INVALID_VALUE, end);
+		weights[i]   = w->valuedouble;
+		cJSON *child = cJSON_GetArrayItem(j_distributions, (int)i);
+		CCS_REFUTE_ERR_GOTO(
+			res, !child || !cJSON_IsObject(child),
+			CCS_RESULT_ERROR_INVALID_VALUE, end);
+		size_t      dummy = 0;
+		const char *cbuf  = (const char *)child;
+		CCS_VALIDATE_ERR_GOTO(
+			res,
+			_ccs_object_deserialize_with_opts_check(
+				(ccs_object_t *)distributions + i,
+				CCS_OBJECT_TYPE_DISTRIBUTION,
+				CCS_SERIALIZE_FORMAT_JSON, version, &dummy,
+				&cbuf, &new_opts),
+			end);
+	}
+	CCS_VALIDATE_ERR_GOTO(
+		res,
+		ccs_create_mixture_distribution(
+			num, distributions, weights, distribution_ret),
+		end);
+end:
+	if (distributions) {
+		for (size_t i = 0; i < num; i++)
+			if (distributions[i])
+				ccs_release_object(distributions[i]);
+		free(distributions);
+	}
+	free(weights);
+	return res;
+}
+
+static inline ccs_result_t
+_ccs_deserialize_json_distribution_multivariate(
+	ccs_distribution_t                *distribution_ret,
+	uint32_t                           version,
+	cJSON                             *json,
+	_ccs_object_deserialize_options_t *opts)
+{
+	ccs_result_t                      res           = CCS_RESULT_SUCCESS;
+	ccs_distribution_t               *distributions = NULL;
+
+	_ccs_object_deserialize_options_t new_opts      = *opts;
+	new_opts.handle_map                             = NULL;
+
+	cJSON *j_distributions =
+		cJSON_GetObjectItemCaseSensitive(json, "distributions");
+	CCS_REFUTE(
+		!j_distributions || !cJSON_IsArray(j_distributions),
+		CCS_RESULT_ERROR_INVALID_VALUE);
+
+	size_t num = (size_t)cJSON_GetArraySize(j_distributions);
+	distributions =
+		(ccs_distribution_t *)calloc(num, sizeof(ccs_distribution_t));
+	CCS_REFUTE(!distributions, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+
+	for (size_t i = 0; i < num; i++) {
+		cJSON *child = cJSON_GetArrayItem(j_distributions, (int)i);
+		CCS_REFUTE_ERR_GOTO(
+			res, !child || !cJSON_IsObject(child),
+			CCS_RESULT_ERROR_INVALID_VALUE, end);
+		size_t      dummy = 0;
+		const char *cbuf  = (const char *)child;
+		CCS_VALIDATE_ERR_GOTO(
+			res,
+			_ccs_object_deserialize_with_opts_check(
+				(ccs_object_t *)distributions + i,
+				CCS_OBJECT_TYPE_DISTRIBUTION,
+				CCS_SERIALIZE_FORMAT_JSON, version, &dummy,
+				&cbuf, &new_opts),
+			end);
+	}
+	CCS_VALIDATE_ERR_GOTO(
+		res,
+		ccs_create_multivariate_distribution(
+			num, distributions, distribution_ret),
+		end);
+end:
+	if (distributions) {
+		for (size_t i = 0; i < num; i++)
+			if (distributions[i])
+				ccs_release_object(distributions[i]);
+		free(distributions);
+	}
+	return res;
+}
+
+static inline ccs_result_t
+_ccs_deserialize_json_distribution(
+	ccs_distribution_t                *distribution_ret,
+	uint32_t                           version,
+	size_t                            *buffer_size,
+	const char                       **buffer,
+	_ccs_object_deserialize_options_t *opts)
+{
+	(void)buffer_size;
+	cJSON                  *json = *(cJSON **)buffer;
+	ccs_distribution_type_t dtype;
+	cJSON                  *j_dtype =
+		cJSON_GetObjectItemCaseSensitive(json, "distribution_type");
+	CCS_REFUTE(
+		!j_dtype || !cJSON_IsString(j_dtype),
+		CCS_RESULT_ERROR_INVALID_VALUE);
+	CCS_VALIDATE(_ccs_json_distribution_type_from_string(
+		j_dtype->valuestring, &dtype));
+	switch (dtype) {
+	case CCS_DISTRIBUTION_TYPE_UNIFORM:
+		CCS_VALIDATE(_ccs_deserialize_json_distribution_uniform(
+			distribution_ret, json));
+		break;
+	case CCS_DISTRIBUTION_TYPE_NORMAL:
+		CCS_VALIDATE(_ccs_deserialize_json_distribution_normal(
+			distribution_ret, json));
+		break;
+	case CCS_DISTRIBUTION_TYPE_ROULETTE:
+		CCS_VALIDATE(_ccs_deserialize_json_distribution_roulette(
+			distribution_ret, json));
+		break;
+	case CCS_DISTRIBUTION_TYPE_MIXTURE:
+		CCS_VALIDATE(_ccs_deserialize_json_distribution_mixture(
+			distribution_ret, version, json, opts));
+		break;
+	case CCS_DISTRIBUTION_TYPE_MULTIVARIATE:
+		CCS_VALIDATE(_ccs_deserialize_json_distribution_multivariate(
+			distribution_ret, version, json, opts));
+		break;
+	default:
+		CCS_RAISE(
+			CCS_RESULT_ERROR_UNSUPPORTED_OPERATION,
+			"Unsupported distribution type: %s",
+			j_dtype->valuestring);
+	}
+	return CCS_RESULT_SUCCESS;
+}
+
 static inline ccs_result_t
 _ccs_deserialize_bin_distribution(
 	ccs_distribution_t                *distribution_ret,
@@ -376,6 +690,10 @@ _ccs_distribution_deserialize(
 	switch (format) {
 	case CCS_SERIALIZE_FORMAT_BINARY:
 		CCS_VALIDATE(_ccs_deserialize_bin_distribution(
+			distribution_ret, version, buffer_size, buffer, opts));
+		break;
+	case CCS_SERIALIZE_FORMAT_JSON:
+		CCS_VALIDATE(_ccs_deserialize_json_distribution(
 			distribution_ret, version, buffer_size, buffer, opts));
 		break;
 	default:

--- a/src/distribution_mixture.c
+++ b/src/distribution_mixture.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include "cconfigspace_internal.h"
 #include "distribution_internal.h"
+#include "cconfigspace_json.h"
 #include "rng_internal.h"
 
 struct _ccs_distribution_mixture_data_s {
@@ -95,6 +96,40 @@ _ccs_serialize_bin_ccs_distribution_mixture(
 	return CCS_RESULT_SUCCESS;
 }
 
+static inline ccs_result_t
+_ccs_serialize_json_ccs_distribution_mixture(
+	ccs_distribution_t               distribution,
+	cJSON                           *json,
+	_ccs_object_serialize_options_t *opts)
+{
+	_ccs_distribution_mixture_data_t *data =
+		(_ccs_distribution_mixture_data_t *)(distribution->data);
+	CCS_REFUTE(
+		!cJSON_AddStringToObject(json, "distribution_type", "mixture"),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	cJSON *weights = cJSON_AddArrayToObject(json, "weights");
+	CCS_REFUTE(!weights, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	for (size_t i = 0; i < data->num_distributions; i++)
+		CCS_REFUTE(
+			!cJSON_AddItemToArray(
+				weights, cJSON_CreateNumber(
+						 data->weights[i + 1] -
+						 data->weights[i])),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	cJSON *distributions = cJSON_AddArrayToObject(json, "distributions");
+	CCS_REFUTE(!distributions, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	for (size_t i = 0; i < data->num_distributions; i++) {
+		cJSON *child = cJSON_CreateObject();
+		CCS_REFUTE(!child, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		cJSON_AddItemToArray(distributions, child);
+		size_t dummy = 0;
+		CCS_VALIDATE(_ccs_object_serialize_with_opts(
+			data->distributions[i], CCS_SERIALIZE_FORMAT_JSON,
+			&dummy, (char **)&child, opts));
+	}
+	return CCS_RESULT_SUCCESS;
+}
+
 static ccs_result_t
 _ccs_distribution_mixture_serialize_size(
 	ccs_object_t                     object,
@@ -106,6 +141,8 @@ _ccs_distribution_mixture_serialize_size(
 	case CCS_SERIALIZE_FORMAT_BINARY:
 		CCS_VALIDATE(_ccs_serialize_bin_size_ccs_distribution_mixture(
 			(ccs_distribution_t)object, cum_size, opts));
+		break;
+	case CCS_SERIALIZE_FORMAT_JSON:
 		break;
 	default:
 		CCS_RAISE(
@@ -127,6 +164,10 @@ _ccs_distribution_mixture_serialize(
 	case CCS_SERIALIZE_FORMAT_BINARY:
 		CCS_VALIDATE(_ccs_serialize_bin_ccs_distribution_mixture(
 			(ccs_distribution_t)object, buffer_size, buffer, opts));
+		break;
+	case CCS_SERIALIZE_FORMAT_JSON:
+		CCS_VALIDATE(_ccs_serialize_json_ccs_distribution_mixture(
+			(ccs_distribution_t)object, *(cJSON **)buffer, opts));
 		break;
 	default:
 		CCS_RAISE(

--- a/src/distribution_mixture.c
+++ b/src/distribution_mixture.c
@@ -142,8 +142,6 @@ _ccs_distribution_mixture_serialize_size(
 		CCS_VALIDATE(_ccs_serialize_bin_size_ccs_distribution_mixture(
 			(ccs_distribution_t)object, cum_size, opts));
 		break;
-	case CCS_SERIALIZE_FORMAT_JSON:
-		break;
 	default:
 		CCS_RAISE(
 			CCS_RESULT_ERROR_INVALID_VALUE,

--- a/src/distribution_multivariate.c
+++ b/src/distribution_multivariate.c
@@ -128,8 +128,6 @@ _ccs_distribution_multivariate_serialize_size(
 			_ccs_serialize_bin_size_ccs_distribution_multivariate(
 				(ccs_distribution_t)object, cum_size, opts));
 		break;
-	case CCS_SERIALIZE_FORMAT_JSON:
-		break;
 	default:
 		CCS_RAISE(
 			CCS_RESULT_ERROR_INVALID_VALUE,

--- a/src/distribution_multivariate.c
+++ b/src/distribution_multivariate.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include "cconfigspace_internal.h"
 #include "distribution_internal.h"
+#include "cconfigspace_json.h"
 
 struct _ccs_distribution_multivariate_data_s {
 	_ccs_distribution_common_data_t common_data;
@@ -88,6 +89,32 @@ _ccs_serialize_bin_ccs_distribution_multivariate(
 	return CCS_RESULT_SUCCESS;
 }
 
+static inline ccs_result_t
+_ccs_serialize_json_ccs_distribution_multivariate(
+	ccs_distribution_t               distribution,
+	cJSON                           *json,
+	_ccs_object_serialize_options_t *opts)
+{
+	_ccs_distribution_multivariate_data_t *data =
+		(_ccs_distribution_multivariate_data_t *)(distribution->data);
+	CCS_REFUTE(
+		!cJSON_AddStringToObject(
+			json, "distribution_type", "multivariate"),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	cJSON *distributions = cJSON_AddArrayToObject(json, "distributions");
+	CCS_REFUTE(!distributions, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	for (size_t i = 0; i < data->num_distributions; i++) {
+		cJSON *child = cJSON_CreateObject();
+		CCS_REFUTE(!child, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		cJSON_AddItemToArray(distributions, child);
+		size_t dummy = 0;
+		CCS_VALIDATE(_ccs_object_serialize_with_opts(
+			data->distributions[i], CCS_SERIALIZE_FORMAT_JSON,
+			&dummy, (char **)&child, opts));
+	}
+	return CCS_RESULT_SUCCESS;
+}
+
 static ccs_result_t
 _ccs_distribution_multivariate_serialize_size(
 	ccs_object_t                     object,
@@ -100,6 +127,8 @@ _ccs_distribution_multivariate_serialize_size(
 		CCS_VALIDATE(
 			_ccs_serialize_bin_size_ccs_distribution_multivariate(
 				(ccs_distribution_t)object, cum_size, opts));
+		break;
+	case CCS_SERIALIZE_FORMAT_JSON:
 		break;
 	default:
 		CCS_RAISE(
@@ -121,6 +150,10 @@ _ccs_distribution_multivariate_serialize(
 	case CCS_SERIALIZE_FORMAT_BINARY:
 		CCS_VALIDATE(_ccs_serialize_bin_ccs_distribution_multivariate(
 			(ccs_distribution_t)object, buffer_size, buffer, opts));
+		break;
+	case CCS_SERIALIZE_FORMAT_JSON:
+		CCS_VALIDATE(_ccs_serialize_json_ccs_distribution_multivariate(
+			(ccs_distribution_t)object, *(cJSON **)buffer, opts));
 		break;
 	default:
 		CCS_RAISE(

--- a/src/distribution_normal.c
+++ b/src/distribution_normal.c
@@ -141,8 +141,6 @@ _ccs_distribution_normal_serialize_size(
 		*cum_size += _ccs_serialize_bin_size_ccs_distribution_normal(
 			(ccs_distribution_t)object);
 		break;
-	case CCS_SERIALIZE_FORMAT_JSON:
-		break;
 	default:
 		CCS_RAISE(
 			CCS_RESULT_ERROR_INVALID_VALUE,

--- a/src/distribution_normal.c
+++ b/src/distribution_normal.c
@@ -3,6 +3,7 @@
 #include <gsl/gsl_randist.h>
 #include "cconfigspace_internal.h"
 #include "distribution_internal.h"
+#include "cconfigspace_json.h"
 #include "rng_internal.h"
 
 struct _ccs_distribution_normal_data_s {
@@ -86,6 +87,47 @@ _ccs_serialize_bin_ccs_distribution_normal(
 	return CCS_RESULT_SUCCESS;
 }
 
+static inline ccs_result_t
+_ccs_serialize_json_ccs_distribution_normal(
+	ccs_distribution_t distribution,
+	cJSON             *json)
+{
+	_ccs_distribution_normal_data_t *data =
+		(_ccs_distribution_normal_data_t *)(distribution->data);
+	CCS_REFUTE(
+		!cJSON_AddStringToObject(json, "distribution_type", "normal"),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	CCS_REFUTE(
+		!cJSON_AddStringToObject(
+			json, "data_type",
+			_ccs_json_numeric_type_to_string(
+				data->common_data.data_types[0])),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	CCS_REFUTE(
+		!cJSON_AddStringToObject(
+			json, "scale_type",
+			_ccs_json_scale_type_to_string(data->scale_type)),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	CCS_REFUTE(
+		!cJSON_AddNumberToObject(json, "mu", data->mu),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	CCS_REFUTE(
+		!cJSON_AddNumberToObject(json, "sigma", data->sigma),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	if (data->common_data.data_types[0] == CCS_NUMERIC_TYPE_FLOAT) {
+		CCS_REFUTE(
+			!cJSON_AddNumberToObject(
+				json, "quantization", data->quantization.f),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	} else {
+		CCS_REFUTE(
+			!cJSON_AddNumberToObject(
+				json, "quantization", data->quantization.i),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	}
+	return CCS_RESULT_SUCCESS;
+}
+
 static ccs_result_t
 _ccs_distribution_normal_serialize_size(
 	ccs_object_t                     object,
@@ -98,6 +140,8 @@ _ccs_distribution_normal_serialize_size(
 	case CCS_SERIALIZE_FORMAT_BINARY:
 		*cum_size += _ccs_serialize_bin_size_ccs_distribution_normal(
 			(ccs_distribution_t)object);
+		break;
+	case CCS_SERIALIZE_FORMAT_JSON:
 		break;
 	default:
 		CCS_RAISE(
@@ -120,6 +164,10 @@ _ccs_distribution_normal_serialize(
 	case CCS_SERIALIZE_FORMAT_BINARY:
 		CCS_VALIDATE(_ccs_serialize_bin_ccs_distribution_normal(
 			(ccs_distribution_t)object, buffer_size, buffer));
+		break;
+	case CCS_SERIALIZE_FORMAT_JSON:
+		CCS_VALIDATE(_ccs_serialize_json_ccs_distribution_normal(
+			(ccs_distribution_t)object, *(cJSON **)buffer));
 		break;
 	default:
 		CCS_RAISE(

--- a/src/distribution_roulette.c
+++ b/src/distribution_roulette.c
@@ -108,8 +108,6 @@ _ccs_distribution_roulette_serialize_size(
 		*cum_size += _ccs_serialize_bin_size_ccs_distribution_roulette(
 			(ccs_distribution_t)object);
 		break;
-	case CCS_SERIALIZE_FORMAT_JSON:
-		break;
 	default:
 		CCS_RAISE(
 			CCS_RESULT_ERROR_INVALID_VALUE,

--- a/src/distribution_roulette.c
+++ b/src/distribution_roulette.c
@@ -3,6 +3,7 @@
 #include <math.h>
 #include "cconfigspace_internal.h"
 #include "distribution_internal.h"
+#include "cconfigspace_json.h"
 #include "rng_internal.h"
 
 struct _ccs_distribution_roulette_data_s {
@@ -72,6 +73,28 @@ _ccs_serialize_bin_ccs_distribution_roulette(
 	return CCS_RESULT_SUCCESS;
 }
 
+static inline ccs_result_t
+_ccs_serialize_json_ccs_distribution_roulette(
+	ccs_distribution_t distribution,
+	cJSON             *json)
+{
+	_ccs_distribution_roulette_data_t *data =
+		(_ccs_distribution_roulette_data_t *)(distribution->data);
+	CCS_REFUTE(
+		!cJSON_AddStringToObject(json, "distribution_type", "roulette"),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	cJSON *areas = cJSON_AddArrayToObject(json, "areas");
+	CCS_REFUTE(!areas, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	for (size_t i = 0; i < data->num_areas; i++)
+		CCS_REFUTE(
+			!cJSON_AddItemToArray(
+				areas,
+				cJSON_CreateNumber(
+					data->areas[i + 1] - data->areas[i])),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	return CCS_RESULT_SUCCESS;
+}
+
 static ccs_result_t
 _ccs_distribution_roulette_serialize_size(
 	ccs_object_t                     object,
@@ -84,6 +107,8 @@ _ccs_distribution_roulette_serialize_size(
 	case CCS_SERIALIZE_FORMAT_BINARY:
 		*cum_size += _ccs_serialize_bin_size_ccs_distribution_roulette(
 			(ccs_distribution_t)object);
+		break;
+	case CCS_SERIALIZE_FORMAT_JSON:
 		break;
 	default:
 		CCS_RAISE(
@@ -106,6 +131,10 @@ _ccs_distribution_roulette_serialize(
 	case CCS_SERIALIZE_FORMAT_BINARY:
 		CCS_VALIDATE(_ccs_serialize_bin_ccs_distribution_roulette(
 			(ccs_distribution_t)object, buffer_size, buffer));
+		break;
+	case CCS_SERIALIZE_FORMAT_JSON:
+		CCS_VALIDATE(_ccs_serialize_json_ccs_distribution_roulette(
+			(ccs_distribution_t)object, *(cJSON **)buffer));
 		break;
 	default:
 		CCS_RAISE(

--- a/src/distribution_uniform.c
+++ b/src/distribution_uniform.c
@@ -158,8 +158,6 @@ _ccs_distribution_uniform_serialize_size(
 		*cum_size += _ccs_serialize_bin_size_ccs_distribution_uniform(
 			(ccs_distribution_t)object);
 		break;
-	case CCS_SERIALIZE_FORMAT_JSON:
-		break;
 	default:
 		CCS_RAISE(
 			CCS_RESULT_ERROR_INVALID_VALUE,

--- a/src/distribution_uniform.c
+++ b/src/distribution_uniform.c
@@ -3,6 +3,7 @@
 #include <gsl/gsl_randist.h>
 #include "cconfigspace_internal.h"
 #include "distribution_internal.h"
+#include "cconfigspace_json.h"
 #include "rng_internal.h"
 
 struct _ccs_distribution_uniform_data_s {
@@ -97,6 +98,53 @@ _ccs_serialize_bin_ccs_distribution_uniform(
 	return CCS_RESULT_SUCCESS;
 }
 
+static inline ccs_result_t
+_ccs_serialize_json_ccs_distribution_uniform(
+	ccs_distribution_t distribution,
+	cJSON             *json)
+{
+	_ccs_distribution_uniform_data_t *data =
+		(_ccs_distribution_uniform_data_t *)(distribution->data);
+	CCS_REFUTE(
+		!cJSON_AddStringToObject(json, "distribution_type", "uniform"),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	CCS_REFUTE(
+		!cJSON_AddStringToObject(
+			json, "data_type",
+			_ccs_json_numeric_type_to_string(
+				data->common_data.data_types[0])),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	CCS_REFUTE(
+		!cJSON_AddStringToObject(
+			json, "scale_type",
+			_ccs_json_scale_type_to_string(data->scale_type)),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	if (data->common_data.data_types[0] == CCS_NUMERIC_TYPE_FLOAT) {
+		CCS_REFUTE(
+			!cJSON_AddNumberToObject(json, "lower", data->lower.f),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		CCS_REFUTE(
+			!cJSON_AddNumberToObject(json, "upper", data->upper.f),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		CCS_REFUTE(
+			!cJSON_AddNumberToObject(
+				json, "quantization", data->quantization.f),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	} else {
+		CCS_REFUTE(
+			!cJSON_AddNumberToObject(json, "lower", data->lower.i),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		CCS_REFUTE(
+			!cJSON_AddNumberToObject(json, "upper", data->upper.i),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		CCS_REFUTE(
+			!cJSON_AddNumberToObject(
+				json, "quantization", data->quantization.i),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	}
+	return CCS_RESULT_SUCCESS;
+}
+
 static ccs_result_t
 _ccs_distribution_uniform_serialize_size(
 	ccs_object_t                     object,
@@ -109,6 +157,8 @@ _ccs_distribution_uniform_serialize_size(
 	case CCS_SERIALIZE_FORMAT_BINARY:
 		*cum_size += _ccs_serialize_bin_size_ccs_distribution_uniform(
 			(ccs_distribution_t)object);
+		break;
+	case CCS_SERIALIZE_FORMAT_JSON:
 		break;
 	default:
 		CCS_RAISE(
@@ -131,6 +181,10 @@ _ccs_distribution_uniform_serialize(
 	case CCS_SERIALIZE_FORMAT_BINARY:
 		CCS_VALIDATE(_ccs_serialize_bin_ccs_distribution_uniform(
 			(ccs_distribution_t)object, buffer_size, buffer));
+		break;
+	case CCS_SERIALIZE_FORMAT_JSON:
+		CCS_VALIDATE(_ccs_serialize_json_ccs_distribution_uniform(
+			(ccs_distribution_t)object, *(cJSON **)buffer));
 		break;
 	default:
 		CCS_RAISE(

--- a/tests/test_mixture_distribution.c
+++ b/tests/test_mixture_distribution.c
@@ -80,15 +80,45 @@ compare_distribution(
 	assert(refcount == 1);
 }
 
+static void
+test_serialize_deserialize(
+	ccs_distribution_t     distrib,
+	ccs_serialize_format_t format,
+	ccs_distribution_t    *distrib_ret)
+{
+	ccs_result_t err;
+	char        *buff;
+	size_t       buff_size;
+
+	err = ccs_object_serialize(
+		distrib, format, CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
+		CCS_SERIALIZE_OPTION_END);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	buff = (char *)malloc(buff_size);
+	assert(buff);
+
+	err = ccs_object_serialize(
+		distrib, format, CCS_SERIALIZE_OPERATION_MEMORY, buff_size,
+		buff, CCS_SERIALIZE_OPTION_END);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	err = ccs_object_deserialize(
+		(ccs_object_t *)distrib_ret, format,
+		CCS_DESERIALIZE_OPERATION_MEMORY, buff_size, buff,
+		CCS_DESERIALIZE_OPTION_END);
+	assert(err == CCS_RESULT_SUCCESS);
+	free(buff);
+}
+
 void
 test_create_mixture_distribution(void)
 {
-	ccs_distribution_t distrib      = NULL, distribs[NUM_DISTRIBS];
+	ccs_distribution_t distrib = NULL, distrib2 = NULL;
+	ccs_distribution_t distribs[NUM_DISTRIBS];
 	ccs_result_t       err          = CCS_RESULT_SUCCESS;
 	const size_t       num_distribs = NUM_DISTRIBS;
 	ccs_float_t        weights[NUM_DISTRIBS];
-	char              *buff;
-	size_t             buff_size;
 
 	for (size_t i = 0; i < num_distribs; i++) {
 		weights[i] = (ccs_float_t)(i + 1);
@@ -110,32 +140,17 @@ test_create_mixture_distribution(void)
 
 	compare_distribution(distrib, num_distribs, distribs, weights);
 
-	err = ccs_object_serialize(
-		distrib, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
-		CCS_SERIALIZE_OPTION_END);
+	test_serialize_deserialize(
+		distrib, CCS_SERIALIZE_FORMAT_BINARY, &distrib2);
+	compare_distribution(distrib2, num_distribs, distribs, weights);
+	err = ccs_release_object(distrib2);
 	assert(err == CCS_RESULT_SUCCESS);
 
-	buff = (char *)malloc(buff_size);
-	assert(buff);
-
-	err = ccs_object_serialize(
-		distrib, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_MEMORY, buff_size, buff,
-		CCS_SERIALIZE_OPTION_END);
+	test_serialize_deserialize(
+		distrib, CCS_SERIALIZE_FORMAT_JSON, &distrib2);
+	compare_distribution(distrib2, num_distribs, distribs, weights);
+	err = ccs_release_object(distrib2);
 	assert(err == CCS_RESULT_SUCCESS);
-
-	err = ccs_release_object(distrib);
-	assert(err == CCS_RESULT_SUCCESS);
-
-	err = ccs_object_deserialize(
-		(ccs_object_t *)&distrib, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_DESERIALIZE_OPERATION_MEMORY, buff_size, buff,
-		CCS_DESERIALIZE_OPTION_END);
-	assert(err == CCS_RESULT_SUCCESS);
-	free(buff);
-
-	compare_distribution(distrib, num_distribs, distribs, weights);
 
 	for (size_t i = 0; i < num_distribs; i++) {
 		err = ccs_release_object(distribs[i]);

--- a/tests/test_mixture_distribution.c
+++ b/tests/test_mixture_distribution.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <cconfigspace.h>
+#include "test_utils.h"
 #include <gsl/gsl_statistics.h>
 #include <gsl/gsl_randist.h>
 #include <gsl/gsl_cdf.h>
@@ -80,37 +81,6 @@ compare_distribution(
 	assert(refcount == 1);
 }
 
-static void
-test_serialize_deserialize(
-	ccs_distribution_t     distrib,
-	ccs_serialize_format_t format,
-	ccs_distribution_t    *distrib_ret)
-{
-	ccs_result_t err;
-	char        *buff;
-	size_t       buff_size;
-
-	err = ccs_object_serialize(
-		distrib, format, CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
-		CCS_SERIALIZE_OPTION_END);
-	assert(err == CCS_RESULT_SUCCESS);
-
-	buff = (char *)malloc(buff_size);
-	assert(buff);
-
-	err = ccs_object_serialize(
-		distrib, format, CCS_SERIALIZE_OPERATION_MEMORY, buff_size,
-		buff, CCS_SERIALIZE_OPTION_END);
-	assert(err == CCS_RESULT_SUCCESS);
-
-	err = ccs_object_deserialize(
-		(ccs_object_t *)distrib_ret, format,
-		CCS_DESERIALIZE_OPERATION_MEMORY, buff_size, buff,
-		CCS_DESERIALIZE_OPTION_END);
-	assert(err == CCS_RESULT_SUCCESS);
-	free(buff);
-}
-
 void
 test_create_mixture_distribution(void)
 {
@@ -141,13 +111,15 @@ test_create_mixture_distribution(void)
 	compare_distribution(distrib, num_distribs, distribs, weights);
 
 	test_serialize_deserialize(
-		distrib, CCS_SERIALIZE_FORMAT_BINARY, &distrib2);
+		(ccs_object_t)distrib, CCS_SERIALIZE_FORMAT_BINARY,
+		(ccs_object_t *)&distrib2);
 	compare_distribution(distrib2, num_distribs, distribs, weights);
 	err = ccs_release_object(distrib2);
 	assert(err == CCS_RESULT_SUCCESS);
 
 	test_serialize_deserialize(
-		distrib, CCS_SERIALIZE_FORMAT_JSON, &distrib2);
+		(ccs_object_t)distrib, CCS_SERIALIZE_FORMAT_JSON,
+		(ccs_object_t *)&distrib2);
 	compare_distribution(distrib2, num_distribs, distribs, weights);
 	err = ccs_release_object(distrib2);
 	assert(err == CCS_RESULT_SUCCESS);

--- a/tests/test_multivariate_distribution.c
+++ b/tests/test_multivariate_distribution.c
@@ -82,19 +82,46 @@ compare_distribution(
 	assert(refcount == 1);
 }
 
+static void
+test_serialize_deserialize(
+	ccs_distribution_t     distrib,
+	ccs_serialize_format_t format,
+	ccs_distribution_t    *distrib_ret)
+{
+	ccs_result_t err;
+	char        *buff;
+	size_t       buff_size;
+
+	err = ccs_object_serialize(
+		distrib, format, CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
+		CCS_SERIALIZE_OPTION_END);
+	assert(err == CCS_RESULT_SUCCESS);
+	buff = (char *)malloc(buff_size);
+	assert(buff);
+	err = ccs_object_serialize(
+		distrib, format, CCS_SERIALIZE_OPERATION_MEMORY, buff_size,
+		buff, CCS_SERIALIZE_OPTION_END);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_object_deserialize(
+		(ccs_object_t *)distrib_ret, format,
+		CCS_DESERIALIZE_OPERATION_MEMORY, buff_size, buff,
+		CCS_DESERIALIZE_OPTION_END);
+	assert(err == CCS_RESULT_SUCCESS);
+	free(buff);
+}
+
 void
 test_create_multivariate_distribution(void)
 {
 	const size_t       num_distribs = NUM_DISTRIBS;
 	ccs_distribution_t distrib      = NULL;
+	ccs_distribution_t distrib2     = NULL;
 	ccs_distribution_t distribs[NUM_DISTRIBS];
 	ccs_result_t       err = CCS_RESULT_SUCCESS;
-	char              *buff;
-	size_t             buff_size;
 
-	err = ccs_create_uniform_distribution(
-		CCS_NUMERIC_TYPE_FLOAT, CCSF(-5.0), CCSF(5.0),
-		CCS_SCALE_TYPE_LINEAR, CCSF(0.0), distribs);
+	err                    = ccs_create_uniform_distribution(
+                CCS_NUMERIC_TYPE_FLOAT, CCSF(-5.0), CCSF(5.0),
+                CCS_SCALE_TYPE_LINEAR, CCSF(0.0), distribs);
 	assert(err == CCS_RESULT_SUCCESS);
 
 	err = ccs_create_uniform_distribution(
@@ -105,35 +132,19 @@ test_create_multivariate_distribution(void)
 	err = ccs_create_multivariate_distribution(
 		num_distribs, distribs, &distrib);
 	assert(err == CCS_RESULT_SUCCESS);
-
 	compare_distribution(distrib, num_distribs, distribs);
 
-	err = ccs_object_serialize(
-		distrib, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
-		CCS_SERIALIZE_OPTION_END);
+	test_serialize_deserialize(
+		distrib, CCS_SERIALIZE_FORMAT_BINARY, &distrib2);
+	compare_distribution(distrib2, num_distribs, distribs);
+	err = ccs_release_object(distrib2);
 	assert(err == CCS_RESULT_SUCCESS);
 
-	buff = (char *)malloc(buff_size);
-	assert(buff);
-
-	err = ccs_object_serialize(
-		distrib, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_MEMORY, buff_size, buff,
-		CCS_SERIALIZE_OPTION_END);
+	test_serialize_deserialize(
+		distrib, CCS_SERIALIZE_FORMAT_JSON, &distrib2);
+	compare_distribution(distrib2, num_distribs, distribs);
+	err = ccs_release_object(distrib2);
 	assert(err == CCS_RESULT_SUCCESS);
-
-	err = ccs_release_object(distrib);
-	assert(err == CCS_RESULT_SUCCESS);
-
-	err = ccs_object_deserialize(
-		(ccs_object_t *)&distrib, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_DESERIALIZE_OPERATION_MEMORY, buff_size, buff,
-		CCS_DESERIALIZE_OPTION_END);
-	assert(err == CCS_RESULT_SUCCESS);
-	free(buff);
-
-	compare_distribution(distrib, num_distribs, distribs);
 
 	for (size_t i = 0; i < num_distribs; i++) {
 		err = ccs_release_object(distribs[i]);

--- a/tests/test_multivariate_distribution.c
+++ b/tests/test_multivariate_distribution.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <cconfigspace.h>
+#include "test_utils.h"
 #include <gsl/gsl_statistics.h>
 #include <gsl/gsl_randist.h>
 #include <gsl/gsl_cdf.h>
@@ -82,34 +83,6 @@ compare_distribution(
 	assert(refcount == 1);
 }
 
-static void
-test_serialize_deserialize(
-	ccs_distribution_t     distrib,
-	ccs_serialize_format_t format,
-	ccs_distribution_t    *distrib_ret)
-{
-	ccs_result_t err;
-	char        *buff;
-	size_t       buff_size;
-
-	err = ccs_object_serialize(
-		distrib, format, CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
-		CCS_SERIALIZE_OPTION_END);
-	assert(err == CCS_RESULT_SUCCESS);
-	buff = (char *)malloc(buff_size);
-	assert(buff);
-	err = ccs_object_serialize(
-		distrib, format, CCS_SERIALIZE_OPERATION_MEMORY, buff_size,
-		buff, CCS_SERIALIZE_OPTION_END);
-	assert(err == CCS_RESULT_SUCCESS);
-	err = ccs_object_deserialize(
-		(ccs_object_t *)distrib_ret, format,
-		CCS_DESERIALIZE_OPERATION_MEMORY, buff_size, buff,
-		CCS_DESERIALIZE_OPTION_END);
-	assert(err == CCS_RESULT_SUCCESS);
-	free(buff);
-}
-
 void
 test_create_multivariate_distribution(void)
 {
@@ -135,13 +108,15 @@ test_create_multivariate_distribution(void)
 	compare_distribution(distrib, num_distribs, distribs);
 
 	test_serialize_deserialize(
-		distrib, CCS_SERIALIZE_FORMAT_BINARY, &distrib2);
+		(ccs_object_t)distrib, CCS_SERIALIZE_FORMAT_BINARY,
+		(ccs_object_t *)&distrib2);
 	compare_distribution(distrib2, num_distribs, distribs);
 	err = ccs_release_object(distrib2);
 	assert(err == CCS_RESULT_SUCCESS);
 
 	test_serialize_deserialize(
-		distrib, CCS_SERIALIZE_FORMAT_JSON, &distrib2);
+		(ccs_object_t)distrib, CCS_SERIALIZE_FORMAT_JSON,
+		(ccs_object_t *)&distrib2);
 	compare_distribution(distrib2, num_distribs, distribs);
 	err = ccs_release_object(distrib2);
 	assert(err == CCS_RESULT_SUCCESS);

--- a/tests/test_normal_distribution.c
+++ b/tests/test_normal_distribution.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <cconfigspace.h>
+#include "test_utils.h"
 #include <gsl/gsl_statistics.h>
 #include <gsl/gsl_randist.h>
 #include <gsl/gsl_cdf.h>
@@ -59,34 +60,6 @@ compare_distribution(
 }
 
 static void
-test_serialize_deserialize(
-	ccs_distribution_t     distrib,
-	ccs_serialize_format_t format,
-	ccs_distribution_t    *distrib_ret)
-{
-	ccs_result_t err;
-	char        *buff;
-	size_t       buff_size;
-
-	err = ccs_object_serialize(
-		distrib, format, CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
-		CCS_SERIALIZE_OPTION_END);
-	assert(err == CCS_RESULT_SUCCESS);
-	buff = (char *)malloc(buff_size);
-	assert(buff);
-	err = ccs_object_serialize(
-		distrib, format, CCS_SERIALIZE_OPERATION_MEMORY, buff_size,
-		buff, CCS_SERIALIZE_OPTION_END);
-	assert(err == CCS_RESULT_SUCCESS);
-	err = ccs_object_deserialize(
-		(ccs_object_t *)distrib_ret, format,
-		CCS_DESERIALIZE_OPERATION_MEMORY, buff_size, buff,
-		CCS_DESERIALIZE_OPTION_END);
-	assert(err == CCS_RESULT_SUCCESS);
-	free(buff);
-}
-
-static void
 test_create_normal_distribution(void)
 {
 	ccs_distribution_t distrib  = NULL;
@@ -100,13 +73,15 @@ test_create_normal_distribution(void)
 	compare_distribution(distrib, 1.0, 2.0, CCSF(0.0));
 
 	test_serialize_deserialize(
-		distrib, CCS_SERIALIZE_FORMAT_BINARY, &distrib2);
+		(ccs_object_t)distrib, CCS_SERIALIZE_FORMAT_BINARY,
+		(ccs_object_t *)&distrib2);
 	compare_distribution(distrib2, 1.0, 2.0, CCSF(0.0));
 	err = ccs_release_object(distrib2);
 	assert(err == CCS_RESULT_SUCCESS);
 
 	test_serialize_deserialize(
-		distrib, CCS_SERIALIZE_FORMAT_JSON, &distrib2);
+		(ccs_object_t)distrib, CCS_SERIALIZE_FORMAT_JSON,
+		(ccs_object_t *)&distrib2);
 	compare_distribution(distrib2, 1.0, 2.0, CCSF(0.0));
 	err = ccs_release_object(distrib2);
 	assert(err == CCS_RESULT_SUCCESS);

--- a/tests/test_normal_distribution.c
+++ b/tests/test_normal_distribution.c
@@ -59,46 +59,57 @@ compare_distribution(
 }
 
 static void
-test_create_normal_distribution(void)
+test_serialize_deserialize(
+	ccs_distribution_t     distrib,
+	ccs_serialize_format_t format,
+	ccs_distribution_t    *distrib_ret)
 {
-	ccs_distribution_t distrib = NULL;
-	ccs_result_t       err     = CCS_RESULT_SUCCESS;
-	char              *buff;
-	size_t             buff_size;
-
-	err = ccs_create_normal_distribution(
-		CCS_NUMERIC_TYPE_FLOAT, 1.0, 2.0, CCS_SCALE_TYPE_LINEAR,
-		CCSF(0.0), &distrib);
-	assert(err == CCS_RESULT_SUCCESS);
-
-	compare_distribution(distrib, 1.0, 2.0, CCSF(0.0));
+	ccs_result_t err;
+	char        *buff;
+	size_t       buff_size;
 
 	err = ccs_object_serialize(
-		distrib, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
+		distrib, format, CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
 		CCS_SERIALIZE_OPTION_END);
 	assert(err == CCS_RESULT_SUCCESS);
-
 	buff = (char *)malloc(buff_size);
 	assert(buff);
-
 	err = ccs_object_serialize(
-		distrib, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_MEMORY, buff_size, buff,
-		CCS_SERIALIZE_OPTION_END);
+		distrib, format, CCS_SERIALIZE_OPERATION_MEMORY, buff_size,
+		buff, CCS_SERIALIZE_OPTION_END);
 	assert(err == CCS_RESULT_SUCCESS);
-
-	err = ccs_release_object(distrib);
-	assert(err == CCS_RESULT_SUCCESS);
-
 	err = ccs_object_deserialize(
-		(ccs_object_t *)&distrib, CCS_SERIALIZE_FORMAT_BINARY,
+		(ccs_object_t *)distrib_ret, format,
 		CCS_DESERIALIZE_OPERATION_MEMORY, buff_size, buff,
 		CCS_DESERIALIZE_OPTION_END);
 	assert(err == CCS_RESULT_SUCCESS);
 	free(buff);
+}
 
+static void
+test_create_normal_distribution(void)
+{
+	ccs_distribution_t distrib  = NULL;
+	ccs_distribution_t distrib2 = NULL;
+	ccs_result_t       err      = CCS_RESULT_SUCCESS;
+
+	err                         = ccs_create_normal_distribution(
+                CCS_NUMERIC_TYPE_FLOAT, 1.0, 2.0, CCS_SCALE_TYPE_LINEAR,
+                CCSF(0.0), &distrib);
+	assert(err == CCS_RESULT_SUCCESS);
 	compare_distribution(distrib, 1.0, 2.0, CCSF(0.0));
+
+	test_serialize_deserialize(
+		distrib, CCS_SERIALIZE_FORMAT_BINARY, &distrib2);
+	compare_distribution(distrib2, 1.0, 2.0, CCSF(0.0));
+	err = ccs_release_object(distrib2);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	test_serialize_deserialize(
+		distrib, CCS_SERIALIZE_FORMAT_JSON, &distrib2);
+	compare_distribution(distrib2, 1.0, 2.0, CCSF(0.0));
+	err = ccs_release_object(distrib2);
+	assert(err == CCS_RESULT_SUCCESS);
 
 	err = ccs_release_object(distrib);
 	assert(err == CCS_RESULT_SUCCESS);

--- a/tests/test_roulette_distribution.c
+++ b/tests/test_roulette_distribution.c
@@ -61,15 +61,42 @@ compare_distribution(
 	assert(refcount == 1);
 }
 
+static void
+test_serialize_deserialize(
+	ccs_distribution_t     distrib,
+	ccs_serialize_format_t format,
+	ccs_distribution_t    *distrib_ret)
+{
+	ccs_result_t err;
+	char        *buff;
+	size_t       buff_size;
+
+	err = ccs_object_serialize(
+		distrib, format, CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
+		CCS_SERIALIZE_OPTION_END);
+	assert(err == CCS_RESULT_SUCCESS);
+	buff = (char *)malloc(buff_size);
+	assert(buff);
+	err = ccs_object_serialize(
+		distrib, format, CCS_SERIALIZE_OPERATION_MEMORY, buff_size,
+		buff, CCS_SERIALIZE_OPTION_END);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_object_deserialize(
+		(ccs_object_t *)distrib_ret, format,
+		CCS_DESERIALIZE_OPERATION_MEMORY, buff_size, buff,
+		CCS_DESERIALIZE_OPTION_END);
+	assert(err == CCS_RESULT_SUCCESS);
+	free(buff);
+}
+
 void
 test_create_roulette_distribution(void)
 {
 	ccs_distribution_t distrib   = NULL;
+	ccs_distribution_t distrib2  = NULL;
 	ccs_result_t       err       = CCS_RESULT_SUCCESS;
 	const size_t       num_areas = NUM_AREAS;
 	ccs_float_t        areas[NUM_AREAS];
-	char              *buff;
-	size_t             buff_size;
 
 	for (size_t i = 0; i < num_areas; i++) {
 		areas[i] = (ccs_float_t)(i + 1);
@@ -77,35 +104,19 @@ test_create_roulette_distribution(void)
 
 	err = ccs_create_roulette_distribution(num_areas, areas, &distrib);
 	assert(err == CCS_RESULT_SUCCESS);
-
 	compare_distribution(distrib, num_areas, areas);
 
-	err = ccs_object_serialize(
-		distrib, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
-		CCS_SERIALIZE_OPTION_END);
+	test_serialize_deserialize(
+		distrib, CCS_SERIALIZE_FORMAT_BINARY, &distrib2);
+	compare_distribution(distrib2, num_areas, areas);
+	err = ccs_release_object(distrib2);
 	assert(err == CCS_RESULT_SUCCESS);
 
-	buff = (char *)malloc(buff_size);
-	assert(buff);
-
-	err = ccs_object_serialize(
-		distrib, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_MEMORY, buff_size, buff,
-		CCS_SERIALIZE_OPTION_END);
+	test_serialize_deserialize(
+		distrib, CCS_SERIALIZE_FORMAT_JSON, &distrib2);
+	compare_distribution(distrib2, num_areas, areas);
+	err = ccs_release_object(distrib2);
 	assert(err == CCS_RESULT_SUCCESS);
-
-	err = ccs_release_object(distrib);
-	assert(err == CCS_RESULT_SUCCESS);
-
-	err = ccs_object_deserialize(
-		(ccs_object_t *)&distrib, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_DESERIALIZE_OPERATION_MEMORY, buff_size, buff,
-		CCS_DESERIALIZE_OPTION_END);
-	assert(err == CCS_RESULT_SUCCESS);
-	free(buff);
-
-	compare_distribution(distrib, num_areas, areas);
 
 	err = ccs_release_object(distrib);
 	assert(err == CCS_RESULT_SUCCESS);

--- a/tests/test_roulette_distribution.c
+++ b/tests/test_roulette_distribution.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <cconfigspace.h>
+#include "test_utils.h"
 #include <gsl/gsl_statistics.h>
 #include <gsl/gsl_randist.h>
 #include <gsl/gsl_cdf.h>
@@ -61,34 +62,6 @@ compare_distribution(
 	assert(refcount == 1);
 }
 
-static void
-test_serialize_deserialize(
-	ccs_distribution_t     distrib,
-	ccs_serialize_format_t format,
-	ccs_distribution_t    *distrib_ret)
-{
-	ccs_result_t err;
-	char        *buff;
-	size_t       buff_size;
-
-	err = ccs_object_serialize(
-		distrib, format, CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
-		CCS_SERIALIZE_OPTION_END);
-	assert(err == CCS_RESULT_SUCCESS);
-	buff = (char *)malloc(buff_size);
-	assert(buff);
-	err = ccs_object_serialize(
-		distrib, format, CCS_SERIALIZE_OPERATION_MEMORY, buff_size,
-		buff, CCS_SERIALIZE_OPTION_END);
-	assert(err == CCS_RESULT_SUCCESS);
-	err = ccs_object_deserialize(
-		(ccs_object_t *)distrib_ret, format,
-		CCS_DESERIALIZE_OPERATION_MEMORY, buff_size, buff,
-		CCS_DESERIALIZE_OPTION_END);
-	assert(err == CCS_RESULT_SUCCESS);
-	free(buff);
-}
-
 void
 test_create_roulette_distribution(void)
 {
@@ -107,13 +80,15 @@ test_create_roulette_distribution(void)
 	compare_distribution(distrib, num_areas, areas);
 
 	test_serialize_deserialize(
-		distrib, CCS_SERIALIZE_FORMAT_BINARY, &distrib2);
+		(ccs_object_t)distrib, CCS_SERIALIZE_FORMAT_BINARY,
+		(ccs_object_t *)&distrib2);
 	compare_distribution(distrib2, num_areas, areas);
 	err = ccs_release_object(distrib2);
 	assert(err == CCS_RESULT_SUCCESS);
 
 	test_serialize_deserialize(
-		distrib, CCS_SERIALIZE_FORMAT_JSON, &distrib2);
+		(ccs_object_t)distrib, CCS_SERIALIZE_FORMAT_JSON,
+		(ccs_object_t *)&distrib2);
 	compare_distribution(distrib2, num_areas, areas);
 	err = ccs_release_object(distrib2);
 	assert(err == CCS_RESULT_SUCCESS);

--- a/tests/test_uniform_distribution.c
+++ b/tests/test_uniform_distribution.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <cconfigspace.h>
+#include "test_utils.h"
 
 #define NUM_SAMPLES     100
 #define NUM_SAMPLES_BIG 1000
@@ -55,37 +56,6 @@ compare_distribution(
 }
 
 static void
-test_serialize_deserialize(
-	ccs_distribution_t     distrib,
-	ccs_serialize_format_t format,
-	ccs_distribution_t    *distrib_ret)
-{
-	ccs_result_t err;
-	char        *buff;
-	size_t       buff_size;
-
-	err = ccs_object_serialize(
-		distrib, format, CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
-		CCS_SERIALIZE_OPTION_END);
-	assert(err == CCS_RESULT_SUCCESS);
-
-	buff = (char *)malloc(buff_size);
-	assert(buff);
-
-	err = ccs_object_serialize(
-		distrib, format, CCS_SERIALIZE_OPERATION_MEMORY, buff_size,
-		buff, CCS_SERIALIZE_OPTION_END);
-	assert(err == CCS_RESULT_SUCCESS);
-
-	err = ccs_object_deserialize(
-		(ccs_object_t *)distrib_ret, format,
-		CCS_DESERIALIZE_OPERATION_MEMORY, buff_size, buff,
-		CCS_DESERIALIZE_OPTION_END);
-	assert(err == CCS_RESULT_SUCCESS);
-	free(buff);
-}
-
-static void
 test_create_uniform_distribution(void)
 {
 	ccs_distribution_t distrib  = NULL;
@@ -103,13 +73,15 @@ test_create_uniform_distribution(void)
 	compare_distribution(distrib, l, u, q);
 
 	test_serialize_deserialize(
-		distrib, CCS_SERIALIZE_FORMAT_BINARY, &distrib2);
+		(ccs_object_t)distrib, CCS_SERIALIZE_FORMAT_BINARY,
+		(ccs_object_t *)&distrib2);
 	compare_distribution(distrib2, l, u, q);
 	err = ccs_release_object(distrib2);
 	assert(err == CCS_RESULT_SUCCESS);
 
 	test_serialize_deserialize(
-		distrib, CCS_SERIALIZE_FORMAT_JSON, &distrib2);
+		(ccs_object_t)distrib, CCS_SERIALIZE_FORMAT_JSON,
+		(ccs_object_t *)&distrib2);
 	compare_distribution(distrib2, l, u, q);
 	err = ccs_release_object(distrib2);
 	assert(err == CCS_RESULT_SUCCESS);

--- a/tests/test_uniform_distribution.c
+++ b/tests/test_uniform_distribution.c
@@ -55,26 +55,17 @@ compare_distribution(
 }
 
 static void
-test_create_uniform_distribution(void)
+test_serialize_deserialize(
+	ccs_distribution_t     distrib,
+	ccs_serialize_format_t format,
+	ccs_distribution_t    *distrib_ret)
 {
-	ccs_distribution_t distrib = NULL;
-	ccs_result_t       err     = CCS_RESULT_SUCCESS;
-	ccs_int_t          l       = -10L;
-	ccs_int_t          u       = 11L;
-	ccs_int_t          q       = 0L;
-	char              *buff;
-	size_t             buff_size;
-
-	err = ccs_create_uniform_distribution(
-		CCS_NUMERIC_TYPE_INT, CCSI(l), CCSI(u), CCS_SCALE_TYPE_LINEAR,
-		CCSI(q), &distrib);
-	assert(err == CCS_RESULT_SUCCESS);
-
-	compare_distribution(distrib, l, u, q);
+	ccs_result_t err;
+	char        *buff;
+	size_t       buff_size;
 
 	err = ccs_object_serialize(
-		distrib, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
+		distrib, format, CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
 		CCS_SERIALIZE_OPTION_END);
 	assert(err == CCS_RESULT_SUCCESS);
 
@@ -82,22 +73,46 @@ test_create_uniform_distribution(void)
 	assert(buff);
 
 	err = ccs_object_serialize(
-		distrib, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_MEMORY, buff_size, buff,
-		CCS_SERIALIZE_OPTION_END);
-	assert(err == CCS_RESULT_SUCCESS);
-
-	err = ccs_release_object(distrib);
+		distrib, format, CCS_SERIALIZE_OPERATION_MEMORY, buff_size,
+		buff, CCS_SERIALIZE_OPTION_END);
 	assert(err == CCS_RESULT_SUCCESS);
 
 	err = ccs_object_deserialize(
-		(ccs_object_t *)&distrib, CCS_SERIALIZE_FORMAT_BINARY,
+		(ccs_object_t *)distrib_ret, format,
 		CCS_DESERIALIZE_OPERATION_MEMORY, buff_size, buff,
 		CCS_DESERIALIZE_OPTION_END);
 	assert(err == CCS_RESULT_SUCCESS);
 	free(buff);
+}
+
+static void
+test_create_uniform_distribution(void)
+{
+	ccs_distribution_t distrib  = NULL;
+	ccs_distribution_t distrib2 = NULL;
+	ccs_result_t       err      = CCS_RESULT_SUCCESS;
+	ccs_int_t          l        = -10L;
+	ccs_int_t          u        = 11L;
+	ccs_int_t          q        = 0L;
+
+	err                         = ccs_create_uniform_distribution(
+                CCS_NUMERIC_TYPE_INT, CCSI(l), CCSI(u), CCS_SCALE_TYPE_LINEAR,
+                CCSI(q), &distrib);
+	assert(err == CCS_RESULT_SUCCESS);
 
 	compare_distribution(distrib, l, u, q);
+
+	test_serialize_deserialize(
+		distrib, CCS_SERIALIZE_FORMAT_BINARY, &distrib2);
+	compare_distribution(distrib2, l, u, q);
+	err = ccs_release_object(distrib2);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	test_serialize_deserialize(
+		distrib, CCS_SERIALIZE_FORMAT_JSON, &distrib2);
+	compare_distribution(distrib2, l, u, q);
+	err = ccs_release_object(distrib2);
+	assert(err == CCS_RESULT_SUCCESS);
 
 	err = ccs_release_object(distrib);
 	assert(err == CCS_RESULT_SUCCESS);

--- a/tests/test_utils.c
+++ b/tests/test_utils.c
@@ -1,5 +1,6 @@
 #include "test_utils.h"
 #include <assert.h>
+#include <stdlib.h>
 
 void
 print_ccs_error_stack(void)
@@ -118,4 +119,31 @@ create_knobs(ccs_features_t *features_on, ccs_features_t *features_off)
 	assert(err == CCS_RESULT_SUCCESS);
 
 	return fspace;
+}
+
+void
+test_serialize_deserialize(
+	ccs_object_t           object,
+	ccs_serialize_format_t format,
+	ccs_object_t          *object_ret)
+{
+	ccs_result_t err;
+	char        *buff;
+	size_t       buff_size;
+
+	err = ccs_object_serialize(
+		object, format, CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
+		CCS_SERIALIZE_OPTION_END);
+	assert(err == CCS_RESULT_SUCCESS);
+	buff = (char *)malloc(buff_size);
+	assert(buff);
+	err = ccs_object_serialize(
+		object, format, CCS_SERIALIZE_OPERATION_MEMORY, buff_size, buff,
+		CCS_SERIALIZE_OPTION_END);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_object_deserialize(
+		object_ret, format, CCS_DESERIALIZE_OPERATION_MEMORY, buff_size,
+		buff, CCS_DESERIALIZE_OPTION_END);
+	assert(err == CCS_RESULT_SUCCESS);
+	free(buff);
 }

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -14,3 +14,9 @@ create_height_objective(ccs_configuration_space_t cspace);
 
 extern ccs_feature_space_t
 create_knobs(ccs_features_t *features_on, ccs_features_t *features_off);
+
+extern void
+test_serialize_deserialize(
+	ccs_object_t           object,
+	ccs_serialize_format_t format,
+	ccs_object_t          *object_ret);


### PR DESCRIPTION
## Summary

Builds on PR #87 (cJSON vendor + infrastructure) to wire up the full JSON serialization/deserialization chain for all 5 distribution types.

### Architecture

Follows the existing binary pattern — format dispatch at each layer's switch statement:

- **`_ccs_serialize_ccs_object_internal`**: writes `"type"` and hex-encoded `"handle"` to cJSON node
- **`_ccs_object_serialize_user_data`**: hex-encodes user data to cJSON
- **Per-type ops**: each distribution type adds `"distribution_type"` and type-specific fields to a `"data"` node (or directly for distributions)
- **Compound distributions** (mixture, multivariate): serialize children via `_ccs_object_serialize_with_opts`, producing nested JSON objects

The `char **buffer` parameter is reinterpreted as `cJSON **` for JSON format — no function signature changes.

### JSON format

```json
{"header":{"version":1,"size":"..."},"object":{"type":"distribution","handle":"...","distribution_type":"mixture","weights":[...],"distributions":[{"type":"distribution","handle":"...","distribution_type":"uniform",...},...]}}
```

- Header includes hex-encoded size for FD deserialization (byte-by-byte header read)
- Object handles are hex-encoded strings (64-bit pointer-safe)
- Nested objects have `type` + `handle` + type-specific fields

### Changes

- `src/cconfigspace.c`: JSON paths in SIZE, MEMORY, FILE, FD serialize; JSON deserialize in `_ccs_object_deserialize` with header/object node separation; FD deserialize refactored with `_header_read`/`_header_decode` split
- `src/cconfigspace_internal.h`: JSON cases in `_ccs_serialize_ccs_object_internal`, `_ccs_deserialize_ccs_object_internal`, `_ccs_object_serialize_user_data`, `_ccs_object_deserialize_user_data`
- `src/cconfigspace_deserialize.h`: JSON case in `_ccs_object_deserialize_with_opts_check`
- `src/cconfigspace_json.h`: string conversion helpers for distribution_type, numeric_type, scale_type
- `src/distribution_{uniform,normal,roulette,mixture,multivariate}.c`: JSON serialize functions
- `src/distribution_deserialize.h`: JSON deserialize for all 5 types
- `tests/test_{uniform,normal,roulette,mixture,multivariate}_distribution.c`: JSON roundtrip tests

## Test plan

- [x] All 30 tests pass
- [x] JSON roundtrip for all 5 distribution types (uniform, normal, roulette, mixture, multivariate)
- [x] Compound distributions with nested children serialize/deserialize correctly
- [x] Same test code exercises both binary and JSON formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)