### PR TITLE
Guard against silent integer precision loss in JSON serialization

### DIFF
--- a/src/cconfigspace.c
+++ b/src/cconfigspace.c
@@ -233,11 +233,8 @@ _ccs_serialize_header(
 	} break;
 	case CCS_SERIALIZE_FORMAT_JSON: {
 		cJSON *header = *(cJSON **)buffer;
-		CCS_REFUTE(
-			!cJSON_AddNumberToObject(
-				header, "version",
-				CCS_SERIALIZATION_API_VERSION),
-			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		CCS_VALIDATE(_ccs_json_add_int(
+			header, "version", CCS_SERIALIZATION_API_VERSION));
 		char hex[sizeof(size_t) * 2 + 1];
 		_ccs_json_hex_encode_buf(&size, sizeof(size_t), hex);
 		CCS_REFUTE(
@@ -285,10 +282,10 @@ _ccs_deserialize_header(
 			cJSON_GetObjectItemCaseSensitive(j_header, "version");
 		cJSON *j_size =
 			cJSON_GetObjectItemCaseSensitive(j_header, "size");
-		CCS_REFUTE(
-			!j_version || !cJSON_IsNumber(j_version),
-			CCS_RESULT_ERROR_INVALID_VALUE);
-		*version = (uint32_t)j_version->valuedouble;
+		ccs_int_t version_val;
+		CCS_REFUTE(!j_version, CCS_RESULT_ERROR_INVALID_VALUE);
+		CCS_VALIDATE(_ccs_json_get_int(j_version, &version_val));
+		*version = (uint32_t)version_val;
 		CCS_REFUTE(
 			*version > CCS_SERIALIZATION_API_VERSION,
 			CCS_RESULT_ERROR_INVALID_VALUE);

--- a/src/cconfigspace_json.h
+++ b/src/cconfigspace_json.h
@@ -348,6 +348,51 @@ _ccs_json_objective_type_from_string(
 }
 
 /*============================================================================
+ * Integer JSON helpers (guards against precision loss)
+ *============================================================================*/
+
+/* Safe integer range matching JavaScript's Number.MAX_SAFE_INTEGER
+ * and Number.MIN_SAFE_INTEGER: ±(2^53 - 1). */
+#define CCS_JSON_INT_MAX (((ccs_int_t)1 << 53) - 1)
+#define CCS_JSON_INT_MIN (-(CCS_JSON_INT_MAX))
+
+/* Add an integer value to a cJSON object, raising an error if the value
+ * exceeds the range representable by a double without precision loss. */
+static inline ccs_result_t
+_ccs_json_add_int(cJSON *json, const char *key, ccs_int_t value)
+{
+	CCS_REFUTE(
+		value > CCS_JSON_INT_MAX || value < CCS_JSON_INT_MIN,
+		CCS_RESULT_ERROR_INVALID_VALUE);
+	CCS_REFUTE(
+		!cJSON_AddNumberToObject(json, key, (double)value),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	return CCS_RESULT_SUCCESS;
+}
+
+/* Create a cJSON number item from an integer, with range check. */
+static inline ccs_result_t
+_ccs_json_create_int(ccs_int_t value, cJSON **item_ret)
+{
+	CCS_REFUTE(
+		value > CCS_JSON_INT_MAX || value < CCS_JSON_INT_MIN,
+		CCS_RESULT_ERROR_INVALID_VALUE);
+	*item_ret = cJSON_CreateNumber((double)value);
+	CCS_REFUTE(!*item_ret, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	return CCS_RESULT_SUCCESS;
+}
+
+/* Read an integer value from a cJSON number. */
+static inline ccs_result_t
+_ccs_json_get_int(cJSON *item, ccs_int_t *value_ret)
+{
+	CCS_REFUTE(
+		!item || !cJSON_IsNumber(item), CCS_RESULT_ERROR_INVALID_VALUE);
+	*value_ret = (ccs_int_t)item->valuedouble;
+	return CCS_RESULT_SUCCESS;
+}
+
+/*============================================================================
  * Float JSON helpers (handles Infinity and NaN)
  *============================================================================*/
 
@@ -371,6 +416,23 @@ _ccs_json_add_float(cJSON *json, const char *key, double value)
 			!cJSON_AddStringToObject(json, key, "NaN"),
 			CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	}
+	return CCS_RESULT_SUCCESS;
+}
+
+/* Create a cJSON item from a float, encoding non-finite values as strings. */
+static inline ccs_result_t
+_ccs_json_create_float(double value, cJSON **item_ret)
+{
+	cJSON *item = NULL;
+	if (isfinite(value)) {
+		item = cJSON_CreateNumber(value);
+	} else if (isinf(value)) {
+		item = cJSON_CreateString(value > 0 ? "Infinity" : "-Infinity");
+	} else {
+		item = cJSON_CreateString("NaN");
+	}
+	CCS_REFUTE(!item, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	*item_ret = item;
 	return CCS_RESULT_SUCCESS;
 }
 
@@ -419,10 +481,9 @@ _ccs_json_datum_to_cjson(ccs_datum_t datum, cJSON **item_ret)
 		CCS_REFUTE_ERR_GOTO(
 			err, !cJSON_AddStringToObject(item, "type", "int"),
 			CCS_RESULT_ERROR_OUT_OF_MEMORY, err_item);
-		CCS_REFUTE_ERR_GOTO(
-			err,
-			!cJSON_AddNumberToObject(item, "value", datum.value.i),
-			CCS_RESULT_ERROR_OUT_OF_MEMORY, err_item);
+		CCS_VALIDATE_ERR_GOTO(
+			err, _ccs_json_add_int(item, "value", datum.value.i),
+			err_item);
 		break;
 	case CCS_DATA_TYPE_FLOAT:
 		CCS_REFUTE_ERR_GOTO(

--- a/src/configuration_space.c
+++ b/src/configuration_space.c
@@ -256,10 +256,8 @@ _ccs_serialize_json_ccs_configuration_space(
 				CCS_REFUTE(
 					!cond, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 				cJSON_AddItemToArray(conds, cond);
-				CCS_REFUTE(
-					!cJSON_AddNumberToObject(
-						cond, "index", (double)i),
-					CCS_RESULT_ERROR_OUT_OF_MEMORY);
+				CCS_VALIDATE(_ccs_json_add_int(
+					cond, "index", (ccs_int_t)i));
 				expr = cJSON_AddObjectToObject(
 					cond, "expression");
 				CCS_REFUTE(

--- a/src/configuration_space_deserialize.h
+++ b/src/configuration_space_deserialize.h
@@ -267,15 +267,15 @@ _ccs_deserialize_json_ccs_configuration_space_data(
 	}
 
 	for (size_t i = 0; i < num_conds; i++) {
-		cJSON *cond_obj = cJSON_GetArrayItem(j_conds, (int)i);
-		cJSON *j_index;
-		cJSON *j_expr;
-		size_t index;
+		cJSON    *cond_obj = cJSON_GetArrayItem(j_conds, (int)i);
+		cJSON    *j_index;
+		cJSON    *j_expr;
+		size_t    index;
+		ccs_int_t index_val;
 		j_index = cJSON_GetObjectItemCaseSensitive(cond_obj, "index");
-		CCS_REFUTE(
-			!j_index || !cJSON_IsNumber(j_index),
-			CCS_RESULT_ERROR_INVALID_VALUE);
-		index = (size_t)j_index->valuedouble;
+		CCS_REFUTE(!j_index, CCS_RESULT_ERROR_INVALID_VALUE);
+		CCS_VALIDATE(_ccs_json_get_int(j_index, &index_val));
+		index = (size_t)index_val;
 		CCS_REFUTE(index >= num, CCS_RESULT_ERROR_INVALID_VALUE);
 		j_expr = cJSON_GetObjectItemCaseSensitive(
 			cond_obj, "expression");

--- a/src/distribution_deserialize.h
+++ b/src/distribution_deserialize.h
@@ -370,18 +370,10 @@ _ccs_deserialize_json_distribution_uniform(
 		upper.f        = fu;
 		quantization.f = fq;
 	} else {
-		CCS_REFUTE(
-			!cJSON_IsNumber(j_lower),
-			CCS_RESULT_ERROR_INVALID_VALUE);
-		CCS_REFUTE(
-			!cJSON_IsNumber(j_upper),
-			CCS_RESULT_ERROR_INVALID_VALUE);
-		CCS_REFUTE(
-			!cJSON_IsNumber(j_quantization),
-			CCS_RESULT_ERROR_INVALID_VALUE);
-		lower.i        = (ccs_int_t)j_lower->valuedouble;
-		upper.i        = (ccs_int_t)j_upper->valuedouble;
-		quantization.i = (ccs_int_t)j_quantization->valuedouble;
+		CCS_VALIDATE(_ccs_json_get_int(j_lower, &lower.i));
+		CCS_VALIDATE(_ccs_json_get_int(j_upper, &upper.i));
+		CCS_VALIDATE(
+			_ccs_json_get_int(j_quantization, &quantization.i));
 	}
 	CCS_VALIDATE(ccs_create_uniform_distribution(
 		data_type, lower, upper, scale_type, quantization,
@@ -429,10 +421,8 @@ _ccs_deserialize_json_distribution_normal(
 		CCS_VALIDATE(_ccs_json_get_float(j_quantization, &fq));
 		quantization.f = fq;
 	} else {
-		CCS_REFUTE(
-			!cJSON_IsNumber(j_quantization),
-			CCS_RESULT_ERROR_INVALID_VALUE);
-		quantization.i = (ccs_int_t)j_quantization->valuedouble;
+		CCS_VALIDATE(
+			_ccs_json_get_int(j_quantization, &quantization.i));
 	}
 	CCS_VALIDATE(ccs_create_normal_distribution(
 		data_type, mu_val, sigma_val, scale_type, quantization,
@@ -457,9 +447,9 @@ _ccs_deserialize_json_distribution_roulette(
 	for (size_t i = 0; i < num_areas; i++) {
 		cJSON *item = cJSON_GetArrayItem(j_areas, (int)i);
 		CCS_REFUTE_ERR_GOTO(
-			res, !item || !cJSON_IsNumber(item),
-			CCS_RESULT_ERROR_INVALID_VALUE, end);
-		areas[i] = item->valuedouble;
+			res, !item, CCS_RESULT_ERROR_INVALID_VALUE, end);
+		CCS_VALIDATE_ERR_GOTO(
+			res, _ccs_json_get_float(item, &areas[i]), end);
 	}
 	CCS_VALIDATE_ERR_GOTO(
 		res,
@@ -512,9 +502,9 @@ _ccs_deserialize_json_distribution_mixture(
 	for (size_t i = 0; i < num; i++) {
 		cJSON *w = cJSON_GetArrayItem(j_weights, (int)i);
 		CCS_REFUTE_ERR_GOTO(
-			res, !w || !cJSON_IsNumber(w),
-			CCS_RESULT_ERROR_INVALID_VALUE, end);
-		weights[i]   = w->valuedouble;
+			res, !w, CCS_RESULT_ERROR_INVALID_VALUE, end);
+		CCS_VALIDATE_ERR_GOTO(
+			res, _ccs_json_get_float(w, &weights[i]), end);
 		cJSON *child = cJSON_GetArrayItem(j_distributions, (int)i);
 		CCS_REFUTE_ERR_GOTO(
 			res, !child || !cJSON_IsObject(child),

--- a/src/distribution_mixture.c
+++ b/src/distribution_mixture.c
@@ -109,13 +109,14 @@ _ccs_serialize_json_ccs_distribution_mixture(
 		CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	cJSON *weights = cJSON_AddArrayToObject(json, "weights");
 	CCS_REFUTE(!weights, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-	for (size_t i = 0; i < data->num_distributions; i++)
+	for (size_t i = 0; i < data->num_distributions; i++) {
+		cJSON *w_item = NULL;
+		CCS_VALIDATE(_ccs_json_create_float(
+			data->weights[i + 1] - data->weights[i], &w_item));
 		CCS_REFUTE(
-			!cJSON_AddItemToArray(
-				weights, cJSON_CreateNumber(
-						 data->weights[i + 1] -
-						 data->weights[i])),
+			!cJSON_AddItemToArray(weights, w_item),
 			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	}
 	cJSON *distributions = cJSON_AddArrayToObject(json, "distributions");
 	CCS_REFUTE(!distributions, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	for (size_t i = 0; i < data->num_distributions; i++) {

--- a/src/distribution_normal.c
+++ b/src/distribution_normal.c
@@ -114,10 +114,8 @@ _ccs_serialize_json_ccs_distribution_normal(
 		CCS_VALIDATE(_ccs_json_add_float(
 			json, "quantization", data->quantization.f));
 	} else {
-		CCS_REFUTE(
-			!cJSON_AddNumberToObject(
-				json, "quantization", data->quantization.i),
-			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		CCS_VALIDATE(_ccs_json_add_int(
+			json, "quantization", data->quantization.i));
 	}
 	return CCS_RESULT_SUCCESS;
 }

--- a/src/distribution_roulette.c
+++ b/src/distribution_roulette.c
@@ -85,13 +85,14 @@ _ccs_serialize_json_ccs_distribution_roulette(
 		CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	cJSON *areas = cJSON_AddArrayToObject(json, "areas");
 	CCS_REFUTE(!areas, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-	for (size_t i = 0; i < data->num_areas; i++)
+	for (size_t i = 0; i < data->num_areas; i++) {
+		cJSON *a_item = NULL;
+		CCS_VALIDATE(_ccs_json_create_float(
+			data->areas[i + 1] - data->areas[i], &a_item));
 		CCS_REFUTE(
-			!cJSON_AddItemToArray(
-				areas,
-				cJSON_CreateNumber(
-					data->areas[i + 1] - data->areas[i])),
+			!cJSON_AddItemToArray(areas, a_item),
 			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	}
 	return CCS_RESULT_SUCCESS;
 }
 

--- a/src/distribution_space.c
+++ b/src/distribution_space.c
@@ -144,14 +144,15 @@ _ccs_serialize_json_ccs_distribution_space(
 		cJSON *indices =
 			cJSON_AddArrayToObject(entry, "parameter_indices");
 		CCS_REFUTE(!indices, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		for (size_t i = 0; i < dw->dimension; i++)
+		for (size_t i = 0; i < dw->dimension; i++) {
+			cJSON *idx_item;
+			CCS_VALIDATE(_ccs_json_create_int(
+				(ccs_int_t)dw->parameter_indexes[i],
+				&idx_item));
 			CCS_REFUTE(
-				!cJSON_AddItemToArray(
-					indices,
-					cJSON_CreateNumber(
-						(double)dw
-							->parameter_indexes[i])),
+				!cJSON_AddItemToArray(indices, idx_item),
 				CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		}
 	}
 
 	return CCS_RESULT_SUCCESS;

--- a/src/distribution_space_deserialize.h
+++ b/src/distribution_space_deserialize.h
@@ -234,11 +234,11 @@ _ccs_deserialize_json_ccs_distribution_space_data(
 		dim                 = (size_t)cJSON_GetArraySize(j_indices);
 		data->dimensions[i] = dim;
 		for (size_t j = 0; j < dim; j++) {
-			cJSON *idx = cJSON_GetArrayItem(j_indices, (int)j);
-			CCS_REFUTE(
-				!idx || !cJSON_IsNumber(idx),
-				CCS_RESULT_ERROR_INVALID_VALUE);
-			*indices = (size_t)idx->valuedouble;
+			ccs_int_t idx_val;
+			cJSON    *idx = cJSON_GetArrayItem(j_indices, (int)j);
+			CCS_REFUTE(!idx, CCS_RESULT_ERROR_INVALID_VALUE);
+			CCS_VALIDATE(_ccs_json_get_int(idx, &idx_val));
+			*indices = (size_t)idx_val;
 			indices++;
 		}
 	}

--- a/src/distribution_uniform.c
+++ b/src/distribution_uniform.c
@@ -125,16 +125,10 @@ _ccs_serialize_json_ccs_distribution_uniform(
 		CCS_VALIDATE(_ccs_json_add_float(
 			json, "quantization", data->quantization.f));
 	} else {
-		CCS_REFUTE(
-			!cJSON_AddNumberToObject(json, "lower", data->lower.i),
-			CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		CCS_REFUTE(
-			!cJSON_AddNumberToObject(json, "upper", data->upper.i),
-			CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		CCS_REFUTE(
-			!cJSON_AddNumberToObject(
-				json, "quantization", data->quantization.i),
-			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		CCS_VALIDATE(_ccs_json_add_int(json, "lower", data->lower.i));
+		CCS_VALIDATE(_ccs_json_add_int(json, "upper", data->upper.i));
+		CCS_VALIDATE(_ccs_json_add_int(
+			json, "quantization", data->quantization.i));
 	}
 	return CCS_RESULT_SUCCESS;
 }

--- a/src/evaluation.c
+++ b/src/evaluation.c
@@ -99,9 +99,8 @@ _ccs_serialize_json_ccs_evaluation(
 	}
 
 	/* result */
-	CCS_REFUTE(
-		!cJSON_AddNumberToObject(json, "result", (double)data->result),
-		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	CCS_VALIDATE(
+		_ccs_json_add_int(json, "result", (ccs_int_t)data->result));
 
 	return CCS_RESULT_SUCCESS;
 }

--- a/src/evaluation_deserialize.h
+++ b/src/evaluation_deserialize.h
@@ -100,6 +100,7 @@ _ccs_deserialize_json_ccs_evaluation(
 	cJSON                     *j_result;
 	const char                *cbuf;
 	size_t                     dummy;
+	ccs_int_t                  result_val;
 
 	(void)version;
 	(void)buffer_size;
@@ -140,9 +141,10 @@ _ccs_deserialize_json_ccs_evaluation(
 	/* result */
 	j_result = cJSON_GetObjectItemCaseSensitive(json, "result");
 	CCS_REFUTE_ERR_GOTO(
-		res, !j_result || !cJSON_IsNumber(j_result),
-		CCS_RESULT_ERROR_INVALID_VALUE, end);
-	result = (ccs_evaluation_result_t)j_result->valuedouble;
+		res, !j_result, CCS_RESULT_ERROR_INVALID_VALUE, end);
+	CCS_VALIDATE_ERR_GOTO(
+		res, _ccs_json_get_int(j_result, &result_val), end);
+	result = (ccs_evaluation_result_t)result_val;
 
 	CCS_VALIDATE_ERR_GOTO(
 		res,

--- a/src/parameter_deserialize.h
+++ b/src/parameter_deserialize.h
@@ -209,18 +209,10 @@ _ccs_deserialize_json_parameter_numerical(
 		quantization.f  = fq;
 		default_value.f = default_datum.value.f;
 	} else {
-		CCS_REFUTE(
-			!cJSON_IsNumber(j_lower),
-			CCS_RESULT_ERROR_INVALID_VALUE);
-		CCS_REFUTE(
-			!cJSON_IsNumber(j_upper),
-			CCS_RESULT_ERROR_INVALID_VALUE);
-		CCS_REFUTE(
-			!cJSON_IsNumber(j_quantization),
-			CCS_RESULT_ERROR_INVALID_VALUE);
-		lower.i         = (ccs_int_t)j_lower->valuedouble;
-		upper.i         = (ccs_int_t)j_upper->valuedouble;
-		quantization.i  = (ccs_int_t)j_quantization->valuedouble;
+		CCS_VALIDATE(_ccs_json_get_int(j_lower, &lower.i));
+		CCS_VALIDATE(_ccs_json_get_int(j_upper, &upper.i));
+		CCS_VALIDATE(
+			_ccs_json_get_int(j_quantization, &quantization.i));
 		default_value.i = default_datum.value.i;
 	}
 	CCS_VALIDATE(ccs_create_numerical_parameter(

--- a/src/parameter_numerical.c
+++ b/src/parameter_numerical.c
@@ -61,20 +61,12 @@ _ccs_serialize_json_ccs_parameter_numerical(
 		CCS_VALIDATE(_ccs_json_add_float(
 			json, "quantization", data->quantization.f));
 	} else {
-		CCS_REFUTE(
-			!cJSON_AddNumberToObject(
-				json, "lower",
-				data->common_data.interval.lower.i),
-			CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		CCS_REFUTE(
-			!cJSON_AddNumberToObject(
-				json, "upper",
-				data->common_data.interval.upper.i),
-			CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		CCS_REFUTE(
-			!cJSON_AddNumberToObject(
-				json, "quantization", data->quantization.i),
-			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		CCS_VALIDATE(_ccs_json_add_int(
+			json, "lower", data->common_data.interval.lower.i));
+		CCS_VALIDATE(_ccs_json_add_int(
+			json, "upper", data->common_data.interval.upper.i));
+		CCS_VALIDATE(_ccs_json_add_int(
+			json, "quantization", data->quantization.i));
 	}
 	CCS_VALIDATE(_ccs_json_add_datum(
 		json, "default_value", data->common_data.default_value));

--- a/src/tree.c
+++ b/src/tree.c
@@ -97,16 +97,10 @@ _ccs_serialize_json_ccs_tree(
 	cJSON            *children;
 	size_t            i;
 
-	CCS_REFUTE(
-		!cJSON_AddNumberToObject(json, "arity", (double)data->arity),
-		CCS_RESULT_ERROR_OUT_OF_MEMORY);
-	CCS_REFUTE(
-		!cJSON_AddNumberToObject(
-			json, "weight", data->weights[data->arity]),
-		CCS_RESULT_ERROR_OUT_OF_MEMORY);
-	CCS_REFUTE(
-		!cJSON_AddNumberToObject(json, "bias", data->bias),
-		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	CCS_VALIDATE(_ccs_json_add_int(json, "arity", (ccs_int_t)data->arity));
+	CCS_VALIDATE(_ccs_json_add_float(
+		json, "weight", data->weights[data->arity]));
+	CCS_VALIDATE(_ccs_json_add_float(json, "bias", data->bias));
 	CCS_VALIDATE(_ccs_json_add_datum(json, "value", data->value));
 
 	children = cJSON_AddArrayToObject(json, "children");

--- a/src/tree_configuration.c
+++ b/src/tree_configuration.c
@@ -100,12 +100,14 @@ _ccs_serialize_json_ccs_tree_configuration(
 
 	positions = cJSON_AddArrayToObject(json, "position");
 	CCS_REFUTE(!positions, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-	for (i = 0; i < data->position_size; i++)
+	for (i = 0; i < data->position_size; i++) {
+		cJSON *pos_item;
+		CCS_VALIDATE(_ccs_json_create_int(
+			(ccs_int_t)data->position[i], &pos_item));
 		CCS_REFUTE(
-			!cJSON_AddItemToArray(
-				positions,
-				cJSON_CreateNumber((double)data->position[i])),
+			!cJSON_AddItemToArray(positions, pos_item),
 			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	}
 
 	if (data->features) {
 		cJSON *feat = cJSON_AddObjectToObject(json, "features");

--- a/src/tree_configuration_deserialize.h
+++ b/src/tree_configuration_deserialize.h
@@ -156,11 +156,14 @@ _ccs_deserialize_json_tree_configuration(
 		CCS_REFUTE_ERR_GOTO(
 			res, !position, CCS_RESULT_ERROR_OUT_OF_MEMORY, end);
 		for (i = 0; i < pos_count; i++) {
-			cJSON *item = cJSON_GetArrayItem(j_position, i);
+			ccs_int_t pos_val;
+			cJSON    *item = cJSON_GetArrayItem(j_position, i);
 			CCS_REFUTE_ERR_GOTO(
-				res, !item || !cJSON_IsNumber(item),
-				CCS_RESULT_ERROR_INVALID_VALUE, end);
-			position[i] = (size_t)item->valuedouble;
+				res, !item, CCS_RESULT_ERROR_INVALID_VALUE,
+				end);
+			CCS_VALIDATE_ERR_GOTO(
+				res, _ccs_json_get_int(item, &pos_val), end);
+			position[i] = (size_t)pos_val;
 		}
 	}
 

--- a/src/tree_deserialize.h
+++ b/src/tree_deserialize.h
@@ -121,6 +121,7 @@ _ccs_deserialize_json_tree(
 	int                               i;
 	const char                       *cbuf;
 	size_t                            dummy;
+	ccs_int_t                         arity_val;
 
 	(void)buffer_size;
 	new_opts.handle_map = NULL;
@@ -128,26 +129,20 @@ _ccs_deserialize_json_tree(
 	data.children       = NULL;
 
 	json                = *(cJSON **)buffer;
-
 	j_arity             = cJSON_GetObjectItemCaseSensitive(json, "arity");
-	CCS_REFUTE(
-		!j_arity || !cJSON_IsNumber(j_arity),
-		CCS_RESULT_ERROR_INVALID_VALUE);
-	data.arity = (size_t)j_arity->valuedouble;
+	CCS_REFUTE(!j_arity, CCS_RESULT_ERROR_INVALID_VALUE);
+	CCS_VALIDATE(_ccs_json_get_int(j_arity, &arity_val));
+	data.arity = (size_t)arity_val;
 
 	j_weight   = cJSON_GetObjectItemCaseSensitive(json, "weight");
-	CCS_REFUTE(
-		!j_weight || !cJSON_IsNumber(j_weight),
-		CCS_RESULT_ERROR_INVALID_VALUE);
-	data.weight = j_weight->valuedouble;
+	CCS_REFUTE(!j_weight, CCS_RESULT_ERROR_INVALID_VALUE);
+	CCS_VALIDATE(_ccs_json_get_float(j_weight, &data.weight));
 
-	j_bias      = cJSON_GetObjectItemCaseSensitive(json, "bias");
-	CCS_REFUTE(
-		!j_bias || !cJSON_IsNumber(j_bias),
-		CCS_RESULT_ERROR_INVALID_VALUE);
-	data.bias = j_bias->valuedouble;
+	j_bias = cJSON_GetObjectItemCaseSensitive(json, "bias");
+	CCS_REFUTE(!j_bias, CCS_RESULT_ERROR_INVALID_VALUE);
+	CCS_VALIDATE(_ccs_json_get_float(j_bias, &data.bias));
 
-	j_value   = cJSON_GetObjectItemCaseSensitive(json, "value");
+	j_value = cJSON_GetObjectItemCaseSensitive(json, "value");
 	CCS_REFUTE(!j_value, CCS_RESULT_ERROR_INVALID_VALUE);
 	CCS_VALIDATE_ERR_GOTO(
 		res, _ccs_json_get_datum(j_value, &data.value), end);


### PR DESCRIPTION
## Summary

cJSON stores numbers as `double`, which has 53 bits of mantissa. Any `ccs_int_t` (int64) beyond ±2^53 would silently lose precision during JSON round-trip.

- Add `_ccs_json_add_int` that raises `CCS_RESULT_ERROR_INVALID_VALUE` if the integer exceeds the safe range
- Add `_ccs_json_get_int` for symmetric deserialization
- Update all integer serialization sites (distributions, parameters, datums) to use the new helper
- Also use `_ccs_json_add_float` for tree weight/bias for consistency

## Test plan

- [x] All 30 tests pass
- [x] Builds clean with gcc, g++, clang

🤖 Generated with [Claude Code](https://claude.com/claude-code)