### PR TITLE
Add JSON serialization for tuner and handle non-finite floats

### DIFF
--- a/src/cconfigspace_json.h
+++ b/src/cconfigspace_json.h
@@ -1,6 +1,7 @@
 #ifndef _CCONFIGSPACE_JSON_H
 #define _CCONFIGSPACE_JSON_H
 #include "cjson/cJSON.h"
+#include <math.h>
 #include <string.h>
 
 /*============================================================================
@@ -347,6 +348,58 @@ _ccs_json_objective_type_from_string(
 }
 
 /*============================================================================
+ * Float JSON helpers (handles Infinity and NaN)
+ *============================================================================*/
+
+/* Add a float value to a cJSON object, encoding non-finite values as strings
+ * so that Infinity and NaN survive round-trip. */
+static inline ccs_result_t
+_ccs_json_add_float(cJSON *json, const char *key, double value)
+{
+	if (isfinite(value)) {
+		CCS_REFUTE(
+			!cJSON_AddNumberToObject(json, key, value),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	} else if (isinf(value)) {
+		CCS_REFUTE(
+			!cJSON_AddStringToObject(
+				json, key,
+				value > 0 ? "Infinity" : "-Infinity"),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	} else {
+		CCS_REFUTE(
+			!cJSON_AddStringToObject(json, key, "NaN"),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	}
+	return CCS_RESULT_SUCCESS;
+}
+
+/* Read a float value that may be a number or a string ("Infinity", etc.). */
+static inline ccs_result_t
+_ccs_json_get_float(cJSON *item, double *value_ret)
+{
+	if (cJSON_IsNumber(item)) {
+		*value_ret = item->valuedouble;
+	} else if (cJSON_IsString(item)) {
+		if (!strcmp(item->valuestring, "Infinity"))
+			*value_ret = INFINITY;
+		else if (!strcmp(item->valuestring, "-Infinity"))
+			*value_ret = -INFINITY;
+		else if (!strcmp(item->valuestring, "NaN"))
+			*value_ret = NAN;
+		else
+			CCS_RAISE(
+				CCS_RESULT_ERROR_INVALID_VALUE,
+				"Unknown float string: %s", item->valuestring);
+	} else {
+		CCS_RAISE(
+			CCS_RESULT_ERROR_INVALID_VALUE,
+			"Expected number or string for float value");
+	}
+	return CCS_RESULT_SUCCESS;
+}
+
+/*============================================================================
  * ccs_datum_t JSON helpers
  *============================================================================*/
 
@@ -369,14 +422,17 @@ _ccs_json_datum_to_cjson(ccs_datum_t datum, cJSON **item_ret)
 			!cJSON_AddNumberToObject(item, "value", datum.value.i),
 			CCS_RESULT_ERROR_OUT_OF_MEMORY);
 		break;
-	case CCS_DATA_TYPE_FLOAT:
+	case CCS_DATA_TYPE_FLOAT: {
+		ccs_result_t _err;
 		CCS_REFUTE(
 			!cJSON_AddStringToObject(item, "type", "float"),
 			CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		CCS_REFUTE(
-			!cJSON_AddNumberToObject(item, "value", datum.value.f),
-			CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		break;
+		_err = _ccs_json_add_float(item, "value", datum.value.f);
+		if (_err != CCS_RESULT_SUCCESS) {
+			cJSON_Delete(item);
+			return _err;
+		}
+	} break;
 	case CCS_DATA_TYPE_BOOL:
 		CCS_REFUTE(
 			!cJSON_AddStringToObject(item, "type", "bool"),
@@ -460,11 +516,11 @@ _ccs_json_get_datum(cJSON *item, ccs_datum_t *datum_ret)
 			CCS_RESULT_ERROR_INVALID_VALUE);
 		*datum_ret = ccs_int((ccs_int_t)j_value->valuedouble);
 	} else if (!strcmp(j_type->valuestring, "float")) {
+		double fval;
 		j_value = cJSON_GetObjectItemCaseSensitive(item, "value");
-		CCS_REFUTE(
-			!j_value || !cJSON_IsNumber(j_value),
-			CCS_RESULT_ERROR_INVALID_VALUE);
-		*datum_ret = ccs_float(j_value->valuedouble);
+		CCS_REFUTE(!j_value, CCS_RESULT_ERROR_INVALID_VALUE);
+		CCS_VALIDATE(_ccs_json_get_float(j_value, &fval));
+		*datum_ret = ccs_float(fval);
 	} else if (!strcmp(j_type->valuestring, "bool")) {
 		j_value = cJSON_GetObjectItemCaseSensitive(item, "value");
 		CCS_REFUTE(

--- a/src/cconfigspace_json.h
+++ b/src/cconfigspace_json.h
@@ -406,73 +406,76 @@ _ccs_json_get_float(cJSON *item, double *value_ret)
 static inline ccs_result_t
 _ccs_json_datum_to_cjson(ccs_datum_t datum, cJSON **item_ret)
 {
-	cJSON *item = cJSON_CreateObject();
+	ccs_result_t err  = CCS_RESULT_SUCCESS;
+	cJSON       *item = cJSON_CreateObject();
 	CCS_REFUTE(!item, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	switch (datum.type) {
 	case CCS_DATA_TYPE_NONE:
-		CCS_REFUTE(
-			!cJSON_AddStringToObject(item, "type", "none"),
-			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		CCS_REFUTE_ERR_GOTO(
+			err, !cJSON_AddStringToObject(item, "type", "none"),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY, err_item);
 		break;
 	case CCS_DATA_TYPE_INT:
-		CCS_REFUTE(
-			!cJSON_AddStringToObject(item, "type", "int"),
-			CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		CCS_REFUTE(
+		CCS_REFUTE_ERR_GOTO(
+			err, !cJSON_AddStringToObject(item, "type", "int"),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY, err_item);
+		CCS_REFUTE_ERR_GOTO(
+			err,
 			!cJSON_AddNumberToObject(item, "value", datum.value.i),
-			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+			CCS_RESULT_ERROR_OUT_OF_MEMORY, err_item);
 		break;
-	case CCS_DATA_TYPE_FLOAT: {
-		ccs_result_t _err;
-		CCS_REFUTE(
-			!cJSON_AddStringToObject(item, "type", "float"),
-			CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		_err = _ccs_json_add_float(item, "value", datum.value.f);
-		if (_err != CCS_RESULT_SUCCESS) {
-			cJSON_Delete(item);
-			return _err;
-		}
-	} break;
+	case CCS_DATA_TYPE_FLOAT:
+		CCS_REFUTE_ERR_GOTO(
+			err, !cJSON_AddStringToObject(item, "type", "float"),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY, err_item);
+		CCS_VALIDATE_ERR_GOTO(
+			err, _ccs_json_add_float(item, "value", datum.value.f),
+			err_item);
+		break;
 	case CCS_DATA_TYPE_BOOL:
-		CCS_REFUTE(
-			!cJSON_AddStringToObject(item, "type", "bool"),
-			CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		CCS_REFUTE(
+		CCS_REFUTE_ERR_GOTO(
+			err, !cJSON_AddStringToObject(item, "type", "bool"),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY, err_item);
+		CCS_REFUTE_ERR_GOTO(
+			err,
 			!cJSON_AddBoolToObject(item, "value", datum.value.i),
-			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+			CCS_RESULT_ERROR_OUT_OF_MEMORY, err_item);
 		break;
 	case CCS_DATA_TYPE_STRING:
-		CCS_REFUTE(
-			!cJSON_AddStringToObject(item, "type", "string"),
-			CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		CCS_REFUTE(
+		CCS_REFUTE_ERR_GOTO(
+			err, !cJSON_AddStringToObject(item, "type", "string"),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY, err_item);
+		CCS_REFUTE_ERR_GOTO(
+			err,
 			!cJSON_AddStringToObject(item, "value", datum.value.s),
-			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+			CCS_RESULT_ERROR_OUT_OF_MEMORY, err_item);
 		break;
 	case CCS_DATA_TYPE_INACTIVE:
-		CCS_REFUTE(
-			!cJSON_AddStringToObject(item, "type", "inactive"),
-			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		CCS_REFUTE_ERR_GOTO(
+			err, !cJSON_AddStringToObject(item, "type", "inactive"),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY, err_item);
 		break;
 	case CCS_DATA_TYPE_OBJECT: {
 		char hex[sizeof(ccs_object_t) * 2 + 1];
 		_ccs_json_hex_encode_buf(
 			&datum.value.o, sizeof(ccs_object_t), hex);
-		CCS_REFUTE(
-			!cJSON_AddStringToObject(item, "type", "object"),
-			CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		CCS_REFUTE(
-			!cJSON_AddStringToObject(item, "value", hex),
-			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		CCS_REFUTE_ERR_GOTO(
+			err, !cJSON_AddStringToObject(item, "type", "object"),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY, err_item);
+		CCS_REFUTE_ERR_GOTO(
+			err, !cJSON_AddStringToObject(item, "value", hex),
+			CCS_RESULT_ERROR_OUT_OF_MEMORY, err_item);
 	} break;
 	default:
-		cJSON_Delete(item);
-		CCS_RAISE(
-			CCS_RESULT_ERROR_INVALID_VALUE,
+		CCS_RAISE_ERR_GOTO(
+			err, CCS_RESULT_ERROR_INVALID_VALUE, err_item,
 			"Unsupported datum type for JSON: %d", datum.type);
 	}
 	*item_ret = item;
 	return CCS_RESULT_SUCCESS;
+err_item:
+	cJSON_Delete(item);
+	return err;
 }
 
 static inline ccs_result_t

--- a/src/distribution_deserialize.h
+++ b/src/distribution_deserialize.h
@@ -349,15 +349,9 @@ _ccs_deserialize_json_distribution_uniform(
 	CCS_REFUTE(
 		!j_scale_type || !cJSON_IsString(j_scale_type),
 		CCS_RESULT_ERROR_INVALID_VALUE);
-	CCS_REFUTE(
-		!j_lower || !cJSON_IsNumber(j_lower),
-		CCS_RESULT_ERROR_INVALID_VALUE);
-	CCS_REFUTE(
-		!j_upper || !cJSON_IsNumber(j_upper),
-		CCS_RESULT_ERROR_INVALID_VALUE);
-	CCS_REFUTE(
-		!j_quantization || !cJSON_IsNumber(j_quantization),
-		CCS_RESULT_ERROR_INVALID_VALUE);
+	CCS_REFUTE(!j_lower, CCS_RESULT_ERROR_INVALID_VALUE);
+	CCS_REFUTE(!j_upper, CCS_RESULT_ERROR_INVALID_VALUE);
+	CCS_REFUTE(!j_quantization, CCS_RESULT_ERROR_INVALID_VALUE);
 
 	ccs_numeric_type_t data_type;
 	ccs_scale_type_t   scale_type;
@@ -368,10 +362,23 @@ _ccs_deserialize_json_distribution_uniform(
 
 	ccs_numeric_t lower, upper, quantization;
 	if (data_type == CCS_NUMERIC_TYPE_FLOAT) {
-		lower.f        = j_lower->valuedouble;
-		upper.f        = j_upper->valuedouble;
-		quantization.f = j_quantization->valuedouble;
+		double fl, fu, fq;
+		CCS_VALIDATE(_ccs_json_get_float(j_lower, &fl));
+		CCS_VALIDATE(_ccs_json_get_float(j_upper, &fu));
+		CCS_VALIDATE(_ccs_json_get_float(j_quantization, &fq));
+		lower.f        = fl;
+		upper.f        = fu;
+		quantization.f = fq;
 	} else {
+		CCS_REFUTE(
+			!cJSON_IsNumber(j_lower),
+			CCS_RESULT_ERROR_INVALID_VALUE);
+		CCS_REFUTE(
+			!cJSON_IsNumber(j_upper),
+			CCS_RESULT_ERROR_INVALID_VALUE);
+		CCS_REFUTE(
+			!cJSON_IsNumber(j_quantization),
+			CCS_RESULT_ERROR_INVALID_VALUE);
 		lower.i        = (ccs_int_t)j_lower->valuedouble;
 		upper.i        = (ccs_int_t)j_upper->valuedouble;
 		quantization.i = (ccs_int_t)j_quantization->valuedouble;
@@ -402,30 +409,34 @@ _ccs_deserialize_json_distribution_normal(
 	CCS_REFUTE(
 		!j_scale_type || !cJSON_IsString(j_scale_type),
 		CCS_RESULT_ERROR_INVALID_VALUE);
-	CCS_REFUTE(
-		!j_mu || !cJSON_IsNumber(j_mu), CCS_RESULT_ERROR_INVALID_VALUE);
-	CCS_REFUTE(
-		!j_sigma || !cJSON_IsNumber(j_sigma),
-		CCS_RESULT_ERROR_INVALID_VALUE);
-	CCS_REFUTE(
-		!j_quantization || !cJSON_IsNumber(j_quantization),
-		CCS_RESULT_ERROR_INVALID_VALUE);
+	CCS_REFUTE(!j_mu, CCS_RESULT_ERROR_INVALID_VALUE);
+	CCS_REFUTE(!j_sigma, CCS_RESULT_ERROR_INVALID_VALUE);
+	CCS_REFUTE(!j_quantization, CCS_RESULT_ERROR_INVALID_VALUE);
 
 	ccs_numeric_type_t data_type;
 	ccs_scale_type_t   scale_type;
+	double             mu_val, sigma_val;
 	CCS_VALIDATE(_ccs_json_numeric_type_from_string(
 		j_data_type->valuestring, &data_type));
 	CCS_VALIDATE(_ccs_json_scale_type_from_string(
 		j_scale_type->valuestring, &scale_type));
+	CCS_VALIDATE(_ccs_json_get_float(j_mu, &mu_val));
+	CCS_VALIDATE(_ccs_json_get_float(j_sigma, &sigma_val));
 
 	ccs_numeric_t quantization;
-	if (data_type == CCS_NUMERIC_TYPE_FLOAT)
-		quantization.f = j_quantization->valuedouble;
-	else
+	if (data_type == CCS_NUMERIC_TYPE_FLOAT) {
+		double fq;
+		CCS_VALIDATE(_ccs_json_get_float(j_quantization, &fq));
+		quantization.f = fq;
+	} else {
+		CCS_REFUTE(
+			!cJSON_IsNumber(j_quantization),
+			CCS_RESULT_ERROR_INVALID_VALUE);
 		quantization.i = (ccs_int_t)j_quantization->valuedouble;
+	}
 	CCS_VALIDATE(ccs_create_normal_distribution(
-		data_type, j_mu->valuedouble, j_sigma->valuedouble, scale_type,
-		quantization, distribution_ret));
+		data_type, mu_val, sigma_val, scale_type, quantization,
+		distribution_ret));
 	return CCS_RESULT_SUCCESS;
 }
 

--- a/src/distribution_normal.c
+++ b/src/distribution_normal.c
@@ -108,17 +108,11 @@ _ccs_serialize_json_ccs_distribution_normal(
 			json, "scale_type",
 			_ccs_json_scale_type_to_string(data->scale_type)),
 		CCS_RESULT_ERROR_OUT_OF_MEMORY);
-	CCS_REFUTE(
-		!cJSON_AddNumberToObject(json, "mu", data->mu),
-		CCS_RESULT_ERROR_OUT_OF_MEMORY);
-	CCS_REFUTE(
-		!cJSON_AddNumberToObject(json, "sigma", data->sigma),
-		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	CCS_VALIDATE(_ccs_json_add_float(json, "mu", data->mu));
+	CCS_VALIDATE(_ccs_json_add_float(json, "sigma", data->sigma));
 	if (data->common_data.data_types[0] == CCS_NUMERIC_TYPE_FLOAT) {
-		CCS_REFUTE(
-			!cJSON_AddNumberToObject(
-				json, "quantization", data->quantization.f),
-			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		CCS_VALIDATE(_ccs_json_add_float(
+			json, "quantization", data->quantization.f));
 	} else {
 		CCS_REFUTE(
 			!cJSON_AddNumberToObject(

--- a/src/distribution_uniform.c
+++ b/src/distribution_uniform.c
@@ -120,16 +120,10 @@ _ccs_serialize_json_ccs_distribution_uniform(
 			_ccs_json_scale_type_to_string(data->scale_type)),
 		CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	if (data->common_data.data_types[0] == CCS_NUMERIC_TYPE_FLOAT) {
-		CCS_REFUTE(
-			!cJSON_AddNumberToObject(json, "lower", data->lower.f),
-			CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		CCS_REFUTE(
-			!cJSON_AddNumberToObject(json, "upper", data->upper.f),
-			CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		CCS_REFUTE(
-			!cJSON_AddNumberToObject(
-				json, "quantization", data->quantization.f),
-			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		CCS_VALIDATE(_ccs_json_add_float(json, "lower", data->lower.f));
+		CCS_VALIDATE(_ccs_json_add_float(json, "upper", data->upper.f));
+		CCS_VALIDATE(_ccs_json_add_float(
+			json, "quantization", data->quantization.f));
 	} else {
 		CCS_REFUTE(
 			!cJSON_AddNumberToObject(json, "lower", data->lower.i),

--- a/src/parameter_deserialize.h
+++ b/src/parameter_deserialize.h
@@ -187,15 +187,9 @@ _ccs_deserialize_json_parameter_numerical(
 	CCS_REFUTE(
 		!j_name || !cJSON_IsString(j_name),
 		CCS_RESULT_ERROR_INVALID_VALUE);
-	CCS_REFUTE(
-		!j_lower || !cJSON_IsNumber(j_lower),
-		CCS_RESULT_ERROR_INVALID_VALUE);
-	CCS_REFUTE(
-		!j_upper || !cJSON_IsNumber(j_upper),
-		CCS_RESULT_ERROR_INVALID_VALUE);
-	CCS_REFUTE(
-		!j_quantization || !cJSON_IsNumber(j_quantization),
-		CCS_RESULT_ERROR_INVALID_VALUE);
+	CCS_REFUTE(!j_lower, CCS_RESULT_ERROR_INVALID_VALUE);
+	CCS_REFUTE(!j_upper, CCS_RESULT_ERROR_INVALID_VALUE);
+	CCS_REFUTE(!j_quantization, CCS_RESULT_ERROR_INVALID_VALUE);
 	CCS_REFUTE(!j_default_value, CCS_RESULT_ERROR_INVALID_VALUE);
 
 	ccs_numeric_type_t data_type;
@@ -206,11 +200,24 @@ _ccs_deserialize_json_parameter_numerical(
 
 	ccs_numeric_t lower, upper, quantization, default_value;
 	if (data_type == CCS_NUMERIC_TYPE_FLOAT) {
-		lower.f         = j_lower->valuedouble;
-		upper.f         = j_upper->valuedouble;
-		quantization.f  = j_quantization->valuedouble;
+		double fl, fu, fq;
+		CCS_VALIDATE(_ccs_json_get_float(j_lower, &fl));
+		CCS_VALIDATE(_ccs_json_get_float(j_upper, &fu));
+		CCS_VALIDATE(_ccs_json_get_float(j_quantization, &fq));
+		lower.f         = fl;
+		upper.f         = fu;
+		quantization.f  = fq;
 		default_value.f = default_datum.value.f;
 	} else {
+		CCS_REFUTE(
+			!cJSON_IsNumber(j_lower),
+			CCS_RESULT_ERROR_INVALID_VALUE);
+		CCS_REFUTE(
+			!cJSON_IsNumber(j_upper),
+			CCS_RESULT_ERROR_INVALID_VALUE);
+		CCS_REFUTE(
+			!cJSON_IsNumber(j_quantization),
+			CCS_RESULT_ERROR_INVALID_VALUE);
 		lower.i         = (ccs_int_t)j_lower->valuedouble;
 		upper.i         = (ccs_int_t)j_upper->valuedouble;
 		quantization.i  = (ccs_int_t)j_quantization->valuedouble;

--- a/src/parameter_numerical.c
+++ b/src/parameter_numerical.c
@@ -54,20 +54,12 @@ _ccs_serialize_json_ccs_parameter_numerical(
 				data->common_data.interval.type)),
 		CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	if (data->common_data.interval.type == CCS_NUMERIC_TYPE_FLOAT) {
-		CCS_REFUTE(
-			!cJSON_AddNumberToObject(
-				json, "lower",
-				data->common_data.interval.lower.f),
-			CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		CCS_REFUTE(
-			!cJSON_AddNumberToObject(
-				json, "upper",
-				data->common_data.interval.upper.f),
-			CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		CCS_REFUTE(
-			!cJSON_AddNumberToObject(
-				json, "quantization", data->quantization.f),
-			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		CCS_VALIDATE(_ccs_json_add_float(
+			json, "lower", data->common_data.interval.lower.f));
+		CCS_VALIDATE(_ccs_json_add_float(
+			json, "upper", data->common_data.interval.upper.f));
+		CCS_VALIDATE(_ccs_json_add_float(
+			json, "quantization", data->quantization.f));
 	} else {
 		CCS_REFUTE(
 			!cJSON_AddNumberToObject(

--- a/src/tuner_deserialize.h
+++ b/src/tuner_deserialize.h
@@ -1,6 +1,7 @@
 #ifndef _TUNER_DESERIALIZE_H
 #define _TUNER_DESERIALIZE_H
 #include "tuner_internal.h"
+#include "cconfigspace_json.h"
 
 struct _ccs_random_tuner_data_mock_s {
 	_ccs_tuner_common_data_t common_data;
@@ -221,6 +222,273 @@ end:
 }
 
 static inline ccs_result_t
+_ccs_deserialize_json_ccs_random_tuner_data(
+	_ccs_random_tuner_data_mock_t     *data,
+	uint32_t                           version,
+	cJSON                             *json,
+	_ccs_object_deserialize_options_t *opts)
+{
+	cJSON      *j_name;
+	cJSON      *j_os;
+	cJSON      *j_history;
+	cJSON      *j_optima;
+	const char *cbuf;
+	size_t      dummy;
+
+	j_name = cJSON_GetObjectItemCaseSensitive(json, "name");
+	CCS_REFUTE(
+		!j_name || !cJSON_IsString(j_name),
+		CCS_RESULT_ERROR_INVALID_VALUE);
+	data->common_data.name = j_name->valuestring;
+
+	/* objective_space (inlined) */
+	j_os = cJSON_GetObjectItemCaseSensitive(json, "objective_space");
+	CCS_REFUTE(
+		!j_os || !cJSON_IsObject(j_os), CCS_RESULT_ERROR_INVALID_VALUE);
+	cbuf  = (const char *)j_os;
+	dummy = 0;
+	CCS_VALIDATE(_ccs_object_deserialize_with_opts_check(
+		(ccs_object_t *)&data->common_data.objective_space,
+		CCS_OBJECT_TYPE_OBJECTIVE_SPACE, CCS_SERIALIZE_FORMAT_JSON,
+		version, &dummy, &cbuf, opts));
+
+	/* history */
+	j_history = cJSON_GetObjectItemCaseSensitive(json, "history");
+	CCS_REFUTE(
+		!j_history || !cJSON_IsArray(j_history),
+		CCS_RESULT_ERROR_INVALID_VALUE);
+	data->history_size = (size_t)cJSON_GetArraySize(j_history);
+
+	/* optima */
+	j_optima           = cJSON_GetObjectItemCaseSensitive(json, "optima");
+	CCS_REFUTE(
+		!j_optima || !cJSON_IsArray(j_optima),
+		CCS_RESULT_ERROR_INVALID_VALUE);
+	data->size_optima = (size_t)cJSON_GetArraySize(j_optima);
+
+	if (!(data->history_size + data->size_optima))
+		return CCS_RESULT_SUCCESS;
+	data->history = (ccs_evaluation_t *)calloc(
+		data->history_size + data->size_optima,
+		sizeof(ccs_evaluation_t));
+	CCS_REFUTE(!data->history, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	data->optima = data->history + data->history_size;
+
+	for (size_t i = 0; i < data->history_size; i++) {
+		cJSON *child = cJSON_GetArrayItem(j_history, (int)i);
+		cbuf         = (const char *)child;
+		dummy        = 0;
+		CCS_VALIDATE(_ccs_object_deserialize_with_opts_check(
+			(ccs_object_t *)data->history + i,
+			CCS_OBJECT_TYPE_EVALUATION, CCS_SERIALIZE_FORMAT_JSON,
+			version, &dummy, &cbuf, opts));
+	}
+
+	for (size_t i = 0; i < data->size_optima; i++) {
+		cJSON *child = cJSON_GetArrayItem(j_optima, (int)i);
+		CCS_REFUTE(
+			!child || !cJSON_IsString(child),
+			CCS_RESULT_ERROR_INVALID_VALUE);
+		CCS_REFUTE(
+			strlen(child->valuestring) != sizeof(ccs_object_t) * 2,
+			CCS_RESULT_ERROR_INVALID_VALUE);
+		CCS_REFUTE(
+			_ccs_json_hex_decode_buf(
+				child->valuestring, sizeof(ccs_object_t) * 2,
+				data->optima + i),
+			CCS_RESULT_ERROR_INVALID_VALUE);
+	}
+	for (size_t i = 0; i < data->size_optima; i++) {
+		ccs_datum_t d;
+		CCS_VALIDATE(ccs_map_get(
+			opts->handle_map, ccs_object(data->optima[i]), &d));
+		CCS_REFUTE(
+			d.type != CCS_DATA_TYPE_OBJECT,
+			CCS_RESULT_ERROR_INVALID_HANDLE);
+		data->optima[i] = (ccs_evaluation_t)(d.value.o);
+	}
+	return CCS_RESULT_SUCCESS;
+}
+
+static inline ccs_result_t
+_ccs_deserialize_json_random_tuner(
+	ccs_tuner_t                       *tuner_ret,
+	uint32_t                           version,
+	size_t                            *buffer_size,
+	const char                       **buffer,
+	_ccs_object_deserialize_options_t *opts)
+{
+	(void)buffer_size;
+	_ccs_random_tuner_data_mock_t data = {
+		{(ccs_tuner_type_t)0, NULL, NULL, NULL, NULL}, 0, 0, NULL, NULL};
+	ccs_result_t res = CCS_RESULT_SUCCESS;
+	CCS_VALIDATE_ERR_GOTO(
+		res,
+		_ccs_deserialize_json_ccs_random_tuner_data(
+			&data, version, *(cJSON **)buffer, opts),
+		evaluations);
+	CCS_VALIDATE_ERR_GOTO(
+		res,
+		ccs_create_random_tuner(
+			data.common_data.name, data.common_data.objective_space,
+			tuner_ret),
+		evaluations);
+	CCS_VALIDATE_ERR_GOTO(
+		res,
+		ccs_tuner_tell(*tuner_ret, data.history_size, data.history),
+		tuner);
+	goto evaluations;
+tuner:
+	ccs_release_object(*tuner_ret);
+	*tuner_ret = NULL;
+evaluations:
+	if (data.history)
+		for (size_t i = 0; i < data.history_size; i++)
+			if (data.history[i])
+				ccs_release_object(data.history[i]);
+	if (data.common_data.objective_space)
+		ccs_release_object(data.common_data.objective_space);
+	if (data.history)
+		free(data.history);
+	return res;
+}
+
+static inline ccs_result_t
+_ccs_deserialize_json_user_defined_tuner(
+	ccs_tuner_t                       *tuner_ret,
+	uint32_t                           version,
+	size_t                            *buffer_size,
+	const char                       **buffer,
+	_ccs_object_deserialize_options_t *opts)
+{
+	(void)buffer_size;
+	_ccs_random_tuner_data_mock_t data = {
+		{(ccs_tuner_type_t)0, NULL, NULL, NULL, NULL}, 0, 0, NULL, NULL};
+	_ccs_blob_t                      blob       = {0, NULL};
+	ccs_user_defined_tuner_vector_t *vector     = NULL;
+	void                            *tuner_data = NULL;
+	ccs_result_t                     res        = CCS_RESULT_SUCCESS;
+
+	CCS_VALIDATE_ERR_GOTO(
+		res,
+		_ccs_deserialize_json_ccs_random_tuner_data(
+			&data, version, *(cJSON **)buffer, opts),
+		end);
+
+	/* user state */
+	{
+		cJSON *j_state = cJSON_GetObjectItemCaseSensitive(
+			*(cJSON **)buffer, "user_state");
+		if (j_state && cJSON_IsString(j_state)) {
+			size_t slen = strlen(j_state->valuestring);
+			if (slen) {
+				blob.sz                = slen / 2;
+				unsigned char *decoded = _ccs_json_hex_decode(
+					j_state->valuestring, &blob.sz);
+				CCS_REFUTE_ERR_GOTO(
+					res, !decoded,
+					CCS_RESULT_ERROR_INVALID_VALUE, end);
+				blob.blob = decoded;
+			}
+		}
+	}
+
+	CCS_VALIDATE_ERR_GOTO(
+		res,
+		opts->deserialize_vector_callback(
+			CCS_OBJECT_TYPE_TUNER, data.common_data.name,
+			opts->deserialize_vector_user_data, (void **)&vector,
+			&tuner_data),
+		end);
+
+	if (vector->deserialize_state)
+		CCS_VALIDATE_ERR_GOTO(
+			res,
+			vector->deserialize_state(
+				data.common_data.objective_space,
+				data.history_size, data.history,
+				data.size_optima, data.optima, blob.sz,
+				blob.blob, &tuner_data),
+			end);
+
+	CCS_VALIDATE_ERR_GOTO(
+		res,
+		ccs_create_user_defined_tuner(
+			data.common_data.name, data.common_data.objective_space,
+			vector, tuner_data, tuner_ret),
+		end);
+	if (!vector->deserialize_state)
+		CCS_VALIDATE_ERR_GOTO(
+			res,
+			vector->tell(
+				*tuner_ret, data.history_size, data.history),
+			tuner);
+	goto end;
+tuner:
+	ccs_release_object(*tuner_ret);
+	*tuner_ret = NULL;
+end:
+	if (blob.blob)
+		free((void *)blob.blob);
+	if (data.common_data.objective_space)
+		ccs_release_object(data.common_data.objective_space);
+	if (data.history) {
+		for (size_t i = 0; i < data.history_size; i++)
+			if (data.history[i])
+				ccs_release_object(data.history[i]);
+		free(data.history);
+	}
+	return res;
+}
+
+static inline ccs_result_t
+_ccs_deserialize_json_tuner(
+	ccs_tuner_t                       *tuner_ret,
+	uint32_t                           version,
+	size_t                            *buffer_size,
+	const char                       **buffer,
+	_ccs_object_deserialize_options_t *opts)
+{
+	_ccs_object_deserialize_options_t new_opts = *opts;
+	ccs_result_t                      res      = CCS_RESULT_SUCCESS;
+	cJSON                            *json     = *(cJSON **)buffer;
+
+	cJSON *j_ttype = cJSON_GetObjectItemCaseSensitive(json, "tuner_type");
+	CCS_REFUTE(
+		!j_ttype || !cJSON_IsString(j_ttype),
+		CCS_RESULT_ERROR_INVALID_VALUE);
+
+	if (!strcmp(j_ttype->valuestring, "user_defined"))
+		CCS_CHECK_PTR(opts->deserialize_vector_callback);
+
+	new_opts.map_values = CCS_TRUE;
+	CCS_VALIDATE(ccs_create_map(&new_opts.handle_map));
+
+	if (!strcmp(j_ttype->valuestring, "random"))
+		CCS_VALIDATE_ERR_GOTO(
+			res,
+			_ccs_deserialize_json_random_tuner(
+				tuner_ret, version, buffer_size, buffer,
+				&new_opts),
+			end);
+	else if (!strcmp(j_ttype->valuestring, "user_defined"))
+		CCS_VALIDATE_ERR_GOTO(
+			res,
+			_ccs_deserialize_json_user_defined_tuner(
+				tuner_ret, version, buffer_size, buffer,
+				&new_opts),
+			end);
+	else
+		CCS_RAISE_ERR_GOTO(
+			res, CCS_RESULT_ERROR_INVALID_TYPE, end,
+			"Unsupported tuner type: %s", j_ttype->valuestring);
+
+end:
+	ccs_release_object(new_opts.handle_map);
+	return res;
+}
+
+static inline ccs_result_t
 _ccs_deserialize_bin_tuner(
 	ccs_tuner_t                       *tuner_ret,
 	uint32_t                           version,
@@ -279,6 +547,10 @@ _ccs_tuner_deserialize(
 	switch (format) {
 	case CCS_SERIALIZE_FORMAT_BINARY:
 		CCS_VALIDATE(_ccs_deserialize_bin_tuner(
+			tuner_ret, version, buffer_size, buffer, opts));
+		break;
+	case CCS_SERIALIZE_FORMAT_JSON:
+		CCS_VALIDATE(_ccs_deserialize_json_tuner(
 			tuner_ret, version, buffer_size, buffer, opts));
 		break;
 	default:

--- a/src/tuner_random.c
+++ b/src/tuner_random.c
@@ -1,4 +1,5 @@
 #include "cconfigspace_internal.h"
+#include "cconfigspace_json.h"
 #include "tuner_internal.h"
 #include "evaluation_internal.h"
 #include "search_space_internal.h"
@@ -150,6 +151,81 @@ _ccs_serialize_bin_ccs_random_tuner(
 	return CCS_RESULT_SUCCESS;
 }
 
+static inline ccs_result_t
+_ccs_serialize_json_ccs_random_tuner(
+	ccs_tuner_t                      tuner,
+	cJSON                           *json,
+	_ccs_object_serialize_options_t *opts)
+{
+	_ccs_random_tuner_data_t *data =
+		(_ccs_random_tuner_data_t *)(tuner->data);
+	_ccs_hash_features_t *cur, *tmp;
+	size_t                dummy = 0;
+
+	/* tuner type + name */
+	CCS_REFUTE(
+		!cJSON_AddStringToObject(json, "tuner_type", "random"),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	CCS_REFUTE(
+		!cJSON_AddStringToObject(json, "name", data->common_data.name),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+
+	/* objective_space (inlined) */
+	{
+		cJSON *os = cJSON_AddObjectToObject(json, "objective_space");
+		CCS_REFUTE(!os, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		CCS_VALIDATE(_ccs_object_serialize_with_opts(
+			data->common_data.objective_space,
+			CCS_SERIALIZE_FORMAT_JSON, &dummy, (char **)&os, opts));
+	}
+
+	/* history (inlined evaluations) */
+	{
+		cJSON *history = cJSON_AddArrayToObject(json, "history");
+		CCS_REFUTE(!history, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		HASH_ITER(hh, data->features_hash, cur, tmp)
+		{
+			ccs_evaluation_t *e = NULL;
+			while ((e = (ccs_evaluation_t *)utarray_next(
+					cur->history, e))) {
+				cJSON *eval_obj = cJSON_CreateObject();
+				CCS_REFUTE(
+					!eval_obj,
+					CCS_RESULT_ERROR_OUT_OF_MEMORY);
+				CCS_REFUTE(
+					!cJSON_AddItemToArray(history, eval_obj),
+					CCS_RESULT_ERROR_OUT_OF_MEMORY);
+				CCS_VALIDATE(_ccs_object_serialize_with_opts(
+					*e, CCS_SERIALIZE_FORMAT_JSON, &dummy,
+					(char **)&eval_obj, opts));
+			}
+		}
+	}
+
+	/* optima (handles referencing history evaluations) */
+	{
+		cJSON *optima = cJSON_AddArrayToObject(json, "optima");
+		CCS_REFUTE(!optima, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		HASH_ITER(hh, data->features_hash, cur, tmp)
+		{
+			ccs_evaluation_t *e = NULL;
+			while ((e = (ccs_evaluation_t *)utarray_next(
+					cur->optima, e))) {
+				char hex[sizeof(ccs_object_t) * 2 + 1];
+				_ccs_json_hex_encode_buf(
+					e, sizeof(ccs_object_t), hex);
+				cJSON *h = cJSON_CreateString(hex);
+				CCS_REFUTE(!h, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+				CCS_REFUTE(
+					!cJSON_AddItemToArray(optima, h),
+					CCS_RESULT_ERROR_OUT_OF_MEMORY);
+			}
+		}
+	}
+
+	return CCS_RESULT_SUCCESS;
+}
+
 static ccs_result_t
 _ccs_tuner_random_serialize_size(
 	ccs_object_t                     object,
@@ -182,6 +258,10 @@ _ccs_tuner_random_serialize(
 	case CCS_SERIALIZE_FORMAT_BINARY:
 		CCS_VALIDATE(_ccs_serialize_bin_ccs_random_tuner(
 			(ccs_tuner_t)object, buffer_size, buffer, opts));
+		break;
+	case CCS_SERIALIZE_FORMAT_JSON:
+		CCS_VALIDATE(_ccs_serialize_json_ccs_random_tuner(
+			(ccs_tuner_t)object, *(cJSON **)buffer, opts));
 		break;
 	default:
 		CCS_RAISE(

--- a/src/tuner_user_defined.c
+++ b/src/tuner_user_defined.c
@@ -1,4 +1,5 @@
 #include "cconfigspace_internal.h"
+#include "cconfigspace_json.h"
 #include "tuner_internal.h"
 #include "evaluation_internal.h"
 #include "search_space_internal.h"
@@ -179,6 +180,140 @@ end:
 	return res;
 }
 
+static inline ccs_result_t
+_ccs_serialize_json_ccs_user_defined_tuner(
+	ccs_tuner_t                      tuner,
+	cJSON                           *json,
+	_ccs_object_serialize_options_t *opts)
+{
+	ccs_result_t                    res = CCS_RESULT_SUCCESS;
+	_ccs_user_defined_tuner_data_t *data =
+		(_ccs_user_defined_tuner_data_t *)(tuner->data);
+	size_t            history_size = 0;
+	size_t            num_optima   = 0;
+	size_t            state_size   = 0;
+	size_t            dummy        = 0;
+	ccs_evaluation_t *history      = NULL;
+	ccs_evaluation_t *optima       = NULL;
+
+	/* tuner type + name */
+	CCS_REFUTE(
+		!cJSON_AddStringToObject(json, "tuner_type", "user_defined"),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	CCS_REFUTE(
+		!cJSON_AddStringToObject(json, "name", data->common_data.name),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+
+	/* objective_space (inlined) */
+	{
+		cJSON *os = cJSON_AddObjectToObject(json, "objective_space");
+		CCS_REFUTE(!os, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		CCS_VALIDATE(_ccs_object_serialize_with_opts(
+			data->common_data.objective_space,
+			CCS_SERIALIZE_FORMAT_JSON, &dummy, (char **)&os, opts));
+	}
+
+	CCS_VALIDATE(
+		data->vector.get_history(tuner, NULL, 0, NULL, &history_size));
+	CCS_VALIDATE(
+		data->vector.get_optima(tuner, NULL, 0, NULL, &num_optima));
+	if (0 != history_size + num_optima) {
+		history = (ccs_evaluation_t *)calloc(
+			history_size + num_optima, sizeof(ccs_evaluation_t));
+		CCS_REFUTE(!history, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		optima = history + history_size;
+		if (history_size)
+			CCS_VALIDATE_ERR_GOTO(
+				res,
+				data->vector.get_history(
+					tuner, NULL, history_size, history,
+					NULL),
+				end);
+		if (num_optima)
+			CCS_VALIDATE_ERR_GOTO(
+				res,
+				data->vector.get_optima(
+					tuner, NULL, num_optima, optima, NULL),
+				end);
+	}
+
+	/* history (inlined evaluations) */
+	{
+		cJSON *j_history = cJSON_AddArrayToObject(json, "history");
+		CCS_REFUTE_ERR_GOTO(
+			res, !j_history, CCS_RESULT_ERROR_OUT_OF_MEMORY, end);
+		for (size_t i = 0; i < history_size; i++) {
+			cJSON *eval_obj = cJSON_CreateObject();
+			CCS_REFUTE_ERR_GOTO(
+				res, !eval_obj, CCS_RESULT_ERROR_OUT_OF_MEMORY,
+				end);
+			CCS_REFUTE_ERR_GOTO(
+				res, !cJSON_AddItemToArray(j_history, eval_obj),
+				CCS_RESULT_ERROR_OUT_OF_MEMORY, end);
+			CCS_VALIDATE_ERR_GOTO(
+				res,
+				_ccs_object_serialize_with_opts(
+					history[i], CCS_SERIALIZE_FORMAT_JSON,
+					&dummy, (char **)&eval_obj, opts),
+				end);
+		}
+	}
+
+	/* optima (handles) */
+	{
+		cJSON *j_optima = cJSON_AddArrayToObject(json, "optima");
+		CCS_REFUTE_ERR_GOTO(
+			res, !j_optima, CCS_RESULT_ERROR_OUT_OF_MEMORY, end);
+		for (size_t i = 0; i < num_optima; i++) {
+			char hex[sizeof(ccs_object_t) * 2 + 1];
+			_ccs_json_hex_encode_buf(
+				&optima[i], sizeof(ccs_object_t), hex);
+			cJSON *h = cJSON_CreateString(hex);
+			CCS_REFUTE_ERR_GOTO(
+				res, !h, CCS_RESULT_ERROR_OUT_OF_MEMORY, end);
+			CCS_REFUTE_ERR_GOTO(
+				res, !cJSON_AddItemToArray(j_optima, h),
+				CCS_RESULT_ERROR_OUT_OF_MEMORY, end);
+		}
+	}
+
+	/* user state */
+	if (data->vector.serialize_user_state) {
+		CCS_VALIDATE_ERR_GOTO(
+			res,
+			data->vector.serialize_user_state(
+				tuner, 0, NULL, &state_size),
+			end);
+		if (state_size) {
+			char *state_buf = (char *)malloc(state_size);
+			CCS_REFUTE_ERR_GOTO(
+				res, !state_buf, CCS_RESULT_ERROR_OUT_OF_MEMORY,
+				end);
+			ccs_result_t err = data->vector.serialize_user_state(
+				tuner, state_size, state_buf, NULL);
+			if (err != CCS_RESULT_SUCCESS) {
+				free(state_buf);
+				res = err;
+				goto end;
+			}
+			char *hex = _ccs_json_hex_encode(state_buf, state_size);
+			free(state_buf);
+			CCS_REFUTE_ERR_GOTO(
+				res, !hex, CCS_RESULT_ERROR_OUT_OF_MEMORY, end);
+			cJSON *j = cJSON_AddStringToObject(
+				json, "user_state", hex);
+			free(hex);
+			CCS_REFUTE_ERR_GOTO(
+				res, !j, CCS_RESULT_ERROR_OUT_OF_MEMORY, end);
+		}
+	}
+
+end:
+	if (history)
+		free(history);
+	return res;
+}
+
 static ccs_result_t
 _ccs_tuner_user_defined_serialize_size(
 	ccs_object_t                     object,
@@ -211,6 +346,10 @@ _ccs_tuner_user_defined_serialize(
 	case CCS_SERIALIZE_FORMAT_BINARY:
 		CCS_VALIDATE(_ccs_serialize_bin_ccs_user_defined_tuner(
 			(ccs_tuner_t)object, buffer_size, buffer, opts));
+		break;
+	case CCS_SERIALIZE_FORMAT_JSON:
+		CCS_VALIDATE(_ccs_serialize_json_ccs_user_defined_tuner(
+			(ccs_tuner_t)object, *(cJSON **)buffer, opts));
 		break;
 	default:
 		CCS_RAISE(

--- a/tests/test_random_tuner.c
+++ b/tests/test_random_tuner.c
@@ -11,6 +11,7 @@ test(ccs_serialize_format_t format)
 	ccs_objective_space_t     ospace;
 	ccs_tuner_t               tuner, tuner_copy;
 	ccs_result_t              err;
+	ccs_datum_t               d;
 	char                     *buff;
 	size_t                    buff_size;
 	ccs_map_t                 map;
@@ -96,6 +97,11 @@ test(ccs_serialize_format_t format)
 	err = ccs_tuner_get_optima(tuner_copy, NULL, 1, &evaluation, &count);
 	assert(err == CCS_RESULT_SUCCESS);
 	assert(count == 1);
+
+	err = ccs_map_get(map, ccs_object((ccs_object_t)tuner), &d);
+	assert(err == CCS_RESULT_SUCCESS);
+	assert(d.type == CCS_DATA_TYPE_OBJECT);
+	assert(d.value.o == (ccs_object_t)tuner_copy);
 
 	free(buff);
 	err = ccs_release_object(map);

--- a/tests/test_random_tuner.c
+++ b/tests/test_random_tuner.c
@@ -5,21 +5,36 @@
 #include "test_utils.h"
 
 void
-test(void)
+test(ccs_serialize_format_t format)
 {
 	ccs_configuration_space_t cspace;
 	ccs_objective_space_t     ospace;
 	ccs_tuner_t               tuner, tuner_copy;
 	ccs_result_t              err;
-	ccs_datum_t               d;
 	char                     *buff;
 	size_t                    buff_size;
 	ccs_map_t                 map;
 
 	cspace = create_2d_plane(NULL);
-	ospace = create_height_objective(cspace);
+	if (format == CCS_SERIALIZE_FORMAT_JSON) {
+		/* JSON cannot represent Infinity — use finite bounds */
+		ccs_parameter_t      zparam;
+		ccs_expression_t     zexpr;
+		ccs_objective_type_t otype = CCS_OBJECTIVE_TYPE_MINIMIZE;
+		zparam                     = create_numerical("z", -1e6, 1e6);
+		err = ccs_create_variable(zparam, &zexpr);
+		assert(err == CCS_RESULT_SUCCESS);
+		err = ccs_create_objective_space(
+			"height", (ccs_search_space_t)cspace, 1, &zparam, 1,
+			&zexpr, &otype, &ospace);
+		assert(err == CCS_RESULT_SUCCESS);
+		ccs_release_object(zexpr);
+		ccs_release_object(zparam);
+	} else {
+		ospace = create_height_objective(cspace);
+	}
 
-	err    = ccs_create_random_tuner("problem", ospace, &tuner);
+	err = ccs_create_random_tuner("problem", ospace, &tuner);
 	assert(err == CCS_RESULT_SUCCESS);
 
 	for (size_t i = 0; i < 100; i++) {
@@ -72,21 +87,19 @@ test(void)
 	err = ccs_create_map(&map);
 	assert(err == CCS_RESULT_SUCCESS);
 	err = ccs_object_serialize(
-		tuner, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
+		tuner, format, CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
 		CCS_SERIALIZE_OPTION_END);
 	assert(err == CCS_RESULT_SUCCESS);
 	buff = (char *)malloc(buff_size);
 	assert(buff);
 
 	err = ccs_object_serialize(
-		tuner, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_MEMORY, buff_size, buff,
+		tuner, format, CCS_SERIALIZE_OPERATION_MEMORY, buff_size, buff,
 		CCS_SERIALIZE_OPTION_END);
 	assert(err == CCS_RESULT_SUCCESS);
 
 	err = ccs_object_deserialize(
-		(ccs_object_t *)&tuner_copy, CCS_SERIALIZE_FORMAT_BINARY,
+		(ccs_object_t *)&tuner_copy, format,
 		CCS_DESERIALIZE_OPERATION_MEMORY, buff_size, buff,
 		CCS_DESERIALIZE_OPTION_HANDLE_MAP, map,
 		CCS_DESERIALIZE_OPTION_MAP_HANDLES, CCS_DESERIALIZE_OPTION_END);
@@ -99,11 +112,6 @@ test(void)
 	err = ccs_tuner_get_optima(tuner_copy, NULL, 1, &evaluation, &count);
 	assert(err == CCS_RESULT_SUCCESS);
 	assert(count == 1);
-
-	err = ccs_map_get(map, ccs_object((ccs_object_t)tuner), &d);
-	assert(err == CCS_RESULT_SUCCESS);
-	assert(d.type == CCS_DATA_TYPE_OBJECT);
-	assert(d.value.o == (ccs_object_t)tuner_copy);
 
 	free(buff);
 	err = ccs_release_object(map);
@@ -348,7 +356,8 @@ int
 main(void)
 {
 	ccs_init();
-	test();
+	test(CCS_SERIALIZE_FORMAT_BINARY);
+	test(CCS_SERIALIZE_FORMAT_JSON);
 	test_objective_space_deserialize();
 	test_evaluation_deserialize();
 	test_evaluation_hash_cmp_compare();

--- a/tests/test_random_tuner.c
+++ b/tests/test_random_tuner.c
@@ -16,25 +16,9 @@ test(ccs_serialize_format_t format)
 	ccs_map_t                 map;
 
 	cspace = create_2d_plane(NULL);
-	if (format == CCS_SERIALIZE_FORMAT_JSON) {
-		/* JSON cannot represent Infinity — use finite bounds */
-		ccs_parameter_t      zparam;
-		ccs_expression_t     zexpr;
-		ccs_objective_type_t otype = CCS_OBJECTIVE_TYPE_MINIMIZE;
-		zparam                     = create_numerical("z", -1e6, 1e6);
-		err = ccs_create_variable(zparam, &zexpr);
-		assert(err == CCS_RESULT_SUCCESS);
-		err = ccs_create_objective_space(
-			"height", (ccs_search_space_t)cspace, 1, &zparam, 1,
-			&zexpr, &otype, &ospace);
-		assert(err == CCS_RESULT_SUCCESS);
-		ccs_release_object(zexpr);
-		ccs_release_object(zparam);
-	} else {
-		ospace = create_height_objective(cspace);
-	}
+	ospace = create_height_objective(cspace);
 
-	err = ccs_create_random_tuner("problem", ospace, &tuner);
+	err    = ccs_create_random_tuner("problem", ospace, &tuner);
 	assert(err == CCS_RESULT_SUCCESS);
 
 	for (size_t i = 0; i < 100; i++) {


### PR DESCRIPTION
## Summary

**Non-finite float handling (commit 1):**
- Add `_ccs_json_add_float` / `_ccs_json_get_float` helpers that serialize `Infinity`, `-Infinity`, and `NaN` as strings since cJSON cannot represent non-finite IEEE 754 values
- Update parameter numerical, uniform distribution, and normal distribution JSON serializers/deserializers to use these helpers
- This removes all previous workarounds for infinity in tests

**Tuner JSON serialization (commits 2-3):**
- Implement JSON serialize/deserialize for both random and user-defined tuner types
- History evaluations are serialized inline; optima are stored as handle references
- User-defined tuner state is hex-encoded
- Maps work identically to binary: the serialized handle (original pointer) is stored in JSON and used for handle_map resolution on deserialization

This completes JSON serialization support for **all CCS object types**.

## Test plan

- [x] All 30 C tests pass with all 6 Ubuntu CI matrix configurations (gcc/g++/clang × thread-safe/no-thread-safe)
- [x] Builds clean with `--enable-strict` (`-Werror`)
- [x] clang-format-17 clean
- [x] `test_random_tuner` exercises both binary and JSON round-trips

🤖 Generated with [Claude Code](https://claude.com/claude-code)