### PR TITLE
Add JSON serialization for configuration space and configuration

### DIFF
--- a/src/configuration.c
+++ b/src/configuration.c
@@ -1,4 +1,5 @@
 #include "cconfigspace_internal.h"
+#include "cconfigspace_json.h"
 #include "configuration_internal.h"
 #include "configuration_space_internal.h"
 #include "features_internal.h"
@@ -72,6 +73,27 @@ _ccs_serialize_bin_ccs_configuration(
 	return CCS_RESULT_SUCCESS;
 }
 
+static inline ccs_result_t
+_ccs_serialize_json_ccs_configuration(
+	ccs_configuration_t              configuration,
+	cJSON                           *json,
+	_ccs_object_serialize_options_t *opts)
+{
+	_ccs_configuration_data_t *data  = configuration->data;
+	size_t                     dummy = 0;
+
+	CCS_VALIDATE(_ccs_serialize_json_ccs_binding(
+		(ccs_binding_t)configuration, json));
+	if (data->features) {
+		cJSON *feat = cJSON_AddObjectToObject(json, "features");
+		CCS_REFUTE(!feat, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		CCS_VALIDATE(_ccs_object_serialize_with_opts(
+			data->features, CCS_SERIALIZE_FORMAT_JSON, &dummy,
+			(char **)&feat, opts));
+	}
+	return CCS_RESULT_SUCCESS;
+}
+
 static ccs_result_t
 _ccs_configuration_serialize_size(
 	ccs_object_t                     object,
@@ -105,6 +127,10 @@ _ccs_configuration_serialize(
 		CCS_VALIDATE(_ccs_serialize_bin_ccs_configuration(
 			(ccs_configuration_t)object, buffer_size, buffer,
 			opts));
+		break;
+	case CCS_SERIALIZE_FORMAT_JSON:
+		CCS_VALIDATE(_ccs_serialize_json_ccs_configuration(
+			(ccs_configuration_t)object, *(cJSON **)buffer, opts));
 		break;
 	default:
 		CCS_RAISE(

--- a/src/configuration_deserialize.h
+++ b/src/configuration_deserialize.h
@@ -1,6 +1,7 @@
 #ifndef _CONFIGURATION_DESERIALIZE_H
 #define _CONFIGURATION_DESERIALIZE_H
 #include "configuration_internal.h"
+#include "cconfigspace_json.h"
 
 struct _ccs_configuration_data_mock_s {
 	_ccs_binding_data_t base;
@@ -79,6 +80,75 @@ end:
 	return res;
 }
 
+static inline ccs_result_t
+_ccs_deserialize_json_configuration(
+	ccs_configuration_t               *configuration_ret,
+	uint32_t                           version,
+	size_t                            *buffer_size,
+	const char                       **buffer,
+	_ccs_object_deserialize_options_t *opts)
+{
+	ccs_datum_t               d;
+	ccs_configuration_space_t cs;
+	ccs_configuration_t       configuration;
+	ccs_result_t              res      = CCS_RESULT_SUCCESS;
+	_ccs_binding_data_t       data     = {NULL, 0, NULL};
+	ccs_features_t            features = NULL;
+	cJSON                    *json;
+	cJSON                    *j_features;
+	const char               *cbuf;
+	size_t                    dummy;
+
+	(void)version;
+	(void)buffer_size;
+	CCS_CHECK_OBJ(opts->handle_map, CCS_OBJECT_TYPE_MAP);
+
+	json = *(cJSON **)buffer;
+	CCS_VALIDATE_ERR_GOTO(
+		res, _ccs_deserialize_json_ccs_binding_data(&data, json), end);
+
+	CCS_VALIDATE_ERR_GOTO(
+		res,
+		ccs_map_get(opts->handle_map, ccs_object(data.context), &d),
+		end);
+	CCS_REFUTE_ERR_GOTO(
+		res, d.type != CCS_DATA_TYPE_OBJECT,
+		CCS_RESULT_ERROR_INVALID_HANDLE, end);
+	cs         = (ccs_configuration_space_t)(d.value.o);
+
+	/* optional features */
+	j_features = cJSON_GetObjectItemCaseSensitive(json, "features");
+	if (j_features && cJSON_IsObject(j_features)) {
+		_ccs_object_deserialize_options_t feat_opts = *opts;
+		feat_opts.map_values                        = CCS_FALSE;
+		cbuf  = (const char *)j_features;
+		dummy = 0;
+		CCS_VALIDATE_ERR_GOTO(
+			res,
+			_ccs_object_deserialize_with_opts_check(
+				(ccs_object_t *)&features,
+				CCS_OBJECT_TYPE_FEATURES,
+				CCS_SERIALIZE_FORMAT_JSON, version, &dummy,
+				&cbuf, &feat_opts),
+			end);
+	}
+
+	CCS_VALIDATE_ERR_GOTO(
+		res,
+		ccs_create_configuration(
+			cs, features, data.num_values, data.values,
+			&configuration),
+		end);
+
+	*configuration_ret = configuration;
+end:
+	if (features)
+		ccs_release_object(features);
+	if (data.values)
+		free(data.values);
+	return res;
+}
+
 static ccs_result_t
 _ccs_configuration_deserialize(
 	ccs_configuration_t               *configuration_ret,
@@ -91,6 +161,10 @@ _ccs_configuration_deserialize(
 	switch (format) {
 	case CCS_SERIALIZE_FORMAT_BINARY:
 		CCS_VALIDATE(_ccs_deserialize_bin_configuration(
+			configuration_ret, version, buffer_size, buffer, opts));
+		break;
+	case CCS_SERIALIZE_FORMAT_JSON:
+		CCS_VALIDATE(_ccs_deserialize_json_configuration(
 			configuration_ret, version, buffer_size, buffer, opts));
 		break;
 	default:

--- a/src/configuration_space.c
+++ b/src/configuration_space.c
@@ -1,4 +1,5 @@
 #include "cconfigspace_internal.h"
+#include "cconfigspace_json.h"
 #include "configuration_space_internal.h"
 #include "distribution_space_internal.h"
 #include "configuration_internal.h"
@@ -198,6 +199,98 @@ _ccs_serialize_bin_ccs_configuration_space(
 	return CCS_RESULT_SUCCESS;
 }
 
+static inline ccs_result_t
+_ccs_serialize_json_ccs_configuration_space(
+	ccs_configuration_space_t        configuration_space,
+	cJSON                           *json,
+	_ccs_object_serialize_options_t *opts)
+{
+	_ccs_configuration_space_data_t *data =
+		(_ccs_configuration_space_data_t *)(configuration_space->data);
+	size_t dummy = 0;
+
+	CCS_REFUTE(
+		!cJSON_AddStringToObject(json, "name", data->name),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+
+	/* feature space (optional) */
+	if (data->feature_space) {
+		cJSON *fs = cJSON_AddObjectToObject(json, "feature_space");
+		CCS_REFUTE(!fs, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		CCS_VALIDATE(_ccs_object_serialize_with_opts(
+			data->feature_space, CCS_SERIALIZE_FORMAT_JSON, &dummy,
+			(char **)&fs, opts));
+	}
+
+	/* rng */
+	{
+		cJSON *rng_node = cJSON_AddObjectToObject(json, "rng");
+		CCS_REFUTE(!rng_node, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		CCS_VALIDATE(_ccs_object_serialize_with_opts(
+			data->rng, CCS_SERIALIZE_FORMAT_JSON, &dummy,
+			(char **)&rng_node, opts));
+	}
+
+	/* parameters */
+	{
+		cJSON *params = cJSON_AddArrayToObject(json, "parameters");
+		CCS_REFUTE(!params, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		for (size_t i = 0; i < data->num_parameters; i++) {
+			cJSON *child = cJSON_CreateObject();
+			CCS_REFUTE(!child, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+			cJSON_AddItemToArray(params, child);
+			CCS_VALIDATE(_ccs_object_serialize_with_opts(
+				data->parameters[i], CCS_SERIALIZE_FORMAT_JSON,
+				&dummy, (char **)&child, opts));
+		}
+	}
+
+	/* conditions -- array of {index, expression} */
+	{
+		cJSON *conds = cJSON_AddArrayToObject(json, "conditions");
+		CCS_REFUTE(!conds, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		for (size_t i = 0; i < data->num_parameters; i++) {
+			if (data->conditions[i]) {
+				cJSON *cond = cJSON_CreateObject();
+				cJSON *expr;
+				CCS_REFUTE(
+					!cond, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+				cJSON_AddItemToArray(conds, cond);
+				CCS_REFUTE(
+					!cJSON_AddNumberToObject(
+						cond, "index", (double)i),
+					CCS_RESULT_ERROR_OUT_OF_MEMORY);
+				expr = cJSON_AddObjectToObject(
+					cond, "expression");
+				CCS_REFUTE(
+					!expr, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+				CCS_VALIDATE(_ccs_object_serialize_with_opts(
+					data->conditions[i],
+					CCS_SERIALIZE_FORMAT_JSON, &dummy,
+					(char **)&expr, opts));
+			}
+		}
+	}
+
+	/* forbidden clauses */
+	{
+		cJSON *forbids =
+			cJSON_AddArrayToObject(json, "forbidden_clauses");
+		CCS_REFUTE(!forbids, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		for (size_t i = 0; i < data->num_forbidden_clauses; i++) {
+			cJSON *child = cJSON_CreateObject();
+			CCS_REFUTE(!child, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+			cJSON_AddItemToArray(forbids, child);
+			CCS_VALIDATE(_ccs_object_serialize_with_opts(
+				data->forbidden_clauses[i],
+				CCS_SERIALIZE_FORMAT_JSON, &dummy,
+				(char **)&child, opts));
+		}
+	}
+
+	return CCS_RESULT_SUCCESS;
+}
+
 static ccs_result_t
 _ccs_configuration_space_serialize_size(
 	ccs_object_t                     object,
@@ -230,6 +323,11 @@ _ccs_configuration_space_serialize(
 	case CCS_SERIALIZE_FORMAT_BINARY:
 		CCS_VALIDATE(_ccs_serialize_bin_ccs_configuration_space(
 			(ccs_configuration_space_t)object, buffer_size, buffer,
+			opts));
+		break;
+	case CCS_SERIALIZE_FORMAT_JSON:
+		CCS_VALIDATE(_ccs_serialize_json_ccs_configuration_space(
+			(ccs_configuration_space_t)object, *(cJSON **)buffer,
 			opts));
 		break;
 	default:

--- a/src/configuration_space_deserialize.h
+++ b/src/configuration_space_deserialize.h
@@ -1,5 +1,6 @@
 #ifndef _CONFIGURATION_SPACE_DESERIALIZE_H
 #define _CONFIGURATION_SPACE_DESERIALIZE_H
+#include "cconfigspace_json.h"
 
 struct _ccs_configuration_space_data_mock_s {
 	const char         *name;
@@ -68,11 +69,12 @@ _ccs_deserialize_bin_ccs_configuration_space_data(
 		CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	}
 
-	data->parameters = (ccs_parameter_t *)mem;
-	mem += data->num_parameters * sizeof(ccs_parameter_t);
-	data->conditions = (ccs_expression_t *)mem;
-	mem += data->num_parameters * sizeof(ccs_expression_t);
-	data->forbidden_clauses = (ccs_expression_t *)mem;
+	data->parameters = CCS_ALLOC_CARVE_ARRAY(
+		mem, data->num_parameters, ccs_parameter_t);
+	data->conditions = CCS_ALLOC_CARVE_ARRAY(
+		mem, data->num_parameters, ccs_expression_t);
+	data->forbidden_clauses = CCS_ALLOC_CARVE_ARRAY(
+		mem, data->num_forbidden_clauses, ccs_expression_t);
 
 	for (size_t i = 0; i < data->num_parameters; i++)
 		CCS_VALIDATE(_ccs_object_deserialize_with_opts_check(
@@ -159,6 +161,206 @@ end:
 	return res;
 }
 
+static inline ccs_result_t
+_ccs_deserialize_json_ccs_configuration_space_data(
+	_ccs_configuration_space_data_mock_t *data,
+	uint32_t                              version,
+	cJSON                                *json,
+	_ccs_object_deserialize_options_t    *opts)
+{
+	cJSON      *j_name;
+	cJSON      *j_fs;
+	cJSON      *j_rng;
+	cJSON      *j_params;
+	cJSON      *j_conds;
+	cJSON      *j_forbids;
+	size_t      num;
+	size_t      num_conds;
+	size_t      num_forbids;
+	uintptr_t   mem;
+	const char *cbuf;
+	size_t      dummy;
+
+	j_name = cJSON_GetObjectItemCaseSensitive(json, "name");
+	CCS_REFUTE(
+		!j_name || !cJSON_IsString(j_name),
+		CCS_RESULT_ERROR_INVALID_VALUE);
+	data->name = j_name->valuestring;
+
+	/* feature space (optional) */
+	j_fs       = cJSON_GetObjectItemCaseSensitive(json, "feature_space");
+	if (j_fs && cJSON_IsObject(j_fs)) {
+		cbuf  = (const char *)j_fs;
+		dummy = 0;
+		CCS_VALIDATE(_ccs_object_deserialize_with_opts_check(
+			(ccs_object_t *)&data->feature_space,
+			CCS_OBJECT_TYPE_FEATURE_SPACE,
+			CCS_SERIALIZE_FORMAT_JSON, version, &dummy, &cbuf,
+			opts));
+	}
+
+	/* rng */
+	j_rng = cJSON_GetObjectItemCaseSensitive(json, "rng");
+	CCS_REFUTE(
+		!j_rng || !cJSON_IsObject(j_rng),
+		CCS_RESULT_ERROR_INVALID_VALUE);
+	cbuf  = (const char *)j_rng;
+	dummy = 0;
+	CCS_VALIDATE(_ccs_object_deserialize_with_opts_check(
+		(ccs_object_t *)&data->rng, CCS_OBJECT_TYPE_RNG,
+		CCS_SERIALIZE_FORMAT_JSON, version, &dummy, &cbuf, opts));
+
+	/* parameters */
+	j_params = cJSON_GetObjectItemCaseSensitive(json, "parameters");
+	CCS_REFUTE(
+		!j_params || !cJSON_IsArray(j_params),
+		CCS_RESULT_ERROR_INVALID_VALUE);
+	num                  = (size_t)cJSON_GetArraySize(j_params);
+	data->num_parameters = num;
+
+	/* conditions */
+	j_conds = cJSON_GetObjectItemCaseSensitive(json, "conditions");
+	CCS_REFUTE(
+		!j_conds || !cJSON_IsArray(j_conds),
+		CCS_RESULT_ERROR_INVALID_VALUE);
+	num_conds            = (size_t)cJSON_GetArraySize(j_conds);
+	data->num_conditions = num_conds;
+
+	/* forbidden clauses */
+	j_forbids = cJSON_GetObjectItemCaseSensitive(json, "forbidden_clauses");
+	CCS_REFUTE(
+		!j_forbids || !cJSON_IsArray(j_forbids),
+		CCS_RESULT_ERROR_INVALID_VALUE);
+	num_forbids                 = (size_t)cJSON_GetArraySize(j_forbids);
+	data->num_forbidden_clauses = num_forbids;
+
+	if (!(num + num_conds + num_forbids))
+		return CCS_RESULT_SUCCESS;
+
+	{
+		size_t _sz;
+		CCS_REFUTE(
+			CCS_ALLOC_SIZE(
+				&_sz,
+				CCS_ALLOC_SIZE_ARRAY(num, ccs_parameter_t),
+				CCS_ALLOC_SIZE_ARRAY(num, ccs_expression_t),
+				CCS_ALLOC_SIZE_ARRAY(
+					num_forbids, ccs_expression_t)),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		mem = (uintptr_t)calloc(1, _sz);
+		CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	}
+
+	data->parameters = CCS_ALLOC_CARVE_ARRAY(mem, num, ccs_parameter_t);
+	data->conditions = CCS_ALLOC_CARVE_ARRAY(mem, num, ccs_expression_t);
+	data->forbidden_clauses =
+		CCS_ALLOC_CARVE_ARRAY(mem, num_forbids, ccs_expression_t);
+
+	for (size_t i = 0; i < num; i++) {
+		cJSON *child = cJSON_GetArrayItem(j_params, (int)i);
+		cbuf         = (const char *)child;
+		dummy        = 0;
+		CCS_VALIDATE(_ccs_object_deserialize_with_opts_check(
+			(ccs_object_t *)data->parameters + i,
+			CCS_OBJECT_TYPE_PARAMETER, CCS_SERIALIZE_FORMAT_JSON,
+			version, &dummy, &cbuf, opts));
+	}
+
+	for (size_t i = 0; i < num_conds; i++) {
+		cJSON *cond_obj = cJSON_GetArrayItem(j_conds, (int)i);
+		cJSON *j_index;
+		cJSON *j_expr;
+		size_t index;
+		j_index = cJSON_GetObjectItemCaseSensitive(cond_obj, "index");
+		CCS_REFUTE(
+			!j_index || !cJSON_IsNumber(j_index),
+			CCS_RESULT_ERROR_INVALID_VALUE);
+		index = (size_t)j_index->valuedouble;
+		CCS_REFUTE(index >= num, CCS_RESULT_ERROR_INVALID_VALUE);
+		j_expr = cJSON_GetObjectItemCaseSensitive(
+			cond_obj, "expression");
+		CCS_REFUTE(
+			!j_expr || !cJSON_IsObject(j_expr),
+			CCS_RESULT_ERROR_INVALID_VALUE);
+		cbuf  = (const char *)j_expr;
+		dummy = 0;
+		CCS_VALIDATE(_ccs_object_deserialize_with_opts_check(
+			(ccs_object_t *)data->conditions + index,
+			CCS_OBJECT_TYPE_EXPRESSION, CCS_SERIALIZE_FORMAT_JSON,
+			version, &dummy, &cbuf, opts));
+	}
+
+	for (size_t i = 0; i < num_forbids; i++) {
+		cJSON *child = cJSON_GetArrayItem(j_forbids, (int)i);
+		cbuf         = (const char *)child;
+		dummy        = 0;
+		CCS_VALIDATE(_ccs_object_deserialize_with_opts_check(
+			(ccs_object_t *)data->forbidden_clauses + i,
+			CCS_OBJECT_TYPE_EXPRESSION, CCS_SERIALIZE_FORMAT_JSON,
+			version, &dummy, &cbuf, opts));
+	}
+
+	return CCS_RESULT_SUCCESS;
+}
+
+static inline ccs_result_t
+_ccs_deserialize_json_configuration_space(
+	ccs_configuration_space_t         *configuration_space_ret,
+	uint32_t                           version,
+	size_t                            *buffer_size,
+	const char                       **buffer,
+	_ccs_object_deserialize_options_t *opts)
+{
+	_ccs_object_deserialize_options_t    new_opts = *opts;
+	ccs_result_t                         res      = CCS_RESULT_SUCCESS;
+	_ccs_configuration_space_data_mock_t data     = {
+                NULL, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL};
+
+	(void)buffer_size;
+
+	if (!opts->map_values) {
+		new_opts.map_values = CCS_TRUE;
+		CCS_VALIDATE(ccs_create_map(&new_opts.handle_map));
+	}
+
+	CCS_VALIDATE_ERR_GOTO(
+		res,
+		_ccs_deserialize_json_ccs_configuration_space_data(
+			&data, version, *(cJSON **)buffer, &new_opts),
+		end);
+	CCS_VALIDATE_ERR_GOTO(
+		res,
+		ccs_create_configuration_space(
+			data.name, data.num_parameters, data.parameters,
+			data.conditions, data.num_forbidden_clauses,
+			data.forbidden_clauses, data.feature_space, data.rng,
+			configuration_space_ret),
+		end);
+
+end:
+	if (data.feature_space)
+		ccs_release_object(data.feature_space);
+	if (data.rng)
+		ccs_release_object(data.rng);
+	if (data.parameters)
+		for (size_t i = 0; i < data.num_parameters; i++)
+			if (data.parameters[i])
+				ccs_release_object(data.parameters[i]);
+	if (data.conditions)
+		for (size_t i = 0; i < data.num_parameters; i++)
+			if (data.conditions[i])
+				ccs_release_object(data.conditions[i]);
+	if (data.forbidden_clauses)
+		for (size_t i = 0; i < data.num_forbidden_clauses; i++)
+			if (data.forbidden_clauses[i])
+				ccs_release_object(data.forbidden_clauses[i]);
+	if (data.parameters)
+		free(data.parameters);
+	if (!opts->map_values)
+		ccs_release_object(new_opts.handle_map);
+	return res;
+}
+
 static ccs_result_t
 _ccs_configuration_space_deserialize(
 	ccs_configuration_space_t         *configuration_space_ret,
@@ -171,6 +373,11 @@ _ccs_configuration_space_deserialize(
 	switch (format) {
 	case CCS_SERIALIZE_FORMAT_BINARY:
 		CCS_VALIDATE(_ccs_deserialize_bin_configuration_space(
+			configuration_space_ret, version, buffer_size, buffer,
+			opts));
+		break;
+	case CCS_SERIALIZE_FORMAT_JSON:
+		CCS_VALIDATE(_ccs_deserialize_json_configuration_space(
 			configuration_space_ret, version, buffer_size, buffer,
 			opts));
 		break;

--- a/src/expression_deserialize.h
+++ b/src/expression_deserialize.h
@@ -346,7 +346,7 @@ _ccs_deserialize_json_expression_general(
 	size_t                            num_nodes;
 
 	_ccs_object_deserialize_options_t new_opts = *opts;
-	new_opts.handle_map                        = NULL;
+	new_opts.map_values                        = CCS_FALSE;
 
 	data.type                                  = type;
 	data.num_nodes                             = 0;
@@ -416,7 +416,7 @@ _ccs_deserialize_json_expression_user_defined(
 	unsigned char                        *state_data = NULL;
 
 	_ccs_object_deserialize_options_t     new_opts   = *opts;
-	new_opts.handle_map                              = NULL;
+	new_opts.map_values                              = CCS_FALSE;
 
 	data.num_nodes                                   = 0;
 	data.nodes                                       = NULL;

--- a/tests/test_configuration_space.c
+++ b/tests/test_configuration_space.c
@@ -240,55 +240,67 @@ test_configuration_deserialize(void)
 		configuration_space, NULL, NULL, NULL, &configuration_ref);
 	assert(err == CCS_RESULT_SUCCESS);
 
-	err = ccs_create_map(&map);
-	assert(err == CCS_RESULT_SUCCESS);
-	err = ccs_object_serialize(
-		configuration_ref, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
-		CCS_SERIALIZE_OPTION_END);
-	assert(err == CCS_RESULT_SUCCESS);
-	buff = (char *)malloc(buff_size);
-	assert(buff);
+	{
+		ccs_serialize_format_t formats[] = {
+			CCS_SERIALIZE_FORMAT_BINARY, CCS_SERIALIZE_FORMAT_JSON};
+		size_t num_formats = sizeof(formats) / sizeof(formats[0]);
+		for (size_t f = 0; f < num_formats; f++) {
+			err = ccs_create_map(&map);
+			assert(err == CCS_RESULT_SUCCESS);
 
-	err = ccs_object_serialize(
-		configuration_ref, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_MEMORY, buff_size, buff,
-		CCS_SERIALIZE_OPTION_END);
-	assert(err == CCS_RESULT_SUCCESS);
+			err = ccs_object_serialize(
+				configuration_ref, formats[f],
+				CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
+				CCS_SERIALIZE_OPTION_END);
+			assert(err == CCS_RESULT_SUCCESS);
+			buff = (char *)malloc(buff_size);
+			assert(buff);
+			err = ccs_object_serialize(
+				configuration_ref, formats[f],
+				CCS_SERIALIZE_OPERATION_MEMORY, buff_size, buff,
+				CCS_SERIALIZE_OPTION_END);
+			assert(err == CCS_RESULT_SUCCESS);
 
-	err = ccs_object_deserialize(
-		(ccs_object_t *)&configuration, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_DESERIALIZE_OPERATION_MEMORY, buff_size, buff,
-		CCS_DESERIALIZE_OPTION_HANDLE_MAP, map,
-		CCS_DESERIALIZE_OPTION_END);
-	assert(err == CCS_RESULT_ERROR_INVALID_HANDLE);
+			/* empty handle map — should fail */
+			err = ccs_object_deserialize(
+				(ccs_object_t *)&configuration, formats[f],
+				CCS_DESERIALIZE_OPERATION_MEMORY, buff_size,
+				buff, CCS_DESERIALIZE_OPTION_HANDLE_MAP, map,
+				CCS_DESERIALIZE_OPTION_END);
+			assert(err == CCS_RESULT_ERROR_INVALID_HANDLE);
+			ccs_clear_thread_error();
 
-	d = ccs_object(configuration_space);
-	d.flags |= CCS_DATUM_FLAG_ID;
-	err = ccs_map_set(map, d, ccs_object(configuration_space));
-	assert(err == CCS_RESULT_SUCCESS);
+			/* correct handle map */
+			d = ccs_object(configuration_space);
+			d.flags |= CCS_DATUM_FLAG_ID;
+			err = ccs_map_set(
+				map, d, ccs_object(configuration_space));
+			assert(err == CCS_RESULT_SUCCESS);
 
-	err = ccs_object_deserialize(
-		(ccs_object_t *)&configuration, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_DESERIALIZE_OPERATION_MEMORY, buff_size, buff,
-		CCS_DESERIALIZE_OPTION_HANDLE_MAP, map,
-		CCS_DESERIALIZE_OPTION_END);
-	assert(err == CCS_RESULT_SUCCESS);
+			err = ccs_object_deserialize(
+				(ccs_object_t *)&configuration, formats[f],
+				CCS_DESERIALIZE_OPERATION_MEMORY, buff_size,
+				buff, CCS_DESERIALIZE_OPTION_HANDLE_MAP, map,
+				CCS_DESERIALIZE_OPTION_END);
+			assert(err == CCS_RESULT_SUCCESS);
 
-	err = ccs_binding_cmp(
-		(ccs_binding_t)configuration_ref, (ccs_binding_t)configuration,
-		&cmp);
-	assert(err == CCS_RESULT_SUCCESS);
-	assert(!cmp);
+			err = ccs_binding_cmp(
+				(ccs_binding_t)configuration_ref,
+				(ccs_binding_t)configuration, &cmp);
+			assert(err == CCS_RESULT_SUCCESS);
+			assert(!cmp);
 
-	free(buff);
+			free(buff);
+			err = ccs_release_object(configuration);
+			assert(err == CCS_RESULT_SUCCESS);
+			err = ccs_release_object(map);
+			assert(err == CCS_RESULT_SUCCESS);
+		}
+	}
+
 	err = ccs_release_object(configuration_space);
 	assert(err == CCS_RESULT_SUCCESS);
 	err = ccs_release_object(configuration_ref);
-	assert(err == CCS_RESULT_SUCCESS);
-	err = ccs_release_object(configuration);
-	assert(err == CCS_RESULT_SUCCESS);
-	err = ccs_release_object(map);
 	assert(err == CCS_RESULT_SUCCESS);
 	for (size_t i = 0; i < 3; i++) {
 		err = ccs_release_object(parameters[i]);
@@ -301,7 +313,7 @@ test_deserialize(void)
 {
 	ccs_parameter_t           parameters[3];
 	ccs_expression_t          conditions[3] = {NULL, NULL, NULL};
-	ccs_configuration_space_t space, space_ref;
+	ccs_configuration_space_t space;
 	ccs_expression_t          expression, expressions[3];
 	char                     *buff;
 	size_t                    buff_size;
@@ -347,73 +359,79 @@ test_deserialize(void)
 		assert(err == CCS_RESULT_SUCCESS);
 	}
 
-	err = ccs_object_serialize(
-		space, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
-		CCS_SERIALIZE_OPTION_END);
-	assert(err == CCS_RESULT_SUCCESS);
+	{
+		ccs_serialize_format_t formats[] = {
+			CCS_SERIALIZE_FORMAT_BINARY, CCS_SERIALIZE_FORMAT_JSON};
+		size_t num_formats = sizeof(formats) / sizeof(formats[0]);
+		for (size_t f = 0; f < num_formats; f++) {
+			ccs_configuration_space_t space_deser;
+			err = ccs_object_serialize(
+				space, formats[f], CCS_SERIALIZE_OPERATION_SIZE,
+				&buff_size, CCS_SERIALIZE_OPTION_END);
+			assert(err == CCS_RESULT_SUCCESS);
+			buff = (char *)malloc(buff_size);
+			assert(buff);
+			err = ccs_object_serialize(
+				space, formats[f],
+				CCS_SERIALIZE_OPERATION_MEMORY, buff_size, buff,
+				CCS_SERIALIZE_OPTION_END);
+			assert(err == CCS_RESULT_SUCCESS);
 
-	buff = (char *)malloc(buff_size);
-	assert(buff);
+			/* deserialize without handle map */
+			err = ccs_object_deserialize(
+				(ccs_object_t *)&space_deser, formats[f],
+				CCS_DESERIALIZE_OPERATION_MEMORY, buff_size,
+				buff, CCS_DESERIALIZE_OPTION_END);
+			assert(err == CCS_RESULT_SUCCESS);
+			err = ccs_release_object(space_deser);
+			assert(err == CCS_RESULT_SUCCESS);
 
-	err = ccs_object_serialize(
-		space, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_MEMORY, buff_size, buff,
-		CCS_SERIALIZE_OPTION_END);
-	assert(err == CCS_RESULT_SUCCESS);
+			/* deserialize with handle map + MAP_HANDLES */
+			err = ccs_create_map(&map);
+			assert(err == CCS_RESULT_SUCCESS);
+			err = ccs_object_deserialize(
+				(ccs_object_t *)&space_deser, formats[f],
+				CCS_DESERIALIZE_OPERATION_MEMORY, buff_size,
+				buff, CCS_DESERIALIZE_OPTION_HANDLE_MAP, map,
+				CCS_DESERIALIZE_OPTION_MAP_HANDLES,
+				CCS_DESERIALIZE_OPTION_END);
+			assert(err == CCS_RESULT_SUCCESS);
 
-	space_ref = space;
-	err       = ccs_release_object(space);
-	assert(err == CCS_RESULT_SUCCESS);
+			err = ccs_map_get(map, ccs_object(space), &d);
+			assert(err == CCS_RESULT_SUCCESS);
+			assert(d.type == CCS_DATA_TYPE_OBJECT);
+			assert(d.value.o == space_deser);
 
-	err = ccs_object_deserialize(
-		(ccs_object_t *)&space, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_DESERIALIZE_OPERATION_MEMORY, buff_size, buff,
-		CCS_DESERIALIZE_OPTION_END);
-	assert(err == CCS_RESULT_SUCCESS);
+			err = ccs_context_get_parameters(
+				(ccs_context_t)space_deser, 0, NULL, &count);
+			assert(err == CCS_RESULT_SUCCESS);
+			assert(count == 3);
 
+			err = ccs_configuration_space_get_conditions(
+				space_deser, 3, expressions, NULL);
+			assert(err == CCS_RESULT_SUCCESS);
+			assert(expressions[0]);
+			assert(!expressions[1]);
+			assert(expressions[2]);
+			assert(expressions[0] != expressions[2]);
+
+			err = ccs_configuration_space_get_forbidden_clauses(
+				space_deser, 3, expressions, &count);
+			assert(err == CCS_RESULT_SUCCESS);
+			assert(count == 1);
+			assert(expressions[0]);
+			assert(!expressions[1]);
+			assert(!expressions[2]);
+
+			err = ccs_release_object(map);
+			assert(err == CCS_RESULT_SUCCESS);
+			err = ccs_release_object(space_deser);
+			assert(err == CCS_RESULT_SUCCESS);
+			free(buff);
+		}
+	}
 	err = ccs_release_object(space);
 	assert(err == CCS_RESULT_SUCCESS);
-
-	err = ccs_create_map(&map);
-	assert(err == CCS_RESULT_SUCCESS);
-	err = ccs_object_deserialize(
-		(ccs_object_t *)&space, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_DESERIALIZE_OPERATION_MEMORY, buff_size, buff,
-		CCS_DESERIALIZE_OPTION_HANDLE_MAP, map,
-		CCS_DESERIALIZE_OPTION_MAP_HANDLES, CCS_DESERIALIZE_OPTION_END);
-	assert(err == CCS_RESULT_SUCCESS);
-
-	err = ccs_map_get(map, ccs_object(space_ref), &d);
-	assert(err == CCS_RESULT_SUCCESS);
-	assert(d.type == CCS_DATA_TYPE_OBJECT);
-	assert(d.value.o == space);
-
-	err = ccs_context_get_parameters((ccs_context_t)space, 0, NULL, &count);
-	assert(err == CCS_RESULT_SUCCESS);
-	assert(count == 3);
-
-	err = ccs_configuration_space_get_conditions(
-		space, 3, expressions, NULL);
-	assert(err == CCS_RESULT_SUCCESS);
-	assert(expressions[0]);
-	assert(!expressions[1]);
-	assert(expressions[2]);
-	assert(expressions[0] != expressions[2]);
-
-	err = ccs_configuration_space_get_forbidden_clauses(
-		space, 3, expressions, &count);
-	assert(err == CCS_RESULT_SUCCESS);
-	assert(count == 1);
-	assert(expressions[0]);
-	assert(!expressions[1]);
-	assert(!expressions[2]);
-
-	err = ccs_release_object(map);
-	assert(err == CCS_RESULT_SUCCESS);
-	err = ccs_release_object(space);
-	assert(err == CCS_RESULT_SUCCESS);
-	free(buff);
 }
 
 void


### PR DESCRIPTION
## Summary

- **Configuration space**: serializes name, optional feature_space, rng, parameters, conditions (index + expression pairs), forbidden_clauses
- **Configuration**: serializes binding data (context handle + values) + optional features
- Both use handle maps for cross-reference resolution during deserialization
- Configuration space auto-creates a handle map if none provided

Also fixes `expression_deserialize.h`: child expression deserialization now correctly sets `map_values=CCS_FALSE` instead of `handle_map=NULL`, matching the binary pattern.

## Test plan

- [x] All 30 tests pass
- [x] JSON roundtrip for configuration space with conditions and forbidden clauses
- [x] JSON roundtrip for configuration with handle map resolution
- [x] Handle map error path tested (empty map → INVALID_HANDLE)
- [x] Builds clean with gcc, g++, clang

🤖 Generated with [Claude Code](https://claude.com/claude-code)