### PR TITLE
Add JSON serialization for tree, tree_configuration, and tree_space

### DIFF
--- a/src/cconfigspace_json.h
+++ b/src/cconfigspace_json.h
@@ -277,6 +277,41 @@ _ccs_json_expression_type_from_string(
 }
 
 /*============================================================================
+ * Tree space type string conversion
+ *============================================================================*/
+
+static inline const char *
+_ccs_json_tree_space_type_to_string(ccs_tree_space_type_t type)
+{
+	switch (type) {
+	case CCS_TREE_SPACE_TYPE_STATIC:
+		return "static";
+	case CCS_TREE_SPACE_TYPE_DYNAMIC:
+		return "dynamic";
+	default:
+		return NULL;
+	}
+}
+
+static inline ccs_result_t
+_ccs_json_tree_space_type_from_string(
+	const char            *str,
+	ccs_tree_space_type_t *type_ret)
+{
+	if (!strcmp(str, "static")) {
+		*type_ret = CCS_TREE_SPACE_TYPE_STATIC;
+		return CCS_RESULT_SUCCESS;
+	}
+	if (!strcmp(str, "dynamic")) {
+		*type_ret = CCS_TREE_SPACE_TYPE_DYNAMIC;
+		return CCS_RESULT_SUCCESS;
+	}
+	CCS_RAISE(
+		CCS_RESULT_ERROR_INVALID_VALUE,
+		"Unknown tree space type string: %s", str);
+}
+
+/*============================================================================
  * ccs_datum_t JSON helpers
  *============================================================================*/
 

--- a/src/tree.c
+++ b/src/tree.c
@@ -1,4 +1,5 @@
 #include "cconfigspace_internal.h"
+#include "cconfigspace_json.h"
 #include "tree_internal.h"
 
 static ccs_result_t
@@ -85,6 +86,47 @@ _ccs_serialize_bin_ccs_tree(
 	return CCS_RESULT_SUCCESS;
 }
 
