### PR TITLE
Add JSON serialization for feature space

### DIFF
--- a/src/binding_internal.h
+++ b/src/binding_internal.h
@@ -170,6 +170,23 @@ _ccs_serialize_bin_ccs_binding_data(
 }
 
 static inline ccs_result_t
+_ccs_serialize_json_ccs_binding(ccs_binding_t binding, cJSON *json)
+{
+	_ccs_binding_data_t *data = binding->data;
+	char                 hex[sizeof(ccs_object_t) * 2 + 1];
+	_ccs_json_hex_encode_buf(&data->context, sizeof(ccs_object_t), hex);
+	CCS_REFUTE(
+		!cJSON_AddStringToObject(json, "context", hex),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	cJSON *values = cJSON_AddArrayToObject(json, "values");
+	CCS_REFUTE(!values, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	for (size_t i = 0; i < data->num_values; i++)
+		CCS_VALIDATE(
+			_ccs_json_add_datum_to_array(values, data->values[i]));
+	return CCS_RESULT_SUCCESS;
+}
+
+static inline ccs_result_t
 _ccs_serialize_bin_size_ccs_binding(ccs_binding_t binding, size_t *cum_size)
 {
 	*cum_size += _ccs_serialize_bin_size_ccs_binding_data(binding->data);
@@ -206,6 +223,43 @@ _ccs_deserialize_bin_ccs_binding_data(
 		for (size_t i = 0; i < data->num_values; i++)
 			CCS_VALIDATE(_ccs_deserialize_bin_ccs_datum(
 				data->values + i, buffer_size, buffer));
+	}
+	return CCS_RESULT_SUCCESS;
+}
+
+static inline ccs_result_t
+_ccs_deserialize_json_ccs_binding_data(_ccs_binding_data_t *data, cJSON *json)
+{
+	size_t num;
+	cJSON *j_context = cJSON_GetObjectItemCaseSensitive(json, "context");
+	cJSON *j_values  = cJSON_GetObjectItemCaseSensitive(json, "values");
+	data->context    = NULL;
+	data->num_values = 0;
+	data->values     = NULL;
+	CCS_REFUTE(
+		!j_context || !cJSON_IsString(j_context),
+		CCS_RESULT_ERROR_INVALID_VALUE);
+	CCS_REFUTE(
+		!j_values || !cJSON_IsArray(j_values),
+		CCS_RESULT_ERROR_INVALID_VALUE);
+	CCS_REFUTE(
+		strlen(j_context->valuestring) != sizeof(ccs_object_t) * 2,
+		CCS_RESULT_ERROR_INVALID_VALUE);
+	CCS_REFUTE(
+		_ccs_json_hex_decode_buf(
+			j_context->valuestring, sizeof(ccs_object_t) * 2,
+			&data->context),
+		CCS_RESULT_ERROR_INVALID_VALUE);
+	num              = (size_t)cJSON_GetArraySize(j_values);
+	data->num_values = num;
+	if (num) {
+		data->values = (ccs_datum_t *)calloc(num, sizeof(ccs_datum_t));
+		CCS_REFUTE(!data->values, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		for (size_t i = 0; i < num; i++) {
+			cJSON *item = cJSON_GetArrayItem(j_values, (int)i);
+			CCS_VALIDATE(
+				_ccs_json_get_datum(item, data->values + i));
+		}
 	}
 	return CCS_RESULT_SUCCESS;
 }

--- a/src/context_deserialize.h
+++ b/src/context_deserialize.h
@@ -36,4 +36,43 @@ _ccs_deserialize_bin_ccs_context_data(
 	return CCS_RESULT_SUCCESS;
 }
 
+static inline ccs_result_t
+_ccs_deserialize_json_ccs_context_data(
+	_ccs_context_data_mock_t          *data,
+	uint32_t                           version,
+	cJSON                             *json,
+	_ccs_object_deserialize_options_t *opts)
+{
+	size_t num;
+	cJSON *j_name   = cJSON_GetObjectItemCaseSensitive(json, "name");
+	cJSON *j_params = cJSON_GetObjectItemCaseSensitive(json, "parameters");
+	data->num_parameters = 0;
+	data->parameters     = NULL;
+	CCS_REFUTE(
+		!j_name || !cJSON_IsString(j_name),
+		CCS_RESULT_ERROR_INVALID_VALUE);
+	CCS_REFUTE(
+		!j_params || !cJSON_IsArray(j_params),
+		CCS_RESULT_ERROR_INVALID_VALUE);
+	data->name           = j_name->valuestring;
+	num                  = (size_t)cJSON_GetArraySize(j_params);
+	data->num_parameters = num;
+	if (num) {
+		data->parameters =
+			(ccs_parameter_t *)calloc(num, sizeof(ccs_parameter_t));
+		CCS_REFUTE(!data->parameters, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		for (size_t i = 0; i < num; i++) {
+			cJSON *child     = cJSON_GetArrayItem(j_params, (int)i);
+			const char *cbuf = (const char *)child;
+			size_t      dummy = 0;
+			CCS_VALIDATE(_ccs_object_deserialize_with_opts_check(
+				(ccs_object_t *)data->parameters + i,
+				CCS_OBJECT_TYPE_PARAMETER,
+				CCS_SERIALIZE_FORMAT_JSON, version, &dummy,
+				&cbuf, opts));
+		}
+	}
+	return CCS_RESULT_SUCCESS;
+}
+
 #endif //_CONTEXT_DESERIALIZE_H

--- a/src/context_internal.h
+++ b/src/context_internal.h
@@ -304,6 +304,30 @@ _ccs_serialize_bin_ccs_context_data(
 }
 
 static inline ccs_result_t
+_ccs_serialize_json_ccs_context(
+	ccs_context_t                    context,
+	cJSON                           *json,
+	_ccs_object_serialize_options_t *opts)
+{
+	_ccs_context_data_t *data = context->data;
+	CCS_REFUTE(
+		!cJSON_AddStringToObject(json, "name", data->name),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	cJSON *parameters = cJSON_AddArrayToObject(json, "parameters");
+	CCS_REFUTE(!parameters, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	for (size_t i = 0; i < data->num_parameters; i++) {
+		cJSON *child = cJSON_CreateObject();
+		CCS_REFUTE(!child, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		cJSON_AddItemToArray(parameters, child);
+		size_t dummy = 0;
+		CCS_VALIDATE(_ccs_object_serialize_with_opts(
+			data->parameters[i], CCS_SERIALIZE_FORMAT_JSON, &dummy,
+			(char **)&child, opts));
+	}
+	return CCS_RESULT_SUCCESS;
+}
+
+static inline ccs_result_t
 _ccs_serialize_bin_size_ccs_context(
 	ccs_context_t                    context,
 	size_t                          *cum_size,

--- a/src/feature_space.c
+++ b/src/feature_space.c
@@ -55,6 +55,10 @@ _ccs_feature_space_serialize(
 		CCS_VALIDATE(_ccs_serialize_bin_ccs_context(
 			(ccs_context_t)object, buffer_size, buffer, opts));
 		break;
+	case CCS_SERIALIZE_FORMAT_JSON:
+		CCS_VALIDATE(_ccs_serialize_json_ccs_context(
+			(ccs_context_t)object, *(cJSON **)buffer, opts));
+		break;
 	default:
 		CCS_RAISE(
 			CCS_RESULT_ERROR_INVALID_VALUE,

--- a/src/feature_space_deserialize.h
+++ b/src/feature_space_deserialize.h
@@ -34,6 +34,38 @@ end:
 	return res;
 }
 
+static inline ccs_result_t
+_ccs_deserialize_json_feature_space(
+	ccs_feature_space_t               *feature_space_ret,
+	uint32_t                           version,
+	size_t                            *buffer_size,
+	const char                       **buffer,
+	_ccs_object_deserialize_options_t *opts)
+{
+	ccs_result_t             res = CCS_RESULT_SUCCESS;
+	_ccs_context_data_mock_t data;
+	(void)buffer_size;
+	CCS_VALIDATE_ERR_GOTO(
+		res,
+		_ccs_deserialize_json_ccs_context_data(
+			&data, version, *(cJSON **)buffer, opts),
+		end);
+	CCS_VALIDATE_ERR_GOTO(
+		res,
+		ccs_create_feature_space(
+			data.name, data.num_parameters, data.parameters,
+			feature_space_ret),
+		end);
+end:
+	if (data.parameters) {
+		for (size_t i = 0; i < data.num_parameters; i++)
+			if (data.parameters[i])
+				ccs_release_object(data.parameters[i]);
+		free(data.parameters);
+	}
+	return res;
+}
+
 static ccs_result_t
 _ccs_feature_space_deserialize(
 	ccs_feature_space_t               *feature_space_ret,
@@ -46,6 +78,10 @@ _ccs_feature_space_deserialize(
 	switch (format) {
 	case CCS_SERIALIZE_FORMAT_BINARY:
 		CCS_VALIDATE(_ccs_deserialize_bin_feature_space(
+			feature_space_ret, version, buffer_size, buffer, opts));
+		break;
+	case CCS_SERIALIZE_FORMAT_JSON:
+		CCS_VALIDATE(_ccs_deserialize_json_feature_space(
 			feature_space_ret, version, buffer_size, buffer, opts));
 		break;
 	default:

--- a/src/features.c
+++ b/src/features.c
@@ -48,6 +48,10 @@ _ccs_features_serialize(
 		CCS_VALIDATE(_ccs_serialize_bin_ccs_binding(
 			(ccs_binding_t)object, buffer_size, buffer));
 		break;
+	case CCS_SERIALIZE_FORMAT_JSON:
+		CCS_VALIDATE(_ccs_serialize_json_ccs_binding(
+			(ccs_binding_t)object, *(cJSON **)buffer));
+		break;
 	default:
 		CCS_RAISE(
 			CCS_RESULT_ERROR_INVALID_VALUE,

--- a/src/features_deserialize.h
+++ b/src/features_deserialize.h
@@ -44,6 +44,45 @@ end:
 	return res;
 }
 
+static inline ccs_result_t
+_ccs_deserialize_json_features(
+	ccs_features_t                    *features_ret,
+	uint32_t                           version,
+	size_t                            *buffer_size,
+	const char                       **buffer,
+	_ccs_object_deserialize_options_t *opts)
+{
+	ccs_datum_t         d;
+	ccs_feature_space_t cs;
+	ccs_result_t        res  = CCS_RESULT_SUCCESS;
+	_ccs_binding_data_t data = {NULL, 0, NULL};
+
+	(void)version;
+	(void)buffer_size;
+	CCS_CHECK_OBJ(opts->handle_map, CCS_OBJECT_TYPE_MAP);
+	CCS_VALIDATE_ERR_GOTO(
+		res,
+		_ccs_deserialize_json_ccs_binding_data(&data, *(cJSON **)buffer),
+		end);
+	CCS_VALIDATE_ERR_GOTO(
+		res,
+		ccs_map_get(opts->handle_map, ccs_object(data.context), &d),
+		end);
+	CCS_REFUTE_ERR_GOTO(
+		res, d.type != CCS_DATA_TYPE_OBJECT,
+		CCS_RESULT_ERROR_INVALID_HANDLE, end);
+	cs = (ccs_feature_space_t)(d.value.o);
+	CCS_VALIDATE_ERR_GOTO(
+		res,
+		ccs_create_features(
+			cs, data.num_values, data.values, features_ret),
+		end);
+end:
+	if (data.values)
+		free(data.values);
+	return res;
+}
+
 static ccs_result_t
 _ccs_features_deserialize(
 	ccs_features_t                    *features_ret,
@@ -56,6 +95,10 @@ _ccs_features_deserialize(
 	switch (format) {
 	case CCS_SERIALIZE_FORMAT_BINARY:
 		CCS_VALIDATE(_ccs_deserialize_bin_features(
+			features_ret, version, buffer_size, buffer, opts));
+		break;
+	case CCS_SERIALIZE_FORMAT_JSON:
+		CCS_VALIDATE(_ccs_deserialize_json_features(
 			features_ret, version, buffer_size, buffer, opts));
 		break;
 	default:

--- a/tests/test_feature_space.c
+++ b/tests/test_feature_space.c
@@ -225,6 +225,31 @@ test_deserialize(void)
 
 	check_features(feature_space, 3, parameters);
 
+	/* JSON roundtrip */
+	{
+		ccs_feature_space_t feature_space2;
+		ccs_parameter_t     param_tmp;
+		const char         *name;
+		test_serialize_deserialize(
+			(ccs_object_t)feature_space, CCS_SERIALIZE_FORMAT_JSON,
+			(ccs_object_t *)&feature_space2);
+		err = ccs_context_get_name(
+			(ccs_context_t)feature_space2, &name);
+		assert(err == CCS_RESULT_SUCCESS);
+		assert(!strcmp(name, "my_config_space"));
+		err = ccs_context_get_parameter_by_name(
+			(ccs_context_t)feature_space2, "param1", &param_tmp);
+		assert(err == CCS_RESULT_SUCCESS);
+		err = ccs_context_get_parameter_by_name(
+			(ccs_context_t)feature_space2, "param2", &param_tmp);
+		assert(err == CCS_RESULT_SUCCESS);
+		err = ccs_context_get_parameter_by_name(
+			(ccs_context_t)feature_space2, "param3", &param_tmp);
+		assert(err == CCS_RESULT_SUCCESS);
+		err = ccs_release_object(feature_space2);
+		assert(err == CCS_RESULT_SUCCESS);
+	}
+
 	err = ccs_object_serialize(
 		feature_space, CCS_SERIALIZE_FORMAT_BINARY,
 		CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
@@ -324,54 +349,66 @@ test_features_deserialize(void)
 	err = ccs_create_features(feature_space, 3, values, &features_ref);
 	assert(err == CCS_RESULT_SUCCESS);
 
-	err = ccs_create_map(&map);
-	assert(err == CCS_RESULT_SUCCESS);
-	err = ccs_object_serialize(
-		features_ref, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
-		CCS_SERIALIZE_OPTION_END);
-	assert(err == CCS_RESULT_SUCCESS);
-	buff = (char *)malloc(buff_size);
-	assert(buff);
+	{
+		ccs_serialize_format_t formats[] = {
+			CCS_SERIALIZE_FORMAT_BINARY, CCS_SERIALIZE_FORMAT_JSON};
+		size_t num_formats = sizeof(formats) / sizeof(formats[0]);
+		for (size_t f = 0; f < num_formats; f++) {
+			err = ccs_create_map(&map);
+			assert(err == CCS_RESULT_SUCCESS);
 
-	err = ccs_object_serialize(
-		features_ref, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_MEMORY, buff_size, buff,
-		CCS_SERIALIZE_OPTION_END);
-	assert(err == CCS_RESULT_SUCCESS);
+			err = ccs_object_serialize(
+				features_ref, formats[f],
+				CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
+				CCS_SERIALIZE_OPTION_END);
+			assert(err == CCS_RESULT_SUCCESS);
+			buff = (char *)malloc(buff_size);
+			assert(buff);
+			err = ccs_object_serialize(
+				features_ref, formats[f],
+				CCS_SERIALIZE_OPERATION_MEMORY, buff_size, buff,
+				CCS_SERIALIZE_OPTION_END);
+			assert(err == CCS_RESULT_SUCCESS);
 
-	err = ccs_object_deserialize(
-		(ccs_object_t *)&features, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_DESERIALIZE_OPERATION_MEMORY, buff_size, buff,
-		CCS_DESERIALIZE_OPTION_HANDLE_MAP, map,
-		CCS_DESERIALIZE_OPTION_END);
-	assert(err == CCS_RESULT_ERROR_INVALID_HANDLE);
+			/* deserialize with empty handle map — should
+			 * fail */
+			err = ccs_object_deserialize(
+				(ccs_object_t *)&features, formats[f],
+				CCS_DESERIALIZE_OPERATION_MEMORY, buff_size,
+				buff, CCS_DESERIALIZE_OPTION_HANDLE_MAP, map,
+				CCS_DESERIALIZE_OPTION_END);
+			assert(err == CCS_RESULT_ERROR_INVALID_HANDLE);
 
-	d = ccs_object(feature_space);
-	d.flags |= CCS_DATUM_FLAG_ID;
-	err = ccs_map_set(map, d, ccs_object(feature_space));
-	assert(err == CCS_RESULT_SUCCESS);
+			/* add feature_space to handle map */
+			d = ccs_object(feature_space);
+			d.flags |= CCS_DATUM_FLAG_ID;
+			err = ccs_map_set(map, d, ccs_object(feature_space));
+			assert(err == CCS_RESULT_SUCCESS);
 
-	err = ccs_object_deserialize(
-		(ccs_object_t *)&features, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_DESERIALIZE_OPERATION_MEMORY, buff_size, buff,
-		CCS_DESERIALIZE_OPTION_HANDLE_MAP, map,
-		CCS_DESERIALIZE_OPTION_END);
-	assert(err == CCS_RESULT_SUCCESS);
+			err = ccs_object_deserialize(
+				(ccs_object_t *)&features, formats[f],
+				CCS_DESERIALIZE_OPERATION_MEMORY, buff_size,
+				buff, CCS_DESERIALIZE_OPTION_HANDLE_MAP, map,
+				CCS_DESERIALIZE_OPTION_END);
+			assert(err == CCS_RESULT_SUCCESS);
 
-	err = ccs_binding_cmp(
-		(ccs_binding_t)features_ref, (ccs_binding_t)features, &cmp);
-	assert(err == CCS_RESULT_SUCCESS);
-	assert(!cmp);
+			err = ccs_binding_cmp(
+				(ccs_binding_t)features_ref,
+				(ccs_binding_t)features, &cmp);
+			assert(err == CCS_RESULT_SUCCESS);
+			assert(!cmp);
 
-	free(buff);
+			free(buff);
+			err = ccs_release_object(features);
+			assert(err == CCS_RESULT_SUCCESS);
+			err = ccs_release_object(map);
+			assert(err == CCS_RESULT_SUCCESS);
+		}
+	}
+
 	err = ccs_release_object(feature_space);
 	assert(err == CCS_RESULT_SUCCESS);
 	err = ccs_release_object(features_ref);
-	assert(err == CCS_RESULT_SUCCESS);
-	err = ccs_release_object(features);
-	assert(err == CCS_RESULT_SUCCESS);
-	err = ccs_release_object(map);
 	assert(err == CCS_RESULT_SUCCESS);
 	for (size_t i = 0; i < 3; i++) {
 		err = ccs_release_object(parameters[i]);


### PR DESCRIPTION
## Summary

- Add shared JSON context serialize/deserialize helpers (`_ccs_serialize_json_ccs_context` in `context_internal.h`, `_ccs_deserialize_json_ccs_context_data` in `context_deserialize.h`) — these will be reused by configuration_space
- Feature space serializes: `name` + `parameters` array (each parameter serialized recursively)
- Add JSON roundtrip test

## Test plan

- [x] All 30 tests pass
- [x] JSON roundtrip for feature space with 3 parameters
- [x] Builds clean with gcc, g++, clang

🤖 Generated with [Claude Code](https://claude.com/claude-code)