### PR TITLE
Add JSON serialization for distribution space

### DIFF
--- a/src/distribution_space.c
+++ b/src/distribution_space.c
@@ -1,4 +1,5 @@
 #include "cconfigspace_internal.h"
+#include "cconfigspace_json.h"
 #include "distribution_space_internal.h"
 #include "distribution_internal.h"
 
@@ -104,6 +105,58 @@ _ccs_serialize_bin_ccs_distribution_space(
 	return CCS_RESULT_SUCCESS;
 }
 
+static inline ccs_result_t
+_ccs_serialize_json_ccs_distribution_space(
+	ccs_distribution_space_t         distribution_space,
+	cJSON                           *json,
+	_ccs_object_serialize_options_t *opts)
+{
+	_ccs_distribution_space_data_t *data = distribution_space->data;
+	_ccs_distribution_wrapper_t    *dw;
+	char                            hex[sizeof(ccs_object_t) * 2 + 1];
+	size_t                          dummy = 0;
+
+	_ccs_json_hex_encode_buf(
+		&data->configuration_space, sizeof(ccs_object_t), hex);
+	CCS_REFUTE(
+		!cJSON_AddStringToObject(json, "configuration_space", hex),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+
+	cJSON *distribs = cJSON_AddArrayToObject(json, "distributions");
+	CCS_REFUTE(!distribs, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+
+	dw = NULL;
+	DL_FOREACH(data->distribution_list, dw)
+	{
+		cJSON *entry = cJSON_CreateObject();
+		CCS_REFUTE(!entry, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		CCS_REFUTE(
+			!cJSON_AddItemToArray(distribs, entry),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+
+		cJSON *dist_obj =
+			cJSON_AddObjectToObject(entry, "distribution");
+		CCS_REFUTE(!dist_obj, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		CCS_VALIDATE(_ccs_object_serialize_with_opts(
+			dw->distribution, CCS_SERIALIZE_FORMAT_JSON, &dummy,
+			(char **)&dist_obj, opts));
+
+		cJSON *indices =
+			cJSON_AddArrayToObject(entry, "parameter_indices");
+		CCS_REFUTE(!indices, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		for (size_t i = 0; i < dw->dimension; i++)
+			CCS_REFUTE(
+				!cJSON_AddItemToArray(
+					indices,
+					cJSON_CreateNumber(
+						(double)dw
+							->parameter_indexes[i])),
+				CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	}
+
+	return CCS_RESULT_SUCCESS;
+}
+
 static ccs_result_t
 _ccs_distribution_space_serialize_size(
 	ccs_object_t                     object,
@@ -149,6 +202,14 @@ _ccs_distribution_space_serialize(
 			_ccs_serialize_bin_ccs_distribution_space(
 				(ccs_distribution_space_t)object, buffer_size,
 				buffer, opts),
+			end);
+		break;
+	case CCS_SERIALIZE_FORMAT_JSON:
+		CCS_VALIDATE_ERR_GOTO(
+			err,
+			_ccs_serialize_json_ccs_distribution_space(
+				(ccs_distribution_space_t)object,
+				*(cJSON **)buffer, opts),
 			end);
 		break;
 	default:

--- a/src/distribution_space_deserialize.h
+++ b/src/distribution_space_deserialize.h
@@ -1,5 +1,6 @@
 #ifndef _DISTRIBUTION_SPACE_DESERIALIZE_H
 #define _DISTRIBUTION_SPACE_DESERIALIZE_H
+#include "cconfigspace_json.h"
 
 struct _ccs_distribution_space_data_mock_s {
 	ccs_configuration_space_t configuration_space;
@@ -141,6 +142,175 @@ end:
 	return res;
 }
 
+static inline ccs_result_t
+_ccs_deserialize_json_ccs_distribution_space_data(
+	_ccs_distribution_space_data_mock_t *data,
+	uint32_t                             version,
+	cJSON                               *json,
+	_ccs_object_deserialize_options_t   *opts)
+{
+	cJSON      *j_cs;
+	cJSON      *j_distribs;
+	size_t      num;
+	size_t      total_indices = 0;
+	uintptr_t   mem;
+	const char *cbuf;
+	size_t      dummy;
+
+	/* configuration_space handle */
+	j_cs = cJSON_GetObjectItemCaseSensitive(json, "configuration_space");
+	CCS_REFUTE(
+		!j_cs || !cJSON_IsString(j_cs), CCS_RESULT_ERROR_INVALID_VALUE);
+	CCS_REFUTE(
+		strlen(j_cs->valuestring) != sizeof(ccs_object_t) * 2,
+		CCS_RESULT_ERROR_INVALID_VALUE);
+	CCS_REFUTE(
+		_ccs_json_hex_decode_buf(
+			j_cs->valuestring, sizeof(ccs_object_t) * 2,
+			&data->configuration_space),
+		CCS_RESULT_ERROR_INVALID_VALUE);
+
+	/* distributions array */
+	j_distribs = cJSON_GetObjectItemCaseSensitive(json, "distributions");
+	CCS_REFUTE(
+		!j_distribs || !cJSON_IsArray(j_distribs),
+		CCS_RESULT_ERROR_INVALID_VALUE);
+	num                     = (size_t)cJSON_GetArraySize(j_distribs);
+	data->num_distributions = num;
+
+	if (!num)
+		return CCS_RESULT_SUCCESS;
+
+	/* First pass: count total indices */
+	for (size_t i = 0; i < num; i++) {
+		cJSON *entry     = cJSON_GetArrayItem(j_distribs, (int)i);
+		cJSON *j_indices = cJSON_GetObjectItemCaseSensitive(
+			entry, "parameter_indices");
+		CCS_REFUTE(
+			!j_indices || !cJSON_IsArray(j_indices),
+			CCS_RESULT_ERROR_INVALID_VALUE);
+		total_indices += (size_t)cJSON_GetArraySize(j_indices);
+	}
+	data->num_parameters = total_indices;
+
+	{
+		size_t _sz;
+		CCS_REFUTE(
+			CCS_ALLOC_SIZE(
+				&_sz,
+				CCS_ALLOC_SIZE_ARRAY(num, ccs_distribution_t),
+				CCS_ALLOC_SIZE_ARRAY(num, size_t),
+				CCS_ALLOC_SIZE_ARRAY(total_indices, size_t)),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		mem = (uintptr_t)calloc(1, _sz);
+		CCS_REFUTE(!mem, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	}
+
+	data->distributions =
+		CCS_ALLOC_CARVE_ARRAY(mem, num, ccs_distribution_t);
+	data->dimensions = CCS_ALLOC_CARVE_ARRAY(mem, num, size_t);
+	data->distrib_parameter_indices =
+		CCS_ALLOC_CARVE_ARRAY(mem, total_indices, size_t);
+
+	size_t *indices = data->distrib_parameter_indices;
+	for (size_t i = 0; i < num; i++) {
+		cJSON *entry = cJSON_GetArrayItem(j_distribs, (int)i);
+		cJSON *j_dist =
+			cJSON_GetObjectItemCaseSensitive(entry, "distribution");
+		cJSON *j_indices = cJSON_GetObjectItemCaseSensitive(
+			entry, "parameter_indices");
+		size_t dim;
+
+		CCS_REFUTE(
+			!j_dist || !cJSON_IsObject(j_dist),
+			CCS_RESULT_ERROR_INVALID_VALUE);
+		cbuf  = (const char *)j_dist;
+		dummy = 0;
+		CCS_VALIDATE(_ccs_object_deserialize_with_opts_check(
+			(ccs_object_t *)data->distributions + i,
+			CCS_OBJECT_TYPE_DISTRIBUTION, CCS_SERIALIZE_FORMAT_JSON,
+			version, &dummy, &cbuf, opts));
+
+		dim                 = (size_t)cJSON_GetArraySize(j_indices);
+		data->dimensions[i] = dim;
+		for (size_t j = 0; j < dim; j++) {
+			cJSON *idx = cJSON_GetArrayItem(j_indices, (int)j);
+			CCS_REFUTE(
+				!idx || !cJSON_IsNumber(idx),
+				CCS_RESULT_ERROR_INVALID_VALUE);
+			*indices = (size_t)idx->valuedouble;
+			indices++;
+		}
+	}
+
+	return CCS_RESULT_SUCCESS;
+}
+
+static inline ccs_result_t
+_ccs_deserialize_json_distribution_space(
+	ccs_distribution_space_t          *distribution_space_ret,
+	uint32_t                           version,
+	size_t                            *buffer_size,
+	const char                       **buffer,
+	_ccs_object_deserialize_options_t *opts)
+{
+	CCS_CHECK_OBJ(opts->handle_map, CCS_OBJECT_TYPE_MAP);
+	_ccs_object_deserialize_options_t new_opts = *opts;
+	new_opts.map_values                        = CCS_FALSE;
+	new_opts.handle_map                        = NULL;
+	ccs_datum_t               d;
+	ccs_configuration_space_t cs;
+	ccs_distribution_space_t  distrib_space;
+	ccs_result_t              res = CCS_RESULT_SUCCESS;
+
+	(void)buffer_size;
+
+	_ccs_distribution_space_data_mock_t data = {NULL, 0,    0,
+						    NULL, NULL, NULL};
+	CCS_VALIDATE_ERR_GOTO(
+		res,
+		_ccs_deserialize_json_ccs_distribution_space_data(
+			&data, version, *(cJSON **)buffer, &new_opts),
+		end);
+
+	CCS_VALIDATE_ERR_GOTO(
+		res,
+		ccs_map_get(
+			opts->handle_map, ccs_object(data.configuration_space),
+			&d),
+		end);
+	CCS_REFUTE_ERR_GOTO(
+		res, d.type != CCS_DATA_TYPE_OBJECT,
+		CCS_RESULT_ERROR_INVALID_HANDLE, end);
+	cs = (ccs_configuration_space_t)(d.value.o);
+
+	CCS_VALIDATE_ERR_GOTO(
+		res, ccs_create_distribution_space(cs, &distrib_space), end);
+	size_t *indices;
+	indices = data.distrib_parameter_indices;
+	for (size_t i = 0; i < data.num_distributions; i++) {
+		CCS_VALIDATE_ERR_GOTO(
+			res,
+			ccs_distribution_space_set_distribution(
+				distrib_space, data.distributions[i], indices),
+			err_distribution_space);
+		indices += data.dimensions[i];
+	}
+	*distribution_space_ret = distrib_space;
+	goto end;
+
+err_distribution_space:
+	ccs_release_object(distrib_space);
+end:
+	if (data.distributions)
+		for (size_t i = 0; i < data.num_distributions; i++)
+			if (data.distributions[i])
+				ccs_release_object(data.distributions[i]);
+	if (data.distributions)
+		free(data.distributions);
+	return res;
+}
+
 static ccs_result_t
 _ccs_distribution_space_deserialize(
 	ccs_distribution_space_t          *distribution_space_ret,
@@ -153,6 +323,11 @@ _ccs_distribution_space_deserialize(
 	switch (format) {
 	case CCS_SERIALIZE_FORMAT_BINARY:
 		CCS_VALIDATE(_ccs_deserialize_bin_distribution_space(
+			distribution_space_ret, version, buffer_size, buffer,
+			opts));
+		break;
+	case CCS_SERIALIZE_FORMAT_JSON:
+		CCS_VALIDATE(_ccs_deserialize_json_distribution_space(
 			distribution_space_ret, version, buffer_size, buffer,
 			opts));
 		break;

--- a/tests/test_distribution_space.c
+++ b/tests/test_distribution_space.c
@@ -260,7 +260,7 @@ test_set_distribution(void)
 }
 
 void
-test_deserialize(void)
+test_deserialize(ccs_serialize_format_t format)
 {
 	ccs_parameter_t           parameters[3];
 	ccs_configuration_space_t space;
@@ -319,8 +319,7 @@ test_deserialize(void)
 	}
 
 	err = ccs_object_serialize(
-		distrib_space, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
+		distrib_space, format, CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
 		CCS_SERIALIZE_OPTION_END);
 	assert(err == CCS_RESULT_SUCCESS);
 
@@ -328,9 +327,8 @@ test_deserialize(void)
 	assert(buff);
 
 	err = ccs_object_serialize(
-		distrib_space, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_MEMORY, buff_size, buff,
-		CCS_SERIALIZE_OPTION_END);
+		distrib_space, format, CCS_SERIALIZE_OPERATION_MEMORY,
+		buff_size, buff, CCS_SERIALIZE_OPTION_END);
 	assert(err == CCS_RESULT_SUCCESS);
 
 	err = ccs_create_map(&map);
@@ -338,21 +336,23 @@ test_deserialize(void)
 	err = ccs_release_object(distrib_space);
 	assert(err == CCS_RESULT_SUCCESS);
 
+	/* Error path: missing handle in map */
 	err = ccs_object_deserialize(
-		(ccs_object_t *)&distrib_space, CCS_SERIALIZE_FORMAT_BINARY,
+		(ccs_object_t *)&distrib_space, format,
 		CCS_DESERIALIZE_OPERATION_MEMORY, buff_size, buff,
 		CCS_DESERIALIZE_OPTION_HANDLE_MAP, map,
 		CCS_DESERIALIZE_OPTION_END);
 	assert(err == CCS_RESULT_ERROR_INVALID_HANDLE);
+	ccs_clear_thread_error();
 
+	/* Add configuration space to map and retry */
 	d = ccs_object(space);
 	d.flags |= CCS_DATUM_FLAG_ID;
 	err = ccs_map_set(map, d, ccs_object(space));
 	assert(err == CCS_RESULT_SUCCESS);
 
-	assert(err == CCS_RESULT_SUCCESS);
 	err = ccs_object_deserialize(
-		(ccs_object_t *)&distrib_space, CCS_SERIALIZE_FORMAT_BINARY,
+		(ccs_object_t *)&distrib_space, format,
 		CCS_DESERIALIZE_OPERATION_MEMORY, buff_size, buff,
 		CCS_DESERIALIZE_OPTION_HANDLE_MAP, map,
 		CCS_DESERIALIZE_OPTION_END);
@@ -386,7 +386,8 @@ main(void)
 	ccs_init();
 	test_create();
 	test_set_distribution();
-	test_deserialize();
+	test_deserialize(CCS_SERIALIZE_FORMAT_BINARY);
+	test_deserialize(CCS_SERIALIZE_FORMAT_JSON);
 	ccs_clear_thread_error();
 	ccs_fini();
 	return 0;


### PR DESCRIPTION
## Summary

- Implement JSON serialize/deserialize for `distribution_space` objects
- Distribution spaces reference a configuration space by handle, so deserialization requires a handle map
- Parameterize `test_deserialize` to run with both binary and JSON formats
- Test the error path when the configuration space handle is missing from the map

This completes the JSON serialization support for all leaf and composite types except tuner and map.

## Test plan

- [x] All 30 C tests pass
- [x] Tested with all 6 Ubuntu CI matrix configurations: gcc/g++/clang × thread-safe/no-thread-safe
- [x] Builds clean with `--enable-strict` (`-Werror`)
- [x] clang-format-17 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)