### PR TITLE
Add JSON serialization for map

### DIFF
--- a/src/map.c
+++ b/src/map.c
@@ -1,4 +1,5 @@
 #include "cconfigspace_internal.h"
+#include "cconfigspace_json.h"
 #include "map_internal.h"
 #include "datum_uthash.h"
 #include "datum_hash.h"
@@ -95,6 +96,31 @@ _ccs_serialize_bin_ccs_map(ccs_map_t map, size_t *buffer_size, char **buffer)
 	return CCS_RESULT_SUCCESS;
 }
 
+static inline ccs_result_t
+_ccs_serialize_json_ccs_map(ccs_map_t map, cJSON *json)
+{
+	_ccs_map_data_t  *data = (_ccs_map_data_t *)(map->data);
+	_ccs_map_datum_t *current, *tmp;
+
+	cJSON            *pairs = cJSON_AddArrayToObject(json, "pairs");
+	CCS_REFUTE(!pairs, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+
+	HASH_ITER(hh, data->map, current, tmp)
+	{
+		cJSON *pair = cJSON_CreateObject();
+		CCS_REFUTE(!pair, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		CCS_REFUTE(
+			!cJSON_AddItemToArray(pairs, pair),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+
+		CCS_VALIDATE(_ccs_json_add_datum(pair, "key", current->key));
+		CCS_VALIDATE(
+			_ccs_json_add_datum(pair, "value", current->value));
+	}
+
+	return CCS_RESULT_SUCCESS;
+}
+
 static ccs_result_t
 _ccs_map_serialize_size(
 	ccs_object_t                     object,
@@ -136,6 +162,13 @@ _ccs_map_serialize(
 			err,
 			_ccs_serialize_bin_ccs_map(
 				(ccs_map_t)object, buffer_size, buffer),
+			end);
+		break;
+	case CCS_SERIALIZE_FORMAT_JSON:
+		CCS_VALIDATE_ERR_GOTO(
+			err,
+			_ccs_serialize_json_ccs_map(
+				(ccs_map_t)object, *(cJSON **)buffer),
 			end);
 		break;
 	default:

--- a/src/map_deserialize.h
+++ b/src/map_deserialize.h
@@ -1,6 +1,7 @@
 #ifndef _MAP_DESERIALIZE_H
 #define _MAP_DESERIALIZE_H
 #include "map_internal.h"
+#include "cconfigspace_json.h"
 
 struct _ccs_map_pair_s {
 	ccs_datum_t key;
@@ -77,6 +78,66 @@ end:
 	return res;
 }
 
+static inline ccs_result_t
+_ccs_deserialize_json_map(
+	ccs_map_t                         *map_ret,
+	uint32_t                           version,
+	size_t                            *buffer_size,
+	const char                       **buffer,
+	_ccs_object_deserialize_options_t *opts)
+{
+	(void)version;
+	(void)buffer_size;
+	(void)opts;
+	ccs_result_t res = CCS_RESULT_SUCCESS;
+	cJSON       *json;
+	cJSON       *j_pairs;
+	size_t       num;
+
+	json    = *(cJSON **)buffer;
+	j_pairs = cJSON_GetObjectItemCaseSensitive(json, "pairs");
+	CCS_REFUTE(
+		!j_pairs || !cJSON_IsArray(j_pairs),
+		CCS_RESULT_ERROR_INVALID_VALUE);
+	num = (size_t)cJSON_GetArraySize(j_pairs);
+
+	CCS_VALIDATE(ccs_create_map(map_ret));
+	for (size_t i = 0; i < num; i++) {
+		cJSON      *pair = cJSON_GetArrayItem(j_pairs, (int)i);
+		cJSON      *j_key;
+		cJSON      *j_value;
+		ccs_datum_t key, value;
+
+		CCS_REFUTE_ERR_GOTO(
+			res, !pair || !cJSON_IsObject(pair),
+			CCS_RESULT_ERROR_INVALID_VALUE, err_map);
+		j_key = cJSON_GetObjectItemCaseSensitive(pair, "key");
+		CCS_REFUTE_ERR_GOTO(
+			res, !j_key, CCS_RESULT_ERROR_INVALID_VALUE, err_map);
+		CCS_VALIDATE_ERR_GOTO(
+			res, _ccs_json_get_datum(j_key, &key), err_map);
+		j_value = cJSON_GetObjectItemCaseSensitive(pair, "value");
+		CCS_REFUTE_ERR_GOTO(
+			res, !j_value, CCS_RESULT_ERROR_INVALID_VALUE, err_map);
+		CCS_VALIDATE_ERR_GOTO(
+			res, _ccs_json_get_datum(j_value, &value), err_map);
+		/* Strings from cJSON point into the cJSON tree which will
+		 * be freed after deserialization.  Mark them transient so
+		 * ccs_map_set copies the data. */
+		if (key.type == CCS_DATA_TYPE_STRING)
+			key.flags |= CCS_DATUM_FLAG_TRANSIENT;
+		if (value.type == CCS_DATA_TYPE_STRING)
+			value.flags |= CCS_DATUM_FLAG_TRANSIENT;
+		CCS_VALIDATE_ERR_GOTO(
+			res, ccs_map_set(*map_ret, key, value), err_map);
+	}
+	return CCS_RESULT_SUCCESS;
+err_map:
+	ccs_release_object(*map_ret);
+	*map_ret = NULL;
+	return res;
+}
+
 static ccs_result_t
 _ccs_map_deserialize(
 	ccs_map_t                         *map_ret,
@@ -89,6 +150,10 @@ _ccs_map_deserialize(
 	switch (format) {
 	case CCS_SERIALIZE_FORMAT_BINARY:
 		CCS_VALIDATE(_ccs_deserialize_bin_map(
+			map_ret, version, buffer_size, buffer, opts));
+		break;
+	case CCS_SERIALIZE_FORMAT_JSON:
+		CCS_VALIDATE(_ccs_deserialize_json_map(
 			map_ret, version, buffer_size, buffer, opts));
 		break;
 	default:

--- a/tests/test_map.c
+++ b/tests/test_map.c
@@ -2,6 +2,7 @@
 #include <assert.h>
 #include <string.h>
 #include <cconfigspace.h>
+#include "test_utils.h"
 
 void
 test_map(void)
@@ -261,6 +262,83 @@ test_map_set_duplicate_value(void)
 	assert(err == CCS_RESULT_SUCCESS);
 }
 
+static void
+test_map_serialize(ccs_serialize_format_t format)
+{
+	ccs_map_t    map, map2;
+	ccs_datum_t  d_ret;
+	size_t       d_count;
+	ccs_result_t err;
+	char        *str1, *str2;
+
+	err = ccs_create_map(&map);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	err = ccs_map_set(map, ccs_string("hello"), ccs_float(1.0));
+	assert(err == CCS_RESULT_SUCCESS);
+
+	err = ccs_map_set(map, ccs_int(42), ccs_string("world"));
+	assert(err == CCS_RESULT_SUCCESS);
+
+	str1 = (char *)malloc(strlen("foo") + 1);
+	assert(str1);
+	strcpy(str1, "foo");
+
+	str2 = (char *)malloc(strlen("bar") + 1);
+	assert(str2);
+	strcpy(str2, "bar");
+
+	{
+		ccs_datum_t d1 = ccs_string(str1);
+		d1.flags |= CCS_DATUM_FLAG_TRANSIENT;
+		err = ccs_map_set(map, d1, ccs_true);
+		assert(err == CCS_RESULT_SUCCESS);
+	}
+	free(str1);
+
+	{
+		ccs_datum_t d2 = ccs_string(str2);
+		d2.flags |= CCS_DATUM_FLAG_TRANSIENT;
+		err = ccs_map_set(map, ccs_false, d2);
+		assert(err == CCS_RESULT_SUCCESS);
+	}
+	free(str2);
+
+	err = ccs_map_set(map, ccs_float(3.14), ccs_none);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	test_serialize_deserialize(map, format, (ccs_object_t *)&map2);
+
+	err = ccs_map_get_pairs(map2, 0, NULL, NULL, &d_count);
+	assert(err == CCS_RESULT_SUCCESS);
+	assert(d_count == 5);
+
+	err = ccs_map_get(map2, ccs_string("hello"), &d_ret);
+	assert(err == CCS_RESULT_SUCCESS);
+	assert(!ccs_datum_cmp(d_ret, ccs_float(1.0)));
+
+	err = ccs_map_get(map2, ccs_int(42), &d_ret);
+	assert(err == CCS_RESULT_SUCCESS);
+	assert(!ccs_datum_cmp(d_ret, ccs_string("world")));
+
+	err = ccs_map_get(map2, ccs_string("foo"), &d_ret);
+	assert(err == CCS_RESULT_SUCCESS);
+	assert(!ccs_datum_cmp(d_ret, ccs_true));
+
+	err = ccs_map_get(map2, ccs_false, &d_ret);
+	assert(err == CCS_RESULT_SUCCESS);
+	assert(!ccs_datum_cmp(d_ret, ccs_string("bar")));
+
+	err = ccs_map_get(map2, ccs_float(3.14), &d_ret);
+	assert(err == CCS_RESULT_SUCCESS);
+	assert(!ccs_datum_cmp(d_ret, ccs_none));
+
+	err = ccs_release_object(map2);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_release_object(map);
+	assert(err == CCS_RESULT_SUCCESS);
+}
+
 int
 main(void)
 {
@@ -270,6 +348,9 @@ main(void)
 	test_map_error_paths();
 	ccs_clear_thread_error();
 	test_map_set_duplicate_value();
+	ccs_clear_thread_error();
+	test_map_serialize(CCS_SERIALIZE_FORMAT_BINARY);
+	test_map_serialize(CCS_SERIALIZE_FORMAT_JSON);
 	ccs_clear_thread_error();
 	ccs_fini();
 	return 0;


### PR DESCRIPTION
## Summary

- Implement JSON serialize/deserialize for `map` objects
- Map entries are serialized as an array of `{"key": ..., "value": ...}` datum pairs
- String datums from the cJSON tree are marked transient during deserialization so `ccs_map_set` copies them before the tree is freed (avoids use-after-free)
- Add `test_map_serialize` that exercises round-trip with both binary and JSON formats, covering string, int, float, bool, and none datum types

After this PR, only **tuner** remains for complete JSON serialization coverage.

## Test plan

- [x] All 30 C tests pass
- [x] Tested with all 6 Ubuntu CI matrix configurations: gcc/g++/clang × thread-safe/no-thread-safe
- [x] Builds clean with `--enable-strict` (`-Werror`)
- [x] clang-format-17 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)