+static inline ccs_result_t
+_ccs_serialize_json_ccs_tree(
+	ccs_tree_t                       tree,
+	cJSON                           *json,
+	_ccs_object_serialize_options_t *opts)
+{
+	_ccs_tree_data_t *data  = tree->data;
+	size_t            dummy = 0;
+	cJSON            *children;
+	size_t            i;
+
+	CCS_REFUTE(
+		!cJSON_AddNumberToObject(json, "arity", (double)data->arity),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	CCS_REFUTE(
+		!cJSON_AddNumberToObject(
+			json, "weight", data->weights[data->arity]),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	CCS_REFUTE(
+		!cJSON_AddNumberToObject(json, "bias", data->bias),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	CCS_VALIDATE(_ccs_json_add_datum(json, "value", data->value));
+
+	children = cJSON_AddArrayToObject(json, "children");
+	CCS_REFUTE(!children, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	for (i = 0; i < data->arity; i++) {
+		if (data->children[i]) {
+			cJSON *child = cJSON_CreateObject();
+			CCS_REFUTE(!child, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+			cJSON_AddItemToArray(children, child);
+			dummy = 0;
+			CCS_VALIDATE(_ccs_object_serialize_with_opts(
+				data->children[i], CCS_SERIALIZE_FORMAT_JSON,
+				&dummy, (char **)&child, opts));
+		} else {
+			cJSON_AddItemToArray(children, cJSON_CreateNull());
+		}
+	}
+	return CCS_RESULT_SUCCESS;
+}
+
 static ccs_result_t
 _ccs_tree_serialize_size(
 	ccs_object_t                     object,
@@ -117,6 +159,10 @@ _ccs_tree_serialize(
 	case CCS_SERIALIZE_FORMAT_BINARY:
 		CCS_VALIDATE(_ccs_serialize_bin_ccs_tree(
 			(ccs_tree_t)object, buffer_size, buffer, opts));
+		break;
+	case CCS_SERIALIZE_FORMAT_JSON:
+		CCS_VALIDATE(_ccs_serialize_json_ccs_tree(
+			(ccs_tree_t)object, *(cJSON **)buffer, opts));
 		break;
 	default:
 		CCS_RAISE(

--- a/src/tree_configuration.c
+++ b/src/tree_configuration.c
@@ -1,4 +1,5 @@
 #include "cconfigspace_internal.h"
+#include "cconfigspace_json.h"
 #include "tree_configuration_internal.h"
 #include "tree_space_internal.h"
 #include "features_internal.h"
@@ -80,6 +81,44 @@ _ccs_serialize_bin_ccs_tree_configuration(
 	return CCS_RESULT_SUCCESS;
 }
 
+static inline ccs_result_t
+_ccs_serialize_json_ccs_tree_configuration(
+	ccs_tree_configuration_t         tree_configuration,
+	cJSON                           *json,
+	_ccs_object_serialize_options_t *opts)
+{
+	_ccs_tree_configuration_data_t *data = tree_configuration->data;
+	char                            hex[sizeof(ccs_object_t) * 2 + 1];
+	cJSON                          *positions;
+	size_t                          dummy = 0;
+	size_t                          i;
+
+	_ccs_json_hex_encode_buf(&data->tree_space, sizeof(ccs_object_t), hex);
+	CCS_REFUTE(
+		!cJSON_AddStringToObject(json, "tree_space", hex),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+
+	positions = cJSON_AddArrayToObject(json, "position");
+	CCS_REFUTE(!positions, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	for (i = 0; i < data->position_size; i++)
+		CCS_REFUTE(
+			!cJSON_AddItemToArray(
+				positions,
+				cJSON_CreateNumber((double)data->position[i])),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+
+	if (data->features) {
+		cJSON *feat = cJSON_AddObjectToObject(json, "features");
+		CCS_REFUTE(!feat, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		dummy = 0;
+		CCS_VALIDATE(_ccs_object_serialize_with_opts(
+			data->features, CCS_SERIALIZE_FORMAT_JSON, &dummy,
+			(char **)&feat, opts));
+	}
+
+	return CCS_RESULT_SUCCESS;
+}
+
 static ccs_result_t
 _ccs_tree_configuration_serialize_size(
 	ccs_object_t                     object,
@@ -112,6 +151,11 @@ _ccs_tree_configuration_serialize(
 	case CCS_SERIALIZE_FORMAT_BINARY:
 		CCS_VALIDATE(_ccs_serialize_bin_ccs_tree_configuration(
 			(ccs_tree_configuration_t)object, buffer_size, buffer,
+			opts));
+		break;
+	case CCS_SERIALIZE_FORMAT_JSON:
+		CCS_VALIDATE(_ccs_serialize_json_ccs_tree_configuration(
+			(ccs_tree_configuration_t)object, *(cJSON **)buffer,
 			opts));
 		break;
 	default:

--- a/src/tree_configuration_deserialize.h
+++ b/src/tree_configuration_deserialize.h
@@ -1,6 +1,7 @@
 #ifndef _TREE_CONFIGURATION_DESERIALIZE_H
 #define _TREE_CONFIGURATION_DESERIALIZE_H
 #include "cconfigspace_internal.h"
+#include "cconfigspace_json.h"
 #include "tree_configuration_internal.h"
 
 struct _ccs_tree_configuration_data_mock_s {
@@ -95,6 +96,105 @@ end:
 	return res;
 }
 
+static inline ccs_result_t
+_ccs_deserialize_json_tree_configuration(
+	ccs_tree_configuration_t          *configuration_ret,
+	uint32_t                           version,
+	size_t                            *buffer_size,
+	const char                       **buffer,
+	_ccs_object_deserialize_options_t *opts)
+{
+	ccs_result_t     res = CCS_RESULT_SUCCESS;
+	cJSON           *json;
+	cJSON           *j_ts;
+	cJSON           *j_position;
+	cJSON           *j_features;
+	ccs_tree_space_t tree_space;
+	ccs_datum_t      d;
+	ccs_object_t     ts_handle;
+	size_t          *position = NULL;
+	ccs_features_t   features = NULL;
+	int              pos_count;
+	int              i;
+	const char      *cbuf;
+	size_t           dummy;
+
+	(void)buffer_size;
+
+	CCS_CHECK_OBJ(opts->handle_map, CCS_OBJECT_TYPE_MAP);
+
+	json = *(cJSON **)buffer;
+
+	j_ts = cJSON_GetObjectItemCaseSensitive(json, "tree_space");
+	CCS_REFUTE(
+		!j_ts || !cJSON_IsString(j_ts), CCS_RESULT_ERROR_INVALID_VALUE);
+	CCS_REFUTE(
+		strlen(j_ts->valuestring) != sizeof(ccs_object_t) * 2,
+		CCS_RESULT_ERROR_INVALID_VALUE);
+	CCS_REFUTE(
+		_ccs_json_hex_decode_buf(
+			j_ts->valuestring, sizeof(ccs_object_t) * 2,
+			&ts_handle),
+		CCS_RESULT_ERROR_INVALID_VALUE);
+
+	CCS_VALIDATE_ERR_GOTO(
+		res, ccs_map_get(opts->handle_map, ccs_object(ts_handle), &d),
+		end);
+	CCS_REFUTE_ERR_GOTO(
+		res, d.type != CCS_DATA_TYPE_OBJECT,
+		CCS_RESULT_ERROR_INVALID_HANDLE, end);
+	tree_space = (ccs_tree_space_t)(d.value.o);
+
+	j_position = cJSON_GetObjectItemCaseSensitive(json, "position");
+	CCS_REFUTE_ERR_GOTO(
+		res, !j_position || !cJSON_IsArray(j_position),
+		CCS_RESULT_ERROR_INVALID_VALUE, end);
+	pos_count = cJSON_GetArraySize(j_position);
+
+	if (pos_count > 0) {
+		position = (size_t *)calloc((size_t)pos_count, sizeof(size_t));
+		CCS_REFUTE_ERR_GOTO(
+			res, !position, CCS_RESULT_ERROR_OUT_OF_MEMORY, end);
+		for (i = 0; i < pos_count; i++) {
+			cJSON *item = cJSON_GetArrayItem(j_position, i);
+			CCS_REFUTE_ERR_GOTO(
+				res, !item || !cJSON_IsNumber(item),
+				CCS_RESULT_ERROR_INVALID_VALUE, end);
+			position[i] = (size_t)item->valuedouble;
+		}
+	}
+
+	j_features = cJSON_GetObjectItemCaseSensitive(json, "features");
+	if (j_features && cJSON_IsObject(j_features)) {
+		_ccs_object_deserialize_options_t feat_opts = *opts;
+		feat_opts.map_values                        = CCS_FALSE;
+		cbuf  = (const char *)j_features;
+		dummy = 0;
+		CCS_VALIDATE_ERR_GOTO(
+			res,
+			_ccs_object_deserialize_with_opts_check(
+				(ccs_object_t *)&features,
+				CCS_OBJECT_TYPE_FEATURES,
+				CCS_SERIALIZE_FORMAT_JSON, version, &dummy,
+				&cbuf, &feat_opts),
+			end);
+	}
+
+	CCS_VALIDATE_ERR_GOTO(
+		res,
+		ccs_create_tree_configuration(
+			tree_space, features, (size_t)pos_count, position,
+			configuration_ret),
+		end);
+
+end:
+	if (features)
+		ccs_release_object(features);
+	if (position)
+		free(position);
+	return res;
+}
+
 static ccs_result_t
 _ccs_tree_configuration_deserialize(
 	ccs_tree_configuration_t          *configuration_ret,
@@ -107,6 +207,10 @@ _ccs_tree_configuration_deserialize(
 	switch (format) {
 	case CCS_SERIALIZE_FORMAT_BINARY:
 		CCS_VALIDATE(_ccs_deserialize_bin_tree_configuration(
+			configuration_ret, version, buffer_size, buffer, opts));
+		break;
+	case CCS_SERIALIZE_FORMAT_JSON:
+		CCS_VALIDATE(_ccs_deserialize_json_tree_configuration(
 			configuration_ret, version, buffer_size, buffer, opts));
 		break;
 	default:

--- a/src/tree_deserialize.h
+++ b/src/tree_deserialize.h
@@ -1,6 +1,7 @@
 #ifndef _TREE_DESERIALIZE_H
 #define _TREE_DESERIALIZE_H
 #include "cconfigspace_internal.h"
+#include "cconfigspace_json.h"
 #include "tree_internal.h"
 
 struct _ccs_tree_data_mock_s {
@@ -98,6 +99,121 @@ end:
 	return res;
 }
 
+static inline ccs_result_t
+_ccs_deserialize_json_tree(
+	ccs_tree_t                        *tree_ret,
+	uint32_t                           version,
+	size_t                            *buffer_size,
+	const char                       **buffer,
+	_ccs_object_deserialize_options_t *opts)
+{
+	_ccs_object_deserialize_options_t new_opts = *opts;
+	ccs_result_t                      res      = CCS_RESULT_SUCCESS;
+	cJSON                            *json;
+	cJSON                            *j_arity;
+	cJSON                            *j_weight;
+	cJSON                            *j_bias;
+	cJSON                            *j_value;
+	cJSON                            *j_children;
+	ccs_tree_t                        tree = NULL;
+	_ccs_tree_data_mock_t             data;
+	int                               num_children;
+	int                               i;
+	const char                       *cbuf;
+	size_t                            dummy;
+
+	(void)buffer_size;
+	new_opts.handle_map = NULL;
+	new_opts.map_values = CCS_FALSE;
+	data.children       = NULL;
+
+	json                = *(cJSON **)buffer;
+
+	j_arity             = cJSON_GetObjectItemCaseSensitive(json, "arity");
+	CCS_REFUTE(
+		!j_arity || !cJSON_IsNumber(j_arity),
+		CCS_RESULT_ERROR_INVALID_VALUE);
+	data.arity = (size_t)j_arity->valuedouble;
+
+	j_weight   = cJSON_GetObjectItemCaseSensitive(json, "weight");
+	CCS_REFUTE(
+		!j_weight || !cJSON_IsNumber(j_weight),
+		CCS_RESULT_ERROR_INVALID_VALUE);
+	data.weight = j_weight->valuedouble;
+
+	j_bias      = cJSON_GetObjectItemCaseSensitive(json, "bias");
+	CCS_REFUTE(
+		!j_bias || !cJSON_IsNumber(j_bias),
+		CCS_RESULT_ERROR_INVALID_VALUE);
+	data.bias = j_bias->valuedouble;
+
+	j_value   = cJSON_GetObjectItemCaseSensitive(json, "value");
+	CCS_REFUTE(!j_value, CCS_RESULT_ERROR_INVALID_VALUE);
+	CCS_VALIDATE_ERR_GOTO(
+		res, _ccs_json_get_datum(j_value, &data.value), end);
+
+	j_children = cJSON_GetObjectItemCaseSensitive(json, "children");
+	CCS_REFUTE_ERR_GOTO(
+		res, !j_children || !cJSON_IsArray(j_children),
+		CCS_RESULT_ERROR_INVALID_VALUE, end);
+	num_children = cJSON_GetArraySize(j_children);
+	CCS_REFUTE_ERR_GOTO(
+		res, (size_t)num_children != data.arity,
+		CCS_RESULT_ERROR_INVALID_VALUE, end);
+
+	if (data.arity) {
+		data.children =
+			(ccs_tree_t *)calloc(data.arity, sizeof(ccs_tree_t));
+		CCS_REFUTE_ERR_GOTO(
+			res, !data.children, CCS_RESULT_ERROR_OUT_OF_MEMORY,
+			end);
+		for (i = 0; i < num_children; i++) {
+			cJSON *child_item = cJSON_GetArrayItem(j_children, i);
+			if (!cJSON_IsNull(child_item)) {
+				cbuf  = (const char *)child_item;
+				dummy = 0;
+				CCS_VALIDATE_ERR_GOTO(
+					res,
+					_ccs_object_deserialize_with_opts_check(
+						(ccs_object_t *)data.children +
+							i,
+						CCS_OBJECT_TYPE_TREE,
+						CCS_SERIALIZE_FORMAT_JSON,
+						version, &dummy, &cbuf,
+						&new_opts),
+					end);
+			}
+		}
+	}
+
+	CCS_VALIDATE_ERR_GOTO(
+		res, ccs_create_tree(data.arity, data.value, &tree), end);
+	CCS_VALIDATE_ERR_GOTO(
+		res, ccs_tree_set_weight(tree, data.weight), err_tree);
+	CCS_VALIDATE_ERR_GOTO(
+		res, ccs_tree_set_bias(tree, data.bias), err_tree);
+	for (i = 0; (size_t)i < data.arity; i++)
+		if (data.children[i])
+			CCS_VALIDATE_ERR_GOTO(
+				res,
+				ccs_tree_set_child(
+					tree, (size_t)i, data.children[i]),
+				err_tree);
+
+	*tree_ret = tree;
+	goto end;
+err_tree:
+	ccs_release_object(tree);
+end:
+	if (data.children) {
+		for (i = 0; (size_t)i < data.arity; i++)
+			if (data.children[i])
+				ccs_release_object(data.children[i]);
+		free(data.children);
+	}
+	return res;
+}
+
 static ccs_result_t
 _ccs_tree_deserialize(
 	ccs_tree_t                        *tree_ret,
@@ -110,6 +226,10 @@ _ccs_tree_deserialize(
 	switch (format) {
 	case CCS_SERIALIZE_FORMAT_BINARY:
 		CCS_VALIDATE(_ccs_deserialize_bin_tree(
+			tree_ret, version, buffer_size, buffer, opts));
+		break;
+	case CCS_SERIALIZE_FORMAT_JSON:
+		CCS_VALIDATE(_ccs_deserialize_json_tree(
 			tree_ret, version, buffer_size, buffer, opts));
 		break;
 	default:

--- a/src/tree_space_deserialize.h
+++ b/src/tree_space_deserialize.h
@@ -1,6 +1,7 @@
 #ifndef _TREE_SPACE_DESERIALIZE_H
 #define _TREE_SPACE_DESERIALIZE_H
 #include "tree_space_internal.h"
+#include "cconfigspace_json.h"
 
 struct _ccs_tree_space_common_data_mock_s {
 	ccs_tree_space_type_t type;
@@ -192,6 +193,247 @@ _ccs_deserialize_bin_tree_space(
 	return CCS_RESULT_SUCCESS;
 }
 
+static inline ccs_result_t
+_ccs_deserialize_json_ccs_tree_space_common_data(
+	_ccs_tree_space_common_data_mock_t *data,
+	uint32_t                            version,
+	cJSON                              *json,
+	_ccs_object_deserialize_options_t  *opts)
+{
+	_ccs_object_deserialize_options_t new_opts = *opts;
+	cJSON                            *j_type;
+	cJSON                            *j_name;
+	cJSON                            *j_rng;
+	cJSON                            *j_tree;
+	cJSON                            *j_fs_handle;
+	cJSON                            *j_fs;
+	const char                       *cbuf;
+	size_t                            dummy;
+
+	new_opts.handle_map = NULL;
+	new_opts.map_values = CCS_FALSE;
+
+	j_type = cJSON_GetObjectItemCaseSensitive(json, "tree_space_type");
+	CCS_REFUTE(
+		!j_type || !cJSON_IsString(j_type),
+		CCS_RESULT_ERROR_INVALID_VALUE);
+	CCS_VALIDATE(_ccs_json_tree_space_type_from_string(
+		j_type->valuestring, &data->type));
+
+	j_name = cJSON_GetObjectItemCaseSensitive(json, "name");
+	CCS_REFUTE(
+		!j_name || !cJSON_IsString(j_name),
+		CCS_RESULT_ERROR_INVALID_VALUE);
+	data->name = j_name->valuestring;
+
+	j_rng      = cJSON_GetObjectItemCaseSensitive(json, "rng");
+	CCS_REFUTE(
+		!j_rng || !cJSON_IsObject(j_rng),
+		CCS_RESULT_ERROR_INVALID_VALUE);
+	cbuf  = (const char *)j_rng;
+	dummy = 0;
+	CCS_VALIDATE(_ccs_object_deserialize_with_opts_check(
+		(ccs_object_t *)&data->rng, CCS_OBJECT_TYPE_RNG,
+		CCS_SERIALIZE_FORMAT_JSON, version, &dummy, &cbuf, &new_opts));
+
+	j_tree = cJSON_GetObjectItemCaseSensitive(json, "tree");
+	CCS_REFUTE(
+		!j_tree || !cJSON_IsObject(j_tree),
+		CCS_RESULT_ERROR_INVALID_VALUE);
+	cbuf  = (const char *)j_tree;
+	dummy = 0;
+	CCS_VALIDATE(_ccs_object_deserialize_with_opts_check(
+		(ccs_object_t *)&data->tree, CCS_OBJECT_TYPE_TREE,
+		CCS_SERIALIZE_FORMAT_JSON, version, &dummy, &cbuf, &new_opts));
+
+	j_fs_handle =
+		cJSON_GetObjectItemCaseSensitive(json, "feature_space_handle");
+	if (j_fs_handle && cJSON_IsString(j_fs_handle)) {
+		CCS_REFUTE(
+			strlen(j_fs_handle->valuestring) !=
+				sizeof(ccs_object_t) * 2,
+			CCS_RESULT_ERROR_INVALID_VALUE);
+		CCS_REFUTE(
+			_ccs_json_hex_decode_buf(
+				j_fs_handle->valuestring,
+				sizeof(ccs_object_t) * 2,
+				&data->feature_space_handle),
+			CCS_RESULT_ERROR_INVALID_VALUE);
+		j_fs = cJSON_GetObjectItemCaseSensitive(json, "feature_space");
+		CCS_REFUTE(
+			!j_fs || !cJSON_IsObject(j_fs),
+			CCS_RESULT_ERROR_INVALID_VALUE);
+		cbuf  = (const char *)j_fs;
+		dummy = 0;
+		CCS_VALIDATE(_ccs_object_deserialize_with_opts_check(
+			(ccs_object_t *)&data->feature_space,
+			CCS_OBJECT_TYPE_FEATURE_SPACE,
+			CCS_SERIALIZE_FORMAT_JSON, version, &dummy, &cbuf,
+			opts));
+	}
+
+	return CCS_RESULT_SUCCESS;
+}
+
+static inline ccs_result_t
+_ccs_deserialize_json_tree_space_static(
+	ccs_tree_space_t                   *tree_space_ret,
+	uint32_t                            version,
+	cJSON                              *json,
+	_ccs_object_deserialize_options_t  *opts,
+	_ccs_tree_space_common_data_mock_t *data)
+{
+	ccs_result_t res = CCS_RESULT_SUCCESS;
+	CCS_VALIDATE_ERR_GOTO(
+		res,
+		_ccs_deserialize_json_ccs_tree_space_common_data(
+			data, version, json, opts),
+		end);
+	CCS_VALIDATE_ERR_GOTO(
+		res,
+		ccs_create_static_tree_space(
+			data->name, data->tree, data->feature_space, data->rng,
+			tree_space_ret),
+		end);
+	if (opts->map_values && data->feature_space_handle)
+		CCS_VALIDATE_ERR_GOTO(
+			res,
+			_ccs_object_handle_check_add(
+				opts->handle_map, data->feature_space_handle,
+				(ccs_object_t)data->feature_space),
+			err_tree_space);
+	goto end;
+err_tree_space:
+	ccs_release_object(*tree_space_ret);
+	*tree_space_ret = NULL;
+end:
+	if (data->feature_space)
+		ccs_release_object(data->feature_space);
+	if (data->rng)
+		ccs_release_object(data->rng);
+	if (data->tree)
+		ccs_release_object(data->tree);
+	return res;
+}
+
+static inline ccs_result_t
+_ccs_deserialize_json_tree_space_dynamic(
+	ccs_tree_space_t                   *tree_space_ret,
+	uint32_t                            version,
+	cJSON                              *json,
+	_ccs_object_deserialize_options_t  *opts,
+	_ccs_tree_space_common_data_mock_t *data)
+{
+	ccs_dynamic_tree_space_vector_t *vector          = NULL;
+	void                            *tree_space_data = NULL;
+	size_t                           blob_sz         = 0;
+	unsigned char                   *blob_data       = NULL;
+	ccs_result_t                     res             = CCS_RESULT_SUCCESS;
+	cJSON                           *j_state;
+
+	CCS_VALIDATE_ERR_GOTO(
+		res,
+		_ccs_deserialize_json_ccs_tree_space_common_data(
+			data, version, json, opts),
+		end);
+
+	j_state = cJSON_GetObjectItemCaseSensitive(json, "user_state");
+	if (j_state && cJSON_IsString(j_state)) {
+		blob_data =
+			_ccs_json_hex_decode(j_state->valuestring, &blob_sz);
+		CCS_REFUTE_ERR_GOTO(
+			res, !blob_data, CCS_RESULT_ERROR_OUT_OF_MEMORY, end);
+	}
+
+	CCS_VALIDATE_ERR_GOTO(
+		res,
+		opts->deserialize_vector_callback(
+			CCS_OBJECT_TYPE_TREE_SPACE, data->name,
+			opts->deserialize_vector_user_data, (void **)&vector,
+			&tree_space_data),
+		end);
+
+	if (vector->deserialize_state)
+		CCS_VALIDATE_ERR_GOTO(
+			res,
+			vector->deserialize_state(
+				data->tree, data->feature_space, blob_sz,
+				blob_data, &tree_space_data),
+			end);
+
+	CCS_VALIDATE_ERR_GOTO(
+		res,
+		ccs_create_dynamic_tree_space(
+			data->name, data->tree, data->feature_space, data->rng,
+			vector, tree_space_data, tree_space_ret),
+		end);
+	if (opts->map_values && data->feature_space_handle)
+		CCS_VALIDATE_ERR_GOTO(
+			res,
+			_ccs_object_handle_check_add(
+				opts->handle_map, data->feature_space_handle,
+				(ccs_object_t)data->feature_space),
+			err_tree_space);
+	goto end;
+err_tree_space:
+	ccs_release_object(*tree_space_ret);
+	*tree_space_ret = NULL;
+end:
+	if (blob_data)
+		free(blob_data);
+	if (data->feature_space)
+		ccs_release_object(data->feature_space);
+	if (data->rng)
+		ccs_release_object(data->rng);
+	if (data->tree)
+		ccs_release_object(data->tree);
+	return res;
+}
+
+static inline ccs_result_t
+_ccs_deserialize_json_tree_space(
+	ccs_tree_space_t                  *tree_space_ret,
+	uint32_t                           version,
+	size_t                            *buffer_size,
+	const char                       **buffer,
+	_ccs_object_deserialize_options_t *opts)
+{
+	cJSON                             *json;
+	cJSON                             *j_type;
+	ccs_tree_space_type_t              stype;
+	_ccs_tree_space_common_data_mock_t data = {
+		CCS_TREE_SPACE_TYPE_STATIC, NULL, NULL, NULL, NULL, NULL};
+
+	(void)buffer_size;
+	json   = *(cJSON **)buffer;
+
+	j_type = cJSON_GetObjectItemCaseSensitive(json, "tree_space_type");
+	CCS_REFUTE(
+		!j_type || !cJSON_IsString(j_type),
+		CCS_RESULT_ERROR_INVALID_VALUE);
+	CCS_VALIDATE(_ccs_json_tree_space_type_from_string(
+		j_type->valuestring, &stype));
+
+	if (stype == CCS_TREE_SPACE_TYPE_DYNAMIC)
+		CCS_CHECK_PTR(opts->deserialize_vector_callback);
+
+	switch (stype) {
+	case CCS_TREE_SPACE_TYPE_STATIC:
+		CCS_VALIDATE(_ccs_deserialize_json_tree_space_static(
+			tree_space_ret, version, json, opts, &data));
+		break;
+	case CCS_TREE_SPACE_TYPE_DYNAMIC:
+		CCS_VALIDATE(_ccs_deserialize_json_tree_space_dynamic(
+			tree_space_ret, version, json, opts, &data));
+		break;
+	default:
+		CCS_RAISE(
+			CCS_RESULT_ERROR_UNSUPPORTED_OPERATION,
+			"Unsupported tree space type: %d", stype);
+	}
+	return CCS_RESULT_SUCCESS;
+}
+
 static ccs_result_t
 _ccs_tree_space_deserialize(
 	ccs_tree_space_t                  *tree_space_ret,
@@ -204,6 +446,10 @@ _ccs_tree_space_deserialize(
 	switch (format) {
 	case CCS_SERIALIZE_FORMAT_BINARY:
 		CCS_VALIDATE(_ccs_deserialize_bin_tree_space(
+			tree_space_ret, version, buffer_size, buffer, opts));
+		break;
+	case CCS_SERIALIZE_FORMAT_JSON:
+		CCS_VALIDATE(_ccs_deserialize_json_tree_space(
 			tree_space_ret, version, buffer_size, buffer, opts));
 		break;
 	default:

--- a/src/tree_space_dynamic.c
+++ b/src/tree_space_dynamic.c
@@ -97,6 +97,46 @@ _ccs_serialize_bin_ccs_tree_space_dynamic(
 	return CCS_RESULT_SUCCESS;
 }
 
+static inline ccs_result_t
+_ccs_serialize_json_ccs_tree_space_dynamic(
+	ccs_tree_space_t                 tree_space,
+	cJSON                           *json,
+	_ccs_object_serialize_options_t *opts)
+{
+	_ccs_tree_space_dynamic_data_t *data =
+		(_ccs_tree_space_dynamic_data_t *)tree_space->data;
+	CCS_VALIDATE(_ccs_serialize_json_ccs_tree_space_common_data(
+		&data->common_data, json, opts));
+
+	/* user state blob */
+	{
+		size_t state_size = 0;
+		if (data->vector.serialize_user_state)
+			CCS_VALIDATE(data->vector.serialize_user_state(
+				tree_space, 0, NULL, &state_size));
+		if (state_size) {
+			char *tmp = (char *)malloc(state_size);
+			char *hex;
+			CCS_REFUTE(!tmp, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+			CCS_VALIDATE(data->vector.serialize_user_state(
+				tree_space, state_size, tmp, NULL));
+			hex = _ccs_json_hex_encode(tmp, state_size);
+			free(tmp);
+			CCS_REFUTE(!hex, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+			{
+				cJSON *j_state = cJSON_AddStringToObject(
+					json, "user_state", hex);
+				free(hex);
+				CCS_REFUTE(
+					!j_state,
+					CCS_RESULT_ERROR_OUT_OF_MEMORY);
+			}
+		}
+	}
+
+	return CCS_RESULT_SUCCESS;
+}
+
 static ccs_result_t
 _ccs_tree_space_dynamic_serialize_size(
 	ccs_object_t                     object,
@@ -129,6 +169,10 @@ _ccs_tree_space_dynamic_serialize(
 	case CCS_SERIALIZE_FORMAT_BINARY:
 		CCS_VALIDATE(_ccs_serialize_bin_ccs_tree_space_dynamic(
 			(ccs_tree_space_t)object, buffer_size, buffer, opts));
+		break;
+	case CCS_SERIALIZE_FORMAT_JSON:
+		CCS_VALIDATE(_ccs_serialize_json_ccs_tree_space_dynamic(
+			(ccs_tree_space_t)object, *(cJSON **)buffer, opts));
 		break;
 	default:
 		CCS_RAISE(

--- a/src/tree_space_internal.h
+++ b/src/tree_space_internal.h
@@ -3,6 +3,7 @@
 #include "tree_internal.h"
 #include "rng_internal.h"
 #include "feature_space_internal.h"
+#include "cconfigspace_json.h"
 
 #define CCS_CHECK_TREE_SPACE(o, t)                                             \
 	do {                                                                   \
@@ -97,6 +98,61 @@ _ccs_serialize_bin_ccs_tree_space_common_data(
 		CCS_VALIDATE(_ccs_object_serialize_with_opts(
 			data->feature_space, CCS_SERIALIZE_FORMAT_BINARY,
 			buffer_size, buffer, opts));
+	return CCS_RESULT_SUCCESS;
+}
+
+static inline ccs_result_t
+_ccs_serialize_json_ccs_tree_space_common_data(
+	_ccs_tree_space_common_data_t   *data,
+	cJSON                           *json,
+	_ccs_object_serialize_options_t *opts)
+{
+	const char *type_str;
+	cJSON      *rng_node;
+	cJSON      *tree_node;
+	size_t      dummy = 0;
+
+	type_str          = _ccs_json_tree_space_type_to_string(data->type);
+	CCS_REFUTE(!type_str, CCS_RESULT_ERROR_INVALID_VALUE);
+	CCS_REFUTE(
+		!cJSON_AddStringToObject(json, "tree_space_type", type_str),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+
+	CCS_REFUTE(
+		!cJSON_AddStringToObject(json, "name", data->name),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+
+	rng_node = cJSON_AddObjectToObject(json, "rng");
+	CCS_REFUTE(!rng_node, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	dummy = 0;
+	CCS_VALIDATE(_ccs_object_serialize_with_opts(
+		data->rng, CCS_SERIALIZE_FORMAT_JSON, &dummy,
+		(char **)&rng_node, opts));
+
+	tree_node = cJSON_AddObjectToObject(json, "tree");
+	CCS_REFUTE(!tree_node, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	dummy = 0;
+	CCS_VALIDATE(_ccs_object_serialize_with_opts(
+		data->tree, CCS_SERIALIZE_FORMAT_JSON, &dummy,
+		(char **)&tree_node, opts));
+
+	if (data->feature_space) {
+		char   hex[sizeof(ccs_object_t) * 2 + 1];
+		cJSON *fs_node;
+		_ccs_json_hex_encode_buf(
+			&data->feature_space, sizeof(ccs_object_t), hex);
+		CCS_REFUTE(
+			!cJSON_AddStringToObject(
+				json, "feature_space_handle", hex),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		fs_node = cJSON_AddObjectToObject(json, "feature_space");
+		CCS_REFUTE(!fs_node, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		dummy = 0;
+		CCS_VALIDATE(_ccs_object_serialize_with_opts(
+			data->feature_space, CCS_SERIALIZE_FORMAT_JSON, &dummy,
+			(char **)&fs_node, opts));
+	}
+
 	return CCS_RESULT_SUCCESS;
 }
 

--- a/src/tree_space_static.c
+++ b/src/tree_space_static.c
@@ -72,6 +72,19 @@ _ccs_serialize_bin_ccs_tree_space_static(
 	return CCS_RESULT_SUCCESS;
 }
 
+static inline ccs_result_t
+_ccs_serialize_json_ccs_tree_space_static(
+	ccs_tree_space_t                 tree_space,
+	cJSON                           *json,
+	_ccs_object_serialize_options_t *opts)
+{
+	_ccs_tree_space_static_data_t *data =
+		(_ccs_tree_space_static_data_t *)tree_space->data;
+	CCS_VALIDATE(_ccs_serialize_json_ccs_tree_space_common_data(
+		&data->common_data, json, opts));
+	return CCS_RESULT_SUCCESS;
+}
+
 static ccs_result_t
 _ccs_tree_space_static_serialize_size(
 	ccs_object_t                     object,
@@ -104,6 +117,10 @@ _ccs_tree_space_static_serialize(
 	case CCS_SERIALIZE_FORMAT_BINARY:
 		CCS_VALIDATE(_ccs_serialize_bin_ccs_tree_space_static(
 			(ccs_tree_space_t)object, buffer_size, buffer, opts));
+		break;
+	case CCS_SERIALIZE_FORMAT_JSON:
+		CCS_VALIDATE(_ccs_serialize_json_ccs_tree_space_static(
+			(ccs_tree_space_t)object, *(cJSON **)buffer, opts));
 		break;
 	default:
 		CCS_RAISE(

--- a/tests/test_static_tree_space.c
+++ b/tests/test_static_tree_space.c
@@ -85,126 +85,148 @@ test_static_tree_space(void)
 	err = ccs_tree_space_sample(tree_space, NULL, NULL, &config);
 	assert(err == CCS_RESULT_SUCCESS);
 
-	ccs_map_t   map;
-	ccs_datum_t d;
-	char       *buff;
-	size_t      buff_size;
+	{
+		ccs_serialize_format_t formats[] = {
+			CCS_SERIALIZE_FORMAT_BINARY, CCS_SERIALIZE_FORMAT_JSON};
+		size_t num_formats = sizeof(formats) / sizeof(formats[0]);
+		size_t f;
 
-	err = ccs_create_map(&map);
-	assert(err == CCS_RESULT_SUCCESS);
+		/* Test tree_configuration roundtrip */
+		for (f = 0; f < num_formats; f++) {
+			ccs_map_t   map;
+			ccs_datum_t d;
+			char       *buff;
+			size_t      buff_size;
 
-	err = ccs_object_serialize(
-		config, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
-		CCS_SERIALIZE_OPTION_END);
-	assert(err == CCS_RESULT_SUCCESS);
+			err = ccs_create_map(&map);
+			assert(err == CCS_RESULT_SUCCESS);
 
-	buff = (char *)malloc(buff_size);
-	assert(buff);
+			err = ccs_object_serialize(
+				config, formats[f],
+				CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
+				CCS_SERIALIZE_OPTION_END);
+			assert(err == CCS_RESULT_SUCCESS);
 
-	err = ccs_object_serialize(
-		config, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_MEMORY, buff_size, buff,
-		CCS_SERIALIZE_OPTION_END);
-	assert(err == CCS_RESULT_SUCCESS);
+			buff = (char *)malloc(buff_size);
+			assert(buff);
 
-	err = ccs_release_object(config);
-	assert(err == CCS_RESULT_SUCCESS);
+			err = ccs_object_serialize(
+				config, formats[f],
+				CCS_SERIALIZE_OPERATION_MEMORY, buff_size, buff,
+				CCS_SERIALIZE_OPTION_END);
+			assert(err == CCS_RESULT_SUCCESS);
 
-	err = ccs_object_deserialize(
-		(ccs_object_t *)&config, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_DESERIALIZE_OPERATION_MEMORY, buff_size, buff,
-		CCS_DESERIALIZE_OPTION_HANDLE_MAP, map,
-		CCS_DESERIALIZE_OPTION_END);
-	assert(err == CCS_RESULT_ERROR_INVALID_HANDLE);
+			err = ccs_release_object(config);
+			assert(err == CCS_RESULT_SUCCESS);
 
-	d = ccs_object(tree_space);
-	d.flags |= CCS_DATUM_FLAG_ID;
-	err = ccs_map_set(map, d, ccs_object(tree_space));
-	assert(err == CCS_RESULT_SUCCESS);
+			err = ccs_object_deserialize(
+				(ccs_object_t *)&config, formats[f],
+				CCS_DESERIALIZE_OPERATION_MEMORY, buff_size,
+				buff, CCS_DESERIALIZE_OPTION_HANDLE_MAP, map,
+				CCS_DESERIALIZE_OPTION_END);
+			assert(err == CCS_RESULT_ERROR_INVALID_HANDLE);
 
-	err = ccs_object_deserialize(
-		(ccs_object_t *)&config, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_DESERIALIZE_OPERATION_MEMORY, buff_size, buff,
-		CCS_DESERIALIZE_OPTION_HANDLE_MAP, map,
-		CCS_DESERIALIZE_OPTION_END);
-	assert(err == CCS_RESULT_SUCCESS);
-	free(buff);
+			d = ccs_object(tree_space);
+			d.flags |= CCS_DATUM_FLAG_ID;
+			err = ccs_map_set(map, d, ccs_object(tree_space));
+			assert(err == CCS_RESULT_SUCCESS);
 
-	err = ccs_release_object(map);
-	assert(err == CCS_RESULT_SUCCESS);
+			err = ccs_object_deserialize(
+				(ccs_object_t *)&config, formats[f],
+				CCS_DESERIALIZE_OPERATION_MEMORY, buff_size,
+				buff, CCS_DESERIALIZE_OPTION_HANDLE_MAP, map,
+				CCS_DESERIALIZE_OPTION_END);
+			assert(err == CCS_RESULT_SUCCESS);
+			free(buff);
 
-	err = ccs_tree_space_samples(
-		tree_space, NULL, NULL, NUM_SAMPLES, configs);
-	assert(err == CCS_RESULT_SUCCESS);
+			err = ccs_release_object(map);
+			assert(err == CCS_RESULT_SUCCESS);
+		}
 
-	inv_sum = 0;
-	for (size_t i = 0; i < 5; i++) {
-		depths[i] = 0;
-		inv_sum += areas[i];
-	}
-	inv_sum = 1.0 / inv_sum;
-	for (size_t i = 0; i < NUM_SAMPLES; i++) {
-		err = ccs_tree_configuration_get_position(
-			configs[i], 0, NULL, &position_size);
+		err = ccs_tree_space_samples(
+			tree_space, NULL, NULL, NUM_SAMPLES, configs);
 		assert(err == CCS_RESULT_SUCCESS);
-		depths[position_size]++;
-		err = ccs_release_object(configs[i]);
-		assert(err == CCS_RESULT_SUCCESS);
-	}
-	for (size_t i = 0; i < 5; i++) {
-		ccs_float_t target = NUM_SAMPLES * areas[i] * inv_sum;
-		assert(depths[i] >= target * 0.95 &&
-		       depths[i] <= target * 1.05);
-	}
 
-	err = ccs_object_serialize(
-		tree_space, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
-		CCS_SERIALIZE_OPTION_END);
-	assert(err == CCS_RESULT_SUCCESS);
+		inv_sum = 0;
+		for (size_t i = 0; i < 5; i++) {
+			depths[i] = 0;
+			inv_sum += areas[i];
+		}
+		inv_sum = 1.0 / inv_sum;
+		for (size_t i = 0; i < NUM_SAMPLES; i++) {
+			err = ccs_tree_configuration_get_position(
+				configs[i], 0, NULL, &position_size);
+			assert(err == CCS_RESULT_SUCCESS);
+			depths[position_size]++;
+			err = ccs_release_object(configs[i]);
+			assert(err == CCS_RESULT_SUCCESS);
+		}
+		for (size_t i = 0; i < 5; i++) {
+			ccs_float_t target = NUM_SAMPLES * areas[i] * inv_sum;
+			assert(depths[i] >= target * 0.95 &&
+			       depths[i] <= target * 1.05);
+		}
 
-	buff = (char *)malloc(buff_size);
-	assert(buff);
+		/* Test tree_space roundtrip */
+		for (f = 0; f < num_formats; f++) {
+			char       *buff;
+			size_t      buff_size;
+			const char *ts_name;
 
-	err = ccs_object_serialize(
-		tree_space, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_MEMORY, buff_size, buff,
-		CCS_SERIALIZE_OPTION_END);
-	assert(err == CCS_RESULT_SUCCESS);
+			err = ccs_object_serialize(
+				tree_space, formats[f],
+				CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
+				CCS_SERIALIZE_OPTION_END);
+			assert(err == CCS_RESULT_SUCCESS);
 
-	err = ccs_release_object(tree_space);
-	assert(err == CCS_RESULT_SUCCESS);
+			buff = (char *)malloc(buff_size);
+			assert(buff);
 
-	err = ccs_object_deserialize(
-		(ccs_object_t *)&tree_space, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_DESERIALIZE_OPERATION_MEMORY, buff_size, buff,
-		CCS_DESERIALIZE_OPTION_END);
-	assert(err == CCS_RESULT_SUCCESS);
-	free(buff);
+			err = ccs_object_serialize(
+				tree_space, formats[f],
+				CCS_SERIALIZE_OPERATION_MEMORY, buff_size, buff,
+				CCS_SERIALIZE_OPTION_END);
+			assert(err == CCS_RESULT_SUCCESS);
 
-	err = ccs_tree_space_samples(
-		tree_space, NULL, NULL, NUM_SAMPLES, configs);
-	assert(err == CCS_RESULT_SUCCESS);
+			err = ccs_release_object(tree_space);
+			assert(err == CCS_RESULT_SUCCESS);
 
-	inv_sum = 0;
-	for (size_t i = 0; i < 5; i++) {
-		depths[i] = 0;
-		inv_sum += areas[i];
-	}
-	inv_sum = 1.0 / inv_sum;
-	for (size_t i = 0; i < NUM_SAMPLES; i++) {
-		err = ccs_tree_configuration_get_position(
-			configs[i], 0, NULL, &position_size);
-		assert(err == CCS_RESULT_SUCCESS);
-		depths[position_size]++;
-		err = ccs_release_object(configs[i]);
-		assert(err == CCS_RESULT_SUCCESS);
-	}
-	for (size_t i = 0; i < 5; i++) {
-		ccs_float_t target = NUM_SAMPLES * areas[i] * inv_sum;
-		assert(depths[i] >= target * 0.95 &&
-		       depths[i] <= target * 1.05);
+			err = ccs_object_deserialize(
+				(ccs_object_t *)&tree_space, formats[f],
+				CCS_DESERIALIZE_OPERATION_MEMORY, buff_size,
+				buff, CCS_DESERIALIZE_OPTION_END);
+			assert(err == CCS_RESULT_SUCCESS);
+			free(buff);
+
+			err = ccs_tree_space_get_name(tree_space, &ts_name);
+			assert(err == CCS_RESULT_SUCCESS);
+			assert(!strcmp(ts_name, "space"));
+
+			err = ccs_tree_space_samples(
+				tree_space, NULL, NULL, NUM_SAMPLES, configs);
+			assert(err == CCS_RESULT_SUCCESS);
+
+			inv_sum = 0;
+			for (size_t i = 0; i < 5; i++) {
+				depths[i] = 0;
+				inv_sum += areas[i];
+			}
+			inv_sum = 1.0 / inv_sum;
+			for (size_t i = 0; i < NUM_SAMPLES; i++) {
+				err = ccs_tree_configuration_get_position(
+					configs[i], 0, NULL, &position_size);
+				assert(err == CCS_RESULT_SUCCESS);
+				depths[position_size]++;
+				err = ccs_release_object(configs[i]);
+				assert(err == CCS_RESULT_SUCCESS);
+			}
+			for (size_t i = 0; i < 5; i++) {
+				ccs_float_t target =
+					NUM_SAMPLES * areas[i] * inv_sum;
+				assert(depths[i] >= target * 0.95 &&
+				       depths[i] <= target * 1.05);
+			}
+		}
 	}
 
 	err = ccs_release_object(config);

--- a/tests/test_tree.c
+++ b/tests/test_tree.c
@@ -235,42 +235,79 @@ test_tree(void)
 	assert(err == CCS_RESULT_SUCCESS);
 	check_samples(5, areas, counts, NUM_SAMPLES, samples);
 
-	char  *buff;
-	size_t buff_size;
+	{
+		ccs_serialize_format_t formats[] = {
+			CCS_SERIALIZE_FORMAT_BINARY, CCS_SERIALIZE_FORMAT_JSON};
+		size_t num_formats = sizeof(formats) / sizeof(formats[0]);
+		size_t f;
+		for (f = 0; f < num_formats; f++) {
+			char  *buff;
+			size_t buff_size;
 
-	err = ccs_object_serialize(
-		root, CCS_SERIALIZE_FORMAT_BINARY, CCS_SERIALIZE_OPERATION_SIZE,
-		&buff_size, CCS_SERIALIZE_OPTION_END);
-	assert(err == CCS_RESULT_SUCCESS);
+			err = ccs_object_serialize(
+				root, formats[f], CCS_SERIALIZE_OPERATION_SIZE,
+				&buff_size, CCS_SERIALIZE_OPTION_END);
+			assert(err == CCS_RESULT_SUCCESS);
 
-	buff = (char *)malloc(buff_size);
-	assert(buff);
+			buff = (char *)malloc(buff_size);
+			assert(buff);
 
-	err = ccs_object_serialize(
-		root, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_MEMORY, buff_size, buff,
-		CCS_SERIALIZE_OPTION_END);
-	assert(err == CCS_RESULT_SUCCESS);
+			err = ccs_object_serialize(
+				root, formats[f],
+				CCS_SERIALIZE_OPERATION_MEMORY, buff_size, buff,
+				CCS_SERIALIZE_OPTION_END);
+			assert(err == CCS_RESULT_SUCCESS);
+
+			err = ccs_release_object(root);
+			assert(err == CCS_RESULT_SUCCESS);
+			err = ccs_release_object(child);
+			assert(err == CCS_RESULT_SUCCESS);
+			err = ccs_release_object(grand_child);
+			assert(err == CCS_RESULT_SUCCESS);
+
+			err = ccs_object_deserialize(
+				(ccs_object_t *)&root, formats[f],
+				CCS_DESERIALIZE_OPERATION_MEMORY, buff_size,
+				buff, CCS_DESERIALIZE_OPTION_END);
+			assert(err == CCS_RESULT_SUCCESS);
+			free(buff);
+
+			err = ccs_tree_samples(root, rng, NUM_SAMPLES, samples);
+			assert(err == CCS_RESULT_SUCCESS);
+			check_samples(5, areas, counts, NUM_SAMPLES, samples);
+
+			/* Verify tree structure */
+			{
+				ccs_datum_t v;
+				size_t      a;
+				err = ccs_tree_get_value(root, &v);
+				assert(err == CCS_RESULT_SUCCESS);
+				assert(!ccs_datum_cmp(v, ccs_string("foo")));
+				err = ccs_tree_get_arity(root, &a);
+				assert(err == CCS_RESULT_SUCCESS);
+				assert(a == 4);
+			}
+
+			/* Re-extract child / grand_child for next
+			 * iteration */
+			err = ccs_tree_get_child(root, 2, &child);
+			assert(err == CCS_RESULT_SUCCESS);
+			assert(child);
+			err = ccs_retain_object(child);
+			assert(err == CCS_RESULT_SUCCESS);
+			err = ccs_tree_get_child(child, 1, &grand_child);
+			assert(err == CCS_RESULT_SUCCESS);
+			assert(grand_child);
+			err = ccs_retain_object(grand_child);
+			assert(err == CCS_RESULT_SUCCESS);
+		}
+	}
 
 	err = ccs_release_object(root);
 	assert(err == CCS_RESULT_SUCCESS);
 	err = ccs_release_object(child);
 	assert(err == CCS_RESULT_SUCCESS);
 	err = ccs_release_object(grand_child);
-	assert(err == CCS_RESULT_SUCCESS);
-
-	err = ccs_object_deserialize(
-		(ccs_object_t *)&root, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_DESERIALIZE_OPERATION_MEMORY, buff_size, buff,
-		CCS_DESERIALIZE_OPTION_END);
-	assert(err == CCS_RESULT_SUCCESS);
-	free(buff);
-
-	err = ccs_tree_samples(root, rng, NUM_SAMPLES, samples);
-	assert(err == CCS_RESULT_SUCCESS);
-	check_samples(5, areas, counts, NUM_SAMPLES, samples);
-
-	err = ccs_release_object(root);
 	assert(err == CCS_RESULT_SUCCESS);
 	err = ccs_release_object(rng);
 	assert(err == CCS_RESULT_SUCCESS);


### PR DESCRIPTION
## Summary

- **Tree**: arity, weight, bias, value (datum), children array (recursive, null for absent)
- **Tree configuration**: tree_space handle (hex), position array, optional features
- **Tree space (static)**: common data — type, name, rng (recursive), tree (recursive), optional feature_space
- **Tree space (dynamic)**: common data + optional hex-encoded user state blob

Add `tree_space_type` string conversion (`"static"`/`"dynamic"`) to `cconfigspace_json.h`.

## Test plan

- [x] All 30 tests pass
- [x] Tree roundtrip with nested children
- [x] Tree configuration roundtrip with handle map (error path + success)
- [x] Static tree space roundtrip with sampling verification
- [x] All tests loop over both BINARY and JSON formats
- [x] Builds clean with gcc, g++, clang

🤖 Generated with [Claude Code](https://claude.com/claude-code)