### PR TITLE
Add JSON object extraction helpers for recursive deserializers

### DIFF
--- a/src/cconfigspace_deserialize.h
+++ b/src/cconfigspace_deserialize.h
@@ -20,6 +20,31 @@ _ccs_object_deserialize_with_opts(
 	const char                       **buffer,
 	_ccs_object_deserialize_options_t *opts);
 
+static inline ccs_result_t
+_ccs_json_extract_object(
+	cJSON                             *json,
+	const char                        *key,
+	ccs_object_type_t                  expected_type,
+	uint32_t                           version,
+	ccs_object_t                      *object_ret,
+	_ccs_object_deserialize_options_t *opts);
+
+static inline ccs_result_t
+_ccs_json_extract_object_uncheck(
+	cJSON                             *json,
+	const char                        *key,
+	uint32_t                           version,
+	ccs_object_t                      *object_ret,
+	_ccs_object_deserialize_options_t *opts);
+
+static inline ccs_result_t
+_ccs_json_deserialize_array_object(
+	cJSON                             *item,
+	ccs_object_type_t                  expected_type,
+	uint32_t                           version,
+	ccs_object_t                      *object_ret,
+	_ccs_object_deserialize_options_t *opts);
+
 #include "rng_deserialize.h"
 #include "distribution_deserialize.h"
 #include "parameter_deserialize.h"
@@ -268,6 +293,76 @@ _ccs_object_deserialize_with_opts(
 errobj:
 	ccs_release_object(obj);
 	return err;
+}
+
+/*============================================================================
+ * JSON object extraction helpers
+ *============================================================================*/
+
+/* Look up a child object by key, validate it is a JSON object,
+ * and deserialize it with type checking. */
+static inline ccs_result_t
+_ccs_json_extract_object(
+	cJSON                             *json,
+	const char                        *key,
+	ccs_object_type_t                  expected_type,
+	uint32_t                           version,
+	ccs_object_t                      *object_ret,
+	_ccs_object_deserialize_options_t *opts)
+{
+	size_t      dummy = 0;
+	cJSON      *item  = cJSON_GetObjectItemCaseSensitive(json, key);
+	const char *cbuf;
+	CCS_REFUTE(
+		!item || !cJSON_IsObject(item), CCS_RESULT_ERROR_INVALID_VALUE);
+	cbuf = (const char *)item;
+	CCS_VALIDATE(_ccs_object_deserialize_with_opts_check(
+		object_ret, expected_type, CCS_SERIALIZE_FORMAT_JSON, version,
+		&dummy, &cbuf, opts));
+	return CCS_RESULT_SUCCESS;
+}
+
+/* Look up a child object by key, validate it is a JSON object,
+ * and deserialize it without type checking (for polymorphic fields). */
+static inline ccs_result_t
+_ccs_json_extract_object_uncheck(
+	cJSON                             *json,
+	const char                        *key,
+	uint32_t                           version,
+	ccs_object_t                      *object_ret,
+	_ccs_object_deserialize_options_t *opts)
+{
+	size_t      dummy = 0;
+	cJSON      *item  = cJSON_GetObjectItemCaseSensitive(json, key);
+	const char *cbuf;
+	CCS_REFUTE(
+		!item || !cJSON_IsObject(item), CCS_RESULT_ERROR_INVALID_VALUE);
+	cbuf = (const char *)item;
+	CCS_VALIDATE(_ccs_object_deserialize_with_opts(
+		object_ret, CCS_SERIALIZE_FORMAT_JSON, version, &dummy, &cbuf,
+		opts));
+	return CCS_RESULT_SUCCESS;
+}
+
+/* Deserialize a JSON array item (already obtained via cJSON_GetArrayItem)
+ * as a typed object. */
+static inline ccs_result_t
+_ccs_json_deserialize_array_object(
+	cJSON                             *item,
+	ccs_object_type_t                  expected_type,
+	uint32_t                           version,
+	ccs_object_t                      *object_ret,
+	_ccs_object_deserialize_options_t *opts)
+{
+	size_t      dummy = 0;
+	const char *cbuf;
+	CCS_REFUTE(
+		!item || !cJSON_IsObject(item), CCS_RESULT_ERROR_INVALID_VALUE);
+	cbuf = (const char *)item;
+	CCS_VALIDATE(_ccs_object_deserialize_with_opts_check(
+		object_ret, expected_type, CCS_SERIALIZE_FORMAT_JSON, version,
+		&dummy, &cbuf, opts));
+	return CCS_RESULT_SUCCESS;
 }
 
 #endif //_CCONFIG_SPACE_SPACE_DESERIALIZE_H

--- a/src/configuration_deserialize.h
+++ b/src/configuration_deserialize.h
@@ -96,8 +96,6 @@ _ccs_deserialize_json_configuration(
 	ccs_features_t            features = NULL;
 	cJSON                    *json;
 	cJSON                    *j_features;
-	const char               *cbuf;
-	size_t                    dummy;
 
 	(void)version;
 	(void)buffer_size;
@@ -118,18 +116,14 @@ _ccs_deserialize_json_configuration(
 
 	/* optional features */
 	j_features = cJSON_GetObjectItemCaseSensitive(json, "features");
-	if (j_features && cJSON_IsObject(j_features)) {
+	if (j_features) {
 		_ccs_object_deserialize_options_t feat_opts = *opts;
 		feat_opts.map_values                        = CCS_FALSE;
-		cbuf  = (const char *)j_features;
-		dummy = 0;
 		CCS_VALIDATE_ERR_GOTO(
 			res,
-			_ccs_object_deserialize_with_opts_check(
-				(ccs_object_t *)&features,
-				CCS_OBJECT_TYPE_FEATURES,
-				CCS_SERIALIZE_FORMAT_JSON, version, &dummy,
-				&cbuf, &feat_opts),
+			_ccs_json_extract_object(
+				json, "features", CCS_OBJECT_TYPE_FEATURES,
+				version, (ccs_object_t *)&features, &feat_opts),
 			end);
 	}
 

--- a/src/configuration_space_deserialize.h
+++ b/src/configuration_space_deserialize.h
@@ -168,42 +168,28 @@ _ccs_deserialize_json_ccs_configuration_space_data(
 	cJSON                                *json,
 	_ccs_object_deserialize_options_t    *opts)
 {
-	cJSON      *j_fs;
-	cJSON      *j_rng;
-	cJSON      *j_params;
-	cJSON      *j_conds;
-	cJSON      *j_forbids;
-	size_t      num;
-	size_t      num_conds;
-	size_t      num_forbids;
-	uintptr_t   mem;
-	const char *cbuf;
-	size_t      dummy;
+	cJSON    *j_fs;
+	cJSON    *j_params;
+	cJSON    *j_conds;
+	cJSON    *j_forbids;
+	size_t    num;
+	size_t    num_conds;
+	size_t    num_forbids;
+	uintptr_t mem;
 
 	CCS_VALIDATE(_ccs_json_extract_string(json, "name", &data->name));
 
 	/* feature space (optional) */
 	j_fs = cJSON_GetObjectItemCaseSensitive(json, "feature_space");
-	if (j_fs && cJSON_IsObject(j_fs)) {
-		cbuf  = (const char *)j_fs;
-		dummy = 0;
-		CCS_VALIDATE(_ccs_object_deserialize_with_opts_check(
-			(ccs_object_t *)&data->feature_space,
-			CCS_OBJECT_TYPE_FEATURE_SPACE,
-			CCS_SERIALIZE_FORMAT_JSON, version, &dummy, &cbuf,
-			opts));
-	}
+	if (j_fs)
+		CCS_VALIDATE(_ccs_json_extract_object(
+			json, "feature_space", CCS_OBJECT_TYPE_FEATURE_SPACE,
+			version, (ccs_object_t *)&data->feature_space, opts));
 
 	/* rng */
-	j_rng = cJSON_GetObjectItemCaseSensitive(json, "rng");
-	CCS_REFUTE(
-		!j_rng || !cJSON_IsObject(j_rng),
-		CCS_RESULT_ERROR_INVALID_VALUE);
-	cbuf  = (const char *)j_rng;
-	dummy = 0;
-	CCS_VALIDATE(_ccs_object_deserialize_with_opts_check(
-		(ccs_object_t *)&data->rng, CCS_OBJECT_TYPE_RNG,
-		CCS_SERIALIZE_FORMAT_JSON, version, &dummy, &cbuf, opts));
+	CCS_VALIDATE(_ccs_json_extract_object(
+		json, "rng", CCS_OBJECT_TYPE_RNG, version,
+		(ccs_object_t *)&data->rng, opts));
 
 	/* parameters */
 	j_params = cJSON_GetObjectItemCaseSensitive(json, "parameters");
@@ -251,47 +237,31 @@ _ccs_deserialize_json_ccs_configuration_space_data(
 	data->forbidden_clauses =
 		CCS_ALLOC_CARVE_ARRAY(mem, num_forbids, ccs_expression_t);
 
-	for (size_t i = 0; i < num; i++) {
-		cJSON *child = cJSON_GetArrayItem(j_params, (int)i);
-		cbuf         = (const char *)child;
-		dummy        = 0;
-		CCS_VALIDATE(_ccs_object_deserialize_with_opts_check(
-			(ccs_object_t *)data->parameters + i,
-			CCS_OBJECT_TYPE_PARAMETER, CCS_SERIALIZE_FORMAT_JSON,
-			version, &dummy, &cbuf, opts));
-	}
+	for (size_t i = 0; i < num; i++)
+		CCS_VALIDATE(_ccs_json_deserialize_array_object(
+			cJSON_GetArrayItem(j_params, (int)i),
+			CCS_OBJECT_TYPE_PARAMETER, version,
+			(ccs_object_t *)data->parameters + i, opts));
 
 	for (size_t i = 0; i < num_conds; i++) {
 		cJSON    *cond_obj = cJSON_GetArrayItem(j_conds, (int)i);
-		cJSON    *j_expr;
 		size_t    index;
 		ccs_int_t index_val;
 		CCS_VALIDATE(
 			_ccs_json_extract_int(cond_obj, "index", &index_val));
 		index = (size_t)index_val;
 		CCS_REFUTE(index >= num, CCS_RESULT_ERROR_INVALID_VALUE);
-		j_expr = cJSON_GetObjectItemCaseSensitive(
-			cond_obj, "expression");
-		CCS_REFUTE(
-			!j_expr || !cJSON_IsObject(j_expr),
-			CCS_RESULT_ERROR_INVALID_VALUE);
-		cbuf  = (const char *)j_expr;
-		dummy = 0;
-		CCS_VALIDATE(_ccs_object_deserialize_with_opts_check(
-			(ccs_object_t *)data->conditions + index,
-			CCS_OBJECT_TYPE_EXPRESSION, CCS_SERIALIZE_FORMAT_JSON,
-			version, &dummy, &cbuf, opts));
+		CCS_VALIDATE(_ccs_json_extract_object(
+			cond_obj, "expression", CCS_OBJECT_TYPE_EXPRESSION,
+			version, (ccs_object_t *)data->conditions + index,
+			opts));
 	}
 
-	for (size_t i = 0; i < num_forbids; i++) {
-		cJSON *child = cJSON_GetArrayItem(j_forbids, (int)i);
-		cbuf         = (const char *)child;
-		dummy        = 0;
-		CCS_VALIDATE(_ccs_object_deserialize_with_opts_check(
-			(ccs_object_t *)data->forbidden_clauses + i,
-			CCS_OBJECT_TYPE_EXPRESSION, CCS_SERIALIZE_FORMAT_JSON,
-			version, &dummy, &cbuf, opts));
-	}
+	for (size_t i = 0; i < num_forbids; i++)
+		CCS_VALIDATE(_ccs_json_deserialize_array_object(
+			cJSON_GetArrayItem(j_forbids, (int)i),
+			CCS_OBJECT_TYPE_EXPRESSION, version,
+			(ccs_object_t *)data->forbidden_clauses + i, opts));
 
 	return CCS_RESULT_SUCCESS;
 }

--- a/src/context_deserialize.h
+++ b/src/context_deserialize.h
@@ -59,16 +59,11 @@ _ccs_deserialize_json_ccs_context_data(
 		data->parameters =
 			(ccs_parameter_t *)calloc(num, sizeof(ccs_parameter_t));
 		CCS_REFUTE(!data->parameters, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		for (size_t i = 0; i < num; i++) {
-			cJSON *child     = cJSON_GetArrayItem(j_params, (int)i);
-			const char *cbuf = (const char *)child;
-			size_t      dummy = 0;
-			CCS_VALIDATE(_ccs_object_deserialize_with_opts_check(
-				(ccs_object_t *)data->parameters + i,
-				CCS_OBJECT_TYPE_PARAMETER,
-				CCS_SERIALIZE_FORMAT_JSON, version, &dummy,
-				&cbuf, opts));
-		}
+		for (size_t i = 0; i < num; i++)
+			CCS_VALIDATE(_ccs_json_deserialize_array_object(
+				cJSON_GetArrayItem(j_params, (int)i),
+				CCS_OBJECT_TYPE_PARAMETER, version,
+				(ccs_object_t *)data->parameters + i, opts));
 	}
 	return CCS_RESULT_SUCCESS;
 }

--- a/src/distribution_deserialize.h
+++ b/src/distribution_deserialize.h
@@ -481,19 +481,12 @@ _ccs_deserialize_json_distribution_mixture(
 			res, !w, CCS_RESULT_ERROR_INVALID_VALUE, end);
 		CCS_VALIDATE_ERR_GOTO(
 			res, _ccs_json_get_float(w, &weights[i]), end);
-		cJSON *child = cJSON_GetArrayItem(j_distributions, (int)i);
-		CCS_REFUTE_ERR_GOTO(
-			res, !child || !cJSON_IsObject(child),
-			CCS_RESULT_ERROR_INVALID_VALUE, end);
-		size_t      dummy = 0;
-		const char *cbuf  = (const char *)child;
 		CCS_VALIDATE_ERR_GOTO(
 			res,
-			_ccs_object_deserialize_with_opts_check(
-				(ccs_object_t *)distributions + i,
-				CCS_OBJECT_TYPE_DISTRIBUTION,
-				CCS_SERIALIZE_FORMAT_JSON, version, &dummy,
-				&cbuf, &new_opts),
+			_ccs_json_deserialize_array_object(
+				cJSON_GetArrayItem(j_distributions, (int)i),
+				CCS_OBJECT_TYPE_DISTRIBUTION, version,
+				(ccs_object_t *)distributions + i, &new_opts),
 			end);
 	}
 	CCS_VALIDATE_ERR_GOTO(
@@ -536,22 +529,14 @@ _ccs_deserialize_json_distribution_multivariate(
 		(ccs_distribution_t *)calloc(num, sizeof(ccs_distribution_t));
 	CCS_REFUTE(!distributions, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 
-	for (size_t i = 0; i < num; i++) {
-		cJSON *child = cJSON_GetArrayItem(j_distributions, (int)i);
-		CCS_REFUTE_ERR_GOTO(
-			res, !child || !cJSON_IsObject(child),
-			CCS_RESULT_ERROR_INVALID_VALUE, end);
-		size_t      dummy = 0;
-		const char *cbuf  = (const char *)child;
+	for (size_t i = 0; i < num; i++)
 		CCS_VALIDATE_ERR_GOTO(
 			res,
-			_ccs_object_deserialize_with_opts_check(
-				(ccs_object_t *)distributions + i,
-				CCS_OBJECT_TYPE_DISTRIBUTION,
-				CCS_SERIALIZE_FORMAT_JSON, version, &dummy,
-				&cbuf, &new_opts),
+			_ccs_json_deserialize_array_object(
+				cJSON_GetArrayItem(j_distributions, (int)i),
+				CCS_OBJECT_TYPE_DISTRIBUTION, version,
+				(ccs_object_t *)distributions + i, &new_opts),
 			end);
-	}
 	CCS_VALIDATE_ERR_GOTO(
 		res,
 		ccs_create_multivariate_distribution(

--- a/src/distribution_space_deserialize.h
+++ b/src/distribution_space_deserialize.h
@@ -153,8 +153,6 @@ _ccs_deserialize_json_ccs_distribution_space_data(
 	size_t      num;
 	size_t      total_indices = 0;
 	uintptr_t   mem;
-	const char *cbuf;
-	size_t      dummy;
 
 	/* configuration_space handle */
 	const char *cs_str;
@@ -213,22 +211,15 @@ _ccs_deserialize_json_ccs_distribution_space_data(
 
 	size_t *indices = data->distrib_parameter_indices;
 	for (size_t i = 0; i < num; i++) {
-		cJSON *entry = cJSON_GetArrayItem(j_distribs, (int)i);
-		cJSON *j_dist =
-			cJSON_GetObjectItemCaseSensitive(entry, "distribution");
+		cJSON *entry     = cJSON_GetArrayItem(j_distribs, (int)i);
 		cJSON *j_indices = cJSON_GetObjectItemCaseSensitive(
 			entry, "parameter_indices");
 		size_t dim;
 
-		CCS_REFUTE(
-			!j_dist || !cJSON_IsObject(j_dist),
-			CCS_RESULT_ERROR_INVALID_VALUE);
-		cbuf  = (const char *)j_dist;
-		dummy = 0;
-		CCS_VALIDATE(_ccs_object_deserialize_with_opts_check(
-			(ccs_object_t *)data->distributions + i,
-			CCS_OBJECT_TYPE_DISTRIBUTION, CCS_SERIALIZE_FORMAT_JSON,
-			version, &dummy, &cbuf, opts));
+		CCS_VALIDATE(_ccs_json_extract_object(
+			entry, "distribution", CCS_OBJECT_TYPE_DISTRIBUTION,
+			version, (ccs_object_t *)data->distributions + i,
+			opts));
 
 		dim                 = (size_t)cJSON_GetArraySize(j_indices);
 		data->dimensions[i] = dim;

--- a/src/evaluation_deserialize.h
+++ b/src/evaluation_deserialize.h
@@ -96,9 +96,6 @@ _ccs_deserialize_json_ccs_evaluation(
 	ccs_search_configuration_t configuration = NULL;
 	ccs_evaluation_result_t    result        = CCS_RESULT_SUCCESS;
 	cJSON                     *json;
-	cJSON                     *j_conf;
-	const char                *cbuf;
-	size_t                     dummy;
 	ccs_int_t                  result_val;
 
 	(void)version;
@@ -116,24 +113,17 @@ _ccs_deserialize_json_ccs_evaluation(
 	CCS_REFUTE_ERR_GOTO(
 		res, d.type != CCS_DATA_TYPE_OBJECT,
 		CCS_RESULT_ERROR_INVALID_HANDLE, end);
-	os     = (ccs_objective_space_t)(d.value.o);
+	os = (ccs_objective_space_t)(d.value.o);
 
 	/* configuration */
-	j_conf = cJSON_GetObjectItemCaseSensitive(json, "configuration");
-	CCS_REFUTE_ERR_GOTO(
-		res, !j_conf || !cJSON_IsObject(j_conf),
-		CCS_RESULT_ERROR_INVALID_VALUE, end);
 	{
 		_ccs_object_deserialize_options_t conf_opts = *opts;
 		conf_opts.map_values                        = CCS_FALSE;
-		cbuf  = (const char *)j_conf;
-		dummy = 0;
 		CCS_VALIDATE_ERR_GOTO(
 			res,
-			_ccs_object_deserialize_with_opts(
-				(ccs_object_t *)&configuration,
-				CCS_SERIALIZE_FORMAT_JSON, version, &dummy,
-				&cbuf, &conf_opts),
+			_ccs_json_extract_object_uncheck(
+				json, "configuration", version,
+				(ccs_object_t *)&configuration, &conf_opts),
 			end);
 	}
 

--- a/src/expression_deserialize.h
+++ b/src/expression_deserialize.h
@@ -359,23 +359,12 @@ _ccs_deserialize_json_expression_general(
 		CCS_REFUTE(!data.nodes, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 		for (size_t i = 0; i < num_nodes; i++) {
 			ccs_expression_t expr;
-			cJSON           *child;
-			size_t           dummy;
-			const char      *cbuf;
-
-			child = cJSON_GetArrayItem(j_nodes, (int)i);
-			CCS_REFUTE_ERR_GOTO(
-				res, !child || !cJSON_IsObject(child),
-				CCS_RESULT_ERROR_INVALID_VALUE, end);
-			dummy = 0;
-			cbuf  = (const char *)child;
 			CCS_VALIDATE_ERR_GOTO(
 				res,
-				_ccs_object_deserialize_with_opts_check(
-					(ccs_object_t *)&expr,
-					CCS_OBJECT_TYPE_EXPRESSION,
-					CCS_SERIALIZE_FORMAT_JSON, version,
-					&dummy, &cbuf, &new_opts),
+				_ccs_json_deserialize_array_object(
+					cJSON_GetArrayItem(j_nodes, (int)i),
+					CCS_OBJECT_TYPE_EXPRESSION, version,
+					(ccs_object_t *)&expr, &new_opts),
 				end);
 			data.nodes[i].type    = CCS_DATA_TYPE_OBJECT;
 			data.nodes[i].value.o = expr;
@@ -430,23 +419,12 @@ _ccs_deserialize_json_expression_user_defined(
 		CCS_REFUTE(!data.nodes, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 		for (size_t i = 0; i < num_nodes; i++) {
 			ccs_expression_t expr;
-			cJSON           *child;
-			size_t           dummy;
-			const char      *cbuf;
-
-			child = cJSON_GetArrayItem(j_nodes, (int)i);
-			CCS_REFUTE_ERR_GOTO(
-				res, !child || !cJSON_IsObject(child),
-				CCS_RESULT_ERROR_INVALID_VALUE, end);
-			dummy = 0;
-			cbuf  = (const char *)child;
 			CCS_VALIDATE_ERR_GOTO(
 				res,
-				_ccs_object_deserialize_with_opts_check(
-					(ccs_object_t *)&expr,
-					CCS_OBJECT_TYPE_EXPRESSION,
-					CCS_SERIALIZE_FORMAT_JSON, version,
-					&dummy, &cbuf, &new_opts),
+				_ccs_json_deserialize_array_object(
+					cJSON_GetArrayItem(j_nodes, (int)i),
+					CCS_OBJECT_TYPE_EXPRESSION, version,
+					(ccs_object_t *)&expr, &new_opts),
 				end);
 			data.nodes[i].type    = CCS_DATA_TYPE_OBJECT;
 			data.nodes[i].value.o = expr;

--- a/src/objective_space_deserialize.h
+++ b/src/objective_space_deserialize.h
@@ -135,26 +135,18 @@ _ccs_deserialize_json_ccs_objective_space_data(
 	cJSON                             *json,
 	_ccs_object_deserialize_options_t *opts)
 {
-	cJSON      *j_ss;
-	cJSON      *j_params;
-	cJSON      *j_objs;
-	size_t      num;
-	size_t      num_objs;
-	uintptr_t   mem;
-	const char *cbuf;
-	size_t      dummy;
+	cJSON    *j_params;
+	cJSON    *j_objs;
+	size_t    num;
+	size_t    num_objs;
+	uintptr_t mem;
 
 	CCS_VALIDATE(_ccs_json_extract_string(json, "name", &data->name));
 
 	/* search_space */
-	j_ss = cJSON_GetObjectItemCaseSensitive(json, "search_space");
-	CCS_REFUTE(
-		!j_ss || !cJSON_IsObject(j_ss), CCS_RESULT_ERROR_INVALID_VALUE);
-	cbuf  = (const char *)j_ss;
-	dummy = 0;
-	CCS_VALIDATE(_ccs_object_deserialize_with_opts(
-		(ccs_object_t *)&data->search_space, CCS_SERIALIZE_FORMAT_JSON,
-		version, &dummy, &cbuf, opts));
+	CCS_VALIDATE(_ccs_json_extract_object_uncheck(
+		json, "search_space", version,
+		(ccs_object_t *)&data->search_space, opts));
 
 	/* parameters */
 	j_params = cJSON_GetObjectItemCaseSensitive(json, "parameters");
@@ -195,30 +187,17 @@ _ccs_deserialize_json_ccs_objective_space_data(
 	data->objective_types =
 		CCS_ALLOC_CARVE_ARRAY(mem, num_objs, ccs_objective_type_t);
 
-	for (size_t i = 0; i < num; i++) {
-		cJSON *child = cJSON_GetArrayItem(j_params, (int)i);
-		cbuf         = (const char *)child;
-		dummy        = 0;
-		CCS_VALIDATE(_ccs_object_deserialize_with_opts_check(
-			(ccs_object_t *)data->parameters + i,
-			CCS_OBJECT_TYPE_PARAMETER, CCS_SERIALIZE_FORMAT_JSON,
-			version, &dummy, &cbuf, opts));
-	}
+	for (size_t i = 0; i < num; i++)
+		CCS_VALIDATE(_ccs_json_deserialize_array_object(
+			cJSON_GetArrayItem(j_params, (int)i),
+			CCS_OBJECT_TYPE_PARAMETER, version,
+			(ccs_object_t *)data->parameters + i, opts));
 
 	for (size_t i = 0; i < num_objs; i++) {
 		cJSON *obj_item = cJSON_GetArrayItem(j_objs, (int)i);
-		cJSON *j_expr;
-		j_expr = cJSON_GetObjectItemCaseSensitive(
-			obj_item, "expression");
-		CCS_REFUTE(
-			!j_expr || !cJSON_IsObject(j_expr),
-			CCS_RESULT_ERROR_INVALID_VALUE);
-		cbuf  = (const char *)j_expr;
-		dummy = 0;
-		CCS_VALIDATE(_ccs_object_deserialize_with_opts_check(
-			(ccs_object_t *)data->objectives + i,
-			CCS_OBJECT_TYPE_EXPRESSION, CCS_SERIALIZE_FORMAT_JSON,
-			version, &dummy, &cbuf, opts));
+		CCS_VALIDATE(_ccs_json_extract_object(
+			obj_item, "expression", CCS_OBJECT_TYPE_EXPRESSION,
+			version, (ccs_object_t *)data->objectives + i, opts));
 		const char *otype_str;
 		CCS_VALIDATE(
 			_ccs_json_extract_string(obj_item, "type", &otype_str));

--- a/src/tree_configuration_deserialize.h
+++ b/src/tree_configuration_deserialize.h
@@ -115,8 +115,6 @@ _ccs_deserialize_json_tree_configuration(
 	ccs_features_t   features = NULL;
 	int              pos_count;
 	int              i;
-	const char      *cbuf;
-	size_t           dummy;
 	const char      *ts_str;
 
 	(void)buffer_size;
@@ -165,18 +163,14 @@ _ccs_deserialize_json_tree_configuration(
 	}
 
 	j_features = cJSON_GetObjectItemCaseSensitive(json, "features");
-	if (j_features && cJSON_IsObject(j_features)) {
+	if (j_features) {
 		_ccs_object_deserialize_options_t feat_opts = *opts;
 		feat_opts.map_values                        = CCS_FALSE;
-		cbuf  = (const char *)j_features;
-		dummy = 0;
 		CCS_VALIDATE_ERR_GOTO(
 			res,
-			_ccs_object_deserialize_with_opts_check(
-				(ccs_object_t *)&features,
-				CCS_OBJECT_TYPE_FEATURES,
-				CCS_SERIALIZE_FORMAT_JSON, version, &dummy,
-				&cbuf, &feat_opts),
+			_ccs_json_extract_object(
+				json, "features", CCS_OBJECT_TYPE_FEATURES,
+				version, (ccs_object_t *)&features, &feat_opts),
 			end);
 	}
 

--- a/src/tree_deserialize.h
+++ b/src/tree_deserialize.h
@@ -115,8 +115,6 @@ _ccs_deserialize_json_tree(
 	_ccs_tree_data_mock_t             data;
 	int                               num_children;
 	int                               i;
-	const char                       *cbuf;
-	size_t                            dummy;
 	ccs_int_t                         arity_val;
 
 	(void)buffer_size;
@@ -152,20 +150,16 @@ _ccs_deserialize_json_tree(
 			end);
 		for (i = 0; i < num_children; i++) {
 			cJSON *child_item = cJSON_GetArrayItem(j_children, i);
-			if (!cJSON_IsNull(child_item)) {
-				cbuf  = (const char *)child_item;
-				dummy = 0;
+			if (!cJSON_IsNull(child_item))
 				CCS_VALIDATE_ERR_GOTO(
 					res,
-					_ccs_object_deserialize_with_opts_check(
+					_ccs_json_deserialize_array_object(
+						child_item,
+						CCS_OBJECT_TYPE_TREE, version,
 						(ccs_object_t *)data.children +
 							i,
-						CCS_OBJECT_TYPE_TREE,
-						CCS_SERIALIZE_FORMAT_JSON,
-						version, &dummy, &cbuf,
 						&new_opts),
 					end);
-			}
 		}
 	}
 

--- a/src/tree_space_deserialize.h
+++ b/src/tree_space_deserialize.h
@@ -201,12 +201,7 @@ _ccs_deserialize_json_ccs_tree_space_common_data(
 	_ccs_object_deserialize_options_t  *opts)
 {
 	_ccs_object_deserialize_options_t new_opts = *opts;
-	cJSON                            *j_rng;
-	cJSON                            *j_tree;
 	cJSON                            *j_fs_handle;
-	cJSON                            *j_fs;
-	const char                       *cbuf;
-	size_t                            dummy;
 	const char                       *type_str;
 
 	new_opts.handle_map = NULL;
@@ -218,25 +213,13 @@ _ccs_deserialize_json_ccs_tree_space_common_data(
 
 	CCS_VALIDATE(_ccs_json_extract_string(json, "name", &data->name));
 
-	j_rng = cJSON_GetObjectItemCaseSensitive(json, "rng");
-	CCS_REFUTE(
-		!j_rng || !cJSON_IsObject(j_rng),
-		CCS_RESULT_ERROR_INVALID_VALUE);
-	cbuf  = (const char *)j_rng;
-	dummy = 0;
-	CCS_VALIDATE(_ccs_object_deserialize_with_opts_check(
-		(ccs_object_t *)&data->rng, CCS_OBJECT_TYPE_RNG,
-		CCS_SERIALIZE_FORMAT_JSON, version, &dummy, &cbuf, &new_opts));
+	CCS_VALIDATE(_ccs_json_extract_object(
+		json, "rng", CCS_OBJECT_TYPE_RNG, version,
+		(ccs_object_t *)&data->rng, &new_opts));
 
-	j_tree = cJSON_GetObjectItemCaseSensitive(json, "tree");
-	CCS_REFUTE(
-		!j_tree || !cJSON_IsObject(j_tree),
-		CCS_RESULT_ERROR_INVALID_VALUE);
-	cbuf  = (const char *)j_tree;
-	dummy = 0;
-	CCS_VALIDATE(_ccs_object_deserialize_with_opts_check(
-		(ccs_object_t *)&data->tree, CCS_OBJECT_TYPE_TREE,
-		CCS_SERIALIZE_FORMAT_JSON, version, &dummy, &cbuf, &new_opts));
+	CCS_VALIDATE(_ccs_json_extract_object(
+		json, "tree", CCS_OBJECT_TYPE_TREE, version,
+		(ccs_object_t *)&data->tree, &new_opts));
 
 	j_fs_handle =
 		cJSON_GetObjectItemCaseSensitive(json, "feature_space_handle");
@@ -251,17 +234,9 @@ _ccs_deserialize_json_ccs_tree_space_common_data(
 				fs_handle_str, sizeof(ccs_object_t) * 2,
 				&data->feature_space_handle),
 			CCS_RESULT_ERROR_INVALID_VALUE);
-		j_fs = cJSON_GetObjectItemCaseSensitive(json, "feature_space");
-		CCS_REFUTE(
-			!j_fs || !cJSON_IsObject(j_fs),
-			CCS_RESULT_ERROR_INVALID_VALUE);
-		cbuf  = (const char *)j_fs;
-		dummy = 0;
-		CCS_VALIDATE(_ccs_object_deserialize_with_opts_check(
-			(ccs_object_t *)&data->feature_space,
-			CCS_OBJECT_TYPE_FEATURE_SPACE,
-			CCS_SERIALIZE_FORMAT_JSON, version, &dummy, &cbuf,
-			opts));
+		CCS_VALIDATE(_ccs_json_extract_object(
+			json, "feature_space", CCS_OBJECT_TYPE_FEATURE_SPACE,
+			version, (ccs_object_t *)&data->feature_space, opts));
 	}
 
 	return CCS_RESULT_SUCCESS;

--- a/src/tuner_deserialize.h
+++ b/src/tuner_deserialize.h
@@ -228,25 +228,17 @@ _ccs_deserialize_json_ccs_random_tuner_data(
 	cJSON                             *json,
 	_ccs_object_deserialize_options_t *opts)
 {
-	cJSON      *j_os;
-	cJSON      *j_history;
-	cJSON      *j_optima;
-	const char *cbuf;
-	size_t      dummy;
+	cJSON *j_history;
+	cJSON *j_optima;
 
 	CCS_VALIDATE(_ccs_json_extract_string(
 		json, "name", &data->common_data.name));
 
 	/* objective_space (inlined) */
-	j_os = cJSON_GetObjectItemCaseSensitive(json, "objective_space");
-	CCS_REFUTE(
-		!j_os || !cJSON_IsObject(j_os), CCS_RESULT_ERROR_INVALID_VALUE);
-	cbuf  = (const char *)j_os;
-	dummy = 0;
-	CCS_VALIDATE(_ccs_object_deserialize_with_opts_check(
-		(ccs_object_t *)&data->common_data.objective_space,
-		CCS_OBJECT_TYPE_OBJECTIVE_SPACE, CCS_SERIALIZE_FORMAT_JSON,
-		version, &dummy, &cbuf, opts));
+	CCS_VALIDATE(_ccs_json_extract_object(
+		json, "objective_space", CCS_OBJECT_TYPE_OBJECTIVE_SPACE,
+		version, (ccs_object_t *)&data->common_data.objective_space,
+		opts));
 
 	/* history */
 	j_history = cJSON_GetObjectItemCaseSensitive(json, "history");
@@ -270,15 +262,11 @@ _ccs_deserialize_json_ccs_random_tuner_data(
 	CCS_REFUTE(!data->history, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	data->optima = data->history + data->history_size;
 
-	for (size_t i = 0; i < data->history_size; i++) {
-		cJSON *child = cJSON_GetArrayItem(j_history, (int)i);
-		cbuf         = (const char *)child;
-		dummy        = 0;
-		CCS_VALIDATE(_ccs_object_deserialize_with_opts_check(
-			(ccs_object_t *)data->history + i,
-			CCS_OBJECT_TYPE_EVALUATION, CCS_SERIALIZE_FORMAT_JSON,
-			version, &dummy, &cbuf, opts));
-	}
+	for (size_t i = 0; i < data->history_size; i++)
+		CCS_VALIDATE(_ccs_json_deserialize_array_object(
+			cJSON_GetArrayItem(j_history, (int)i),
+			CCS_OBJECT_TYPE_EVALUATION, version,
+			(ccs_object_t *)data->history + i, opts));
 
 	for (size_t i = 0; i < data->size_optima; i++) {
 		cJSON      *child = cJSON_GetArrayItem(j_optima, (int)i);


### PR DESCRIPTION
## Summary

Add three helpers to `cconfigspace_deserialize.h` that eliminate the recurring 5-line boilerplate for recursive JSON object deserialization:

- `_ccs_json_extract_object(json, key, expected_type, version, object_ret, opts)` — lookup + IsObject check + deserialize with type check
- `_ccs_json_extract_object_uncheck(json, key, version, object_ret, opts)` — same without type check (for polymorphic fields like search_space)
- `_ccs_json_deserialize_array_object(item, expected_type, version, object_ret, opts)` — for array items

Replace boilerplate across 12 deserializer files, removing 72 lines net. Eliminated intermediate `cJSON *`, `cbuf`, and `dummy` variables throughout.

## Test plan

- [x] All 30 tests pass
- [x] Builds clean with gcc, g++, clang

🤖 Generated with [Claude Code](https://claude.com/claude-code)