### PR TITLE
Add JSON embed helpers for serialize-side object nesting

### DIFF
--- a/src/cconfigspace_internal.h
+++ b/src/cconfigspace_internal.h
@@ -1724,4 +1724,42 @@ _ccs_object_serialize_with_opts(
 
 #include "cconfigspace_json.h"
 
+/*============================================================================
+ * JSON embed helpers (serialize a child object into a cJSON parent)
+ *============================================================================*/
+
+/* Embed a child object under a named key in a JSON object. */
+static inline ccs_result_t
+_ccs_json_embed_object(
+	cJSON                           *json,
+	const char                      *key,
+	ccs_object_t                     object,
+	_ccs_object_serialize_options_t *opts)
+{
+	size_t dummy = 0;
+	cJSON *child = cJSON_AddObjectToObject(json, key);
+	CCS_REFUTE(!child, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	CCS_VALIDATE(_ccs_object_serialize_with_opts(
+		object, CCS_SERIALIZE_FORMAT_JSON, &dummy, (char **)&child,
+		opts));
+	return CCS_RESULT_SUCCESS;
+}
+
+/* Append a child object to a JSON array. */
+static inline ccs_result_t
+_ccs_json_embed_array_object(
+	cJSON                           *array,
+	ccs_object_t                     object,
+	_ccs_object_serialize_options_t *opts)
+{
+	size_t dummy = 0;
+	cJSON *child = cJSON_CreateObject();
+	CCS_REFUTE(!child, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	cJSON_AddItemToArray(array, child);
+	CCS_VALIDATE(_ccs_object_serialize_with_opts(
+		object, CCS_SERIALIZE_FORMAT_JSON, &dummy, (char **)&child,
+		opts));
+	return CCS_RESULT_SUCCESS;
+}
+
 #endif //_CONFIGSPACE_INTERNAL_H

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -79,18 +79,13 @@ _ccs_serialize_json_ccs_configuration(
 	cJSON                           *json,
 	_ccs_object_serialize_options_t *opts)
 {
-	_ccs_configuration_data_t *data  = configuration->data;
-	size_t                     dummy = 0;
+	_ccs_configuration_data_t *data = configuration->data;
 
 	CCS_VALIDATE(_ccs_serialize_json_ccs_binding(
 		(ccs_binding_t)configuration, json));
-	if (data->features) {
-		cJSON *feat = cJSON_AddObjectToObject(json, "features");
-		CCS_REFUTE(!feat, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		CCS_VALIDATE(_ccs_object_serialize_with_opts(
-			data->features, CCS_SERIALIZE_FORMAT_JSON, &dummy,
-			(char **)&feat, opts));
-	}
+	if (data->features)
+		CCS_VALIDATE(_ccs_json_embed_object(
+			json, "features", data->features, opts));
 	return CCS_RESULT_SUCCESS;
 }
 

--- a/src/configuration_space.c
+++ b/src/configuration_space.c
@@ -207,40 +207,24 @@ _ccs_serialize_json_ccs_configuration_space(
 {
 	_ccs_configuration_space_data_t *data =
 		(_ccs_configuration_space_data_t *)(configuration_space->data);
-	size_t dummy = 0;
 
 	CCS_VALIDATE(_ccs_json_add_string(json, "name", data->name));
 
 	/* feature space (optional) */
-	if (data->feature_space) {
-		cJSON *fs = cJSON_AddObjectToObject(json, "feature_space");
-		CCS_REFUTE(!fs, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		CCS_VALIDATE(_ccs_object_serialize_with_opts(
-			data->feature_space, CCS_SERIALIZE_FORMAT_JSON, &dummy,
-			(char **)&fs, opts));
-	}
+	if (data->feature_space)
+		CCS_VALIDATE(_ccs_json_embed_object(
+			json, "feature_space", data->feature_space, opts));
 
 	/* rng */
-	{
-		cJSON *rng_node = cJSON_AddObjectToObject(json, "rng");
-		CCS_REFUTE(!rng_node, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		CCS_VALIDATE(_ccs_object_serialize_with_opts(
-			data->rng, CCS_SERIALIZE_FORMAT_JSON, &dummy,
-			(char **)&rng_node, opts));
-	}
+	CCS_VALIDATE(_ccs_json_embed_object(json, "rng", data->rng, opts));
 
 	/* parameters */
 	{
 		cJSON *params = cJSON_AddArrayToObject(json, "parameters");
 		CCS_REFUTE(!params, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		for (size_t i = 0; i < data->num_parameters; i++) {
-			cJSON *child = cJSON_CreateObject();
-			CCS_REFUTE(!child, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-			cJSON_AddItemToArray(params, child);
-			CCS_VALIDATE(_ccs_object_serialize_with_opts(
-				data->parameters[i], CCS_SERIALIZE_FORMAT_JSON,
-				&dummy, (char **)&child, opts));
-		}
+		for (size_t i = 0; i < data->num_parameters; i++)
+			CCS_VALIDATE(_ccs_json_embed_array_object(
+				params, data->parameters[i], opts));
 	}
 
 	/* conditions -- array of {index, expression} */
@@ -250,20 +234,14 @@ _ccs_serialize_json_ccs_configuration_space(
 		for (size_t i = 0; i < data->num_parameters; i++) {
 			if (data->conditions[i]) {
 				cJSON *cond = cJSON_CreateObject();
-				cJSON *expr;
 				CCS_REFUTE(
 					!cond, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 				cJSON_AddItemToArray(conds, cond);
 				CCS_VALIDATE(_ccs_json_add_int(
 					cond, "index", (ccs_int_t)i));
-				expr = cJSON_AddObjectToObject(
-					cond, "expression");
-				CCS_REFUTE(
-					!expr, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-				CCS_VALIDATE(_ccs_object_serialize_with_opts(
-					data->conditions[i],
-					CCS_SERIALIZE_FORMAT_JSON, &dummy,
-					(char **)&expr, opts));
+				CCS_VALIDATE(_ccs_json_embed_object(
+					cond, "expression", data->conditions[i],
+					opts));
 			}
 		}
 	}
@@ -273,15 +251,9 @@ _ccs_serialize_json_ccs_configuration_space(
 		cJSON *forbids =
 			cJSON_AddArrayToObject(json, "forbidden_clauses");
 		CCS_REFUTE(!forbids, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		for (size_t i = 0; i < data->num_forbidden_clauses; i++) {
-			cJSON *child = cJSON_CreateObject();
-			CCS_REFUTE(!child, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-			cJSON_AddItemToArray(forbids, child);
-			CCS_VALIDATE(_ccs_object_serialize_with_opts(
-				data->forbidden_clauses[i],
-				CCS_SERIALIZE_FORMAT_JSON, &dummy,
-				(char **)&child, opts));
-		}
+		for (size_t i = 0; i < data->num_forbidden_clauses; i++)
+			CCS_VALIDATE(_ccs_json_embed_array_object(
+				forbids, data->forbidden_clauses[i], opts));
 	}
 
 	return CCS_RESULT_SUCCESS;

--- a/src/context_internal.h
+++ b/src/context_internal.h
@@ -313,15 +313,9 @@ _ccs_serialize_json_ccs_context(
 	CCS_VALIDATE(_ccs_json_add_string(json, "name", data->name));
 	cJSON *parameters = cJSON_AddArrayToObject(json, "parameters");
 	CCS_REFUTE(!parameters, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-	for (size_t i = 0; i < data->num_parameters; i++) {
-		cJSON *child = cJSON_CreateObject();
-		CCS_REFUTE(!child, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		cJSON_AddItemToArray(parameters, child);
-		size_t dummy = 0;
-		CCS_VALIDATE(_ccs_object_serialize_with_opts(
-			data->parameters[i], CCS_SERIALIZE_FORMAT_JSON, &dummy,
-			(char **)&child, opts));
-	}
+	for (size_t i = 0; i < data->num_parameters; i++)
+		CCS_VALIDATE(_ccs_json_embed_array_object(
+			parameters, data->parameters[i], opts));
 	return CCS_RESULT_SUCCESS;
 }
 

--- a/src/distribution_mixture.c
+++ b/src/distribution_mixture.c
@@ -118,15 +118,9 @@ _ccs_serialize_json_ccs_distribution_mixture(
 	}
 	cJSON *distributions = cJSON_AddArrayToObject(json, "distributions");
 	CCS_REFUTE(!distributions, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-	for (size_t i = 0; i < data->num_distributions; i++) {
-		cJSON *child = cJSON_CreateObject();
-		CCS_REFUTE(!child, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		cJSON_AddItemToArray(distributions, child);
-		size_t dummy = 0;
-		CCS_VALIDATE(_ccs_object_serialize_with_opts(
-			data->distributions[i], CCS_SERIALIZE_FORMAT_JSON,
-			&dummy, (char **)&child, opts));
-	}
+	for (size_t i = 0; i < data->num_distributions; i++)
+		CCS_VALIDATE(_ccs_json_embed_array_object(
+			distributions, data->distributions[i], opts));
 	return CCS_RESULT_SUCCESS;
 }
 

--- a/src/distribution_multivariate.c
+++ b/src/distribution_multivariate.c
@@ -101,15 +101,9 @@ _ccs_serialize_json_ccs_distribution_multivariate(
 		json, "distribution_type", "multivariate"));
 	cJSON *distributions = cJSON_AddArrayToObject(json, "distributions");
 	CCS_REFUTE(!distributions, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-	for (size_t i = 0; i < data->num_distributions; i++) {
-		cJSON *child = cJSON_CreateObject();
-		CCS_REFUTE(!child, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		cJSON_AddItemToArray(distributions, child);
-		size_t dummy = 0;
-		CCS_VALIDATE(_ccs_object_serialize_with_opts(
-			data->distributions[i], CCS_SERIALIZE_FORMAT_JSON,
-			&dummy, (char **)&child, opts));
-	}
+	for (size_t i = 0; i < data->num_distributions; i++)
+		CCS_VALIDATE(_ccs_json_embed_array_object(
+			distributions, data->distributions[i], opts));
 	return CCS_RESULT_SUCCESS;
 }
 

--- a/src/distribution_space.c
+++ b/src/distribution_space.c
@@ -114,7 +114,6 @@ _ccs_serialize_json_ccs_distribution_space(
 	_ccs_distribution_space_data_t *data = distribution_space->data;
 	_ccs_distribution_wrapper_t    *dw;
 	char                            hex[sizeof(ccs_object_t) * 2 + 1];
-	size_t                          dummy = 0;
 
 	_ccs_json_hex_encode_buf(
 		&data->configuration_space, sizeof(ccs_object_t), hex);
@@ -132,12 +131,8 @@ _ccs_serialize_json_ccs_distribution_space(
 			!cJSON_AddItemToArray(distribs, entry),
 			CCS_RESULT_ERROR_OUT_OF_MEMORY);
 
-		cJSON *dist_obj =
-			cJSON_AddObjectToObject(entry, "distribution");
-		CCS_REFUTE(!dist_obj, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		CCS_VALIDATE(_ccs_object_serialize_with_opts(
-			dw->distribution, CCS_SERIALIZE_FORMAT_JSON, &dummy,
-			(char **)&dist_obj, opts));
+		CCS_VALIDATE(_ccs_json_embed_object(
+			entry, "distribution", dw->distribution, opts));
 
 		cJSON *indices =
 			cJSON_AddArrayToObject(entry, "parameter_indices");

--- a/src/evaluation.c
+++ b/src/evaluation.c
@@ -83,20 +83,14 @@ _ccs_serialize_json_ccs_evaluation(
 	cJSON                           *json,
 	_ccs_object_serialize_options_t *opts)
 {
-	_ccs_evaluation_data_t *data  = evaluation->data;
-	size_t                  dummy = 0;
+	_ccs_evaluation_data_t *data = evaluation->data;
 
 	CCS_VALIDATE(_ccs_serialize_json_ccs_binding(
 		(ccs_binding_t)evaluation, json));
 
 	/* configuration */
-	{
-		cJSON *conf = cJSON_AddObjectToObject(json, "configuration");
-		CCS_REFUTE(!conf, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		CCS_VALIDATE(_ccs_object_serialize_with_opts(
-			data->configuration, CCS_SERIALIZE_FORMAT_JSON, &dummy,
-			(char **)&conf, opts));
-	}
+	CCS_VALIDATE(_ccs_json_embed_object(
+		json, "configuration", data->configuration, opts));
 
 	/* result */
 	CCS_VALIDATE(

--- a/src/expression.c
+++ b/src/expression.c
@@ -178,15 +178,9 @@ _ccs_serialize_json_ccs_expression(
 		_ccs_json_expression_type_to_string(data->type)));
 	cJSON *nodes = cJSON_AddArrayToObject(json, "nodes");
 	CCS_REFUTE(!nodes, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-	for (size_t i = 0; i < data->num_nodes; i++) {
-		cJSON *child = cJSON_CreateObject();
-		CCS_REFUTE(!child, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		cJSON_AddItemToArray(nodes, child);
-		size_t dummy = 0;
-		CCS_VALIDATE(_ccs_object_serialize_with_opts(
-			data->nodes[i], CCS_SERIALIZE_FORMAT_JSON, &dummy,
-			(char **)&child, opts));
-	}
+	for (size_t i = 0; i < data->num_nodes; i++)
+		CCS_VALIDATE(_ccs_json_embed_array_object(
+			nodes, data->nodes[i], opts));
 	return CCS_RESULT_SUCCESS;
 }
 
@@ -1448,15 +1442,9 @@ _ccs_serialize_json_ccs_expression_user_defined(
 	/* serialize child nodes */
 	cJSON *nodes = cJSON_AddArrayToObject(json, "nodes");
 	CCS_REFUTE(!nodes, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-	for (size_t i = 0; i < data->expr.num_nodes; i++) {
-		cJSON *child = cJSON_CreateObject();
-		CCS_REFUTE(!child, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		cJSON_AddItemToArray(nodes, child);
-		size_t dummy = 0;
-		CCS_VALIDATE(_ccs_object_serialize_with_opts(
-			data->expr.nodes[i], CCS_SERIALIZE_FORMAT_JSON, &dummy,
-			(char **)&child, opts));
-	}
+	for (size_t i = 0; i < data->expr.num_nodes; i++)
+		CCS_VALIDATE(_ccs_json_embed_array_object(
+			nodes, data->expr.nodes[i], opts));
 	/* serialize user state */
 	size_t state_size = 0;
 	if (data->vector.serialize_user_state) {

--- a/src/objective_space.c
+++ b/src/objective_space.c
@@ -150,31 +150,20 @@ _ccs_serialize_json_ccs_objective_space(
 {
 	_ccs_objective_space_data_t *data =
 		(_ccs_objective_space_data_t *)(objective_space->data);
-	size_t dummy = 0;
 
 	CCS_VALIDATE(_ccs_json_add_string(json, "name", data->name));
 
 	/* search_space (embedded) */
-	{
-		cJSON *ss = cJSON_AddObjectToObject(json, "search_space");
-		CCS_REFUTE(!ss, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		CCS_VALIDATE(_ccs_object_serialize_with_opts(
-			data->search_space, CCS_SERIALIZE_FORMAT_JSON, &dummy,
-			(char **)&ss, opts));
-	}
+	CCS_VALIDATE(_ccs_json_embed_object(
+		json, "search_space", data->search_space, opts));
 
 	/* parameters */
 	{
 		cJSON *params = cJSON_AddArrayToObject(json, "parameters");
 		CCS_REFUTE(!params, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		for (size_t i = 0; i < data->num_parameters; i++) {
-			cJSON *child = cJSON_CreateObject();
-			CCS_REFUTE(!child, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-			cJSON_AddItemToArray(params, child);
-			CCS_VALIDATE(_ccs_object_serialize_with_opts(
-				data->parameters[i], CCS_SERIALIZE_FORMAT_JSON,
-				&dummy, (char **)&child, opts));
-		}
+		for (size_t i = 0; i < data->num_parameters; i++)
+			CCS_VALIDATE(_ccs_json_embed_array_object(
+				params, data->parameters[i], opts));
 	}
 
 	/* objectives: expression + type */
@@ -185,13 +174,9 @@ _ccs_serialize_json_ccs_objective_space(
 			cJSON *obj = cJSON_CreateObject();
 			CCS_REFUTE(!obj, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 			cJSON_AddItemToArray(objs, obj);
-			cJSON *expr =
-				cJSON_AddObjectToObject(obj, "expression");
-			CCS_REFUTE(!expr, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-			CCS_VALIDATE(_ccs_object_serialize_with_opts(
-				data->objectives[i].expression,
-				CCS_SERIALIZE_FORMAT_JSON, &dummy,
-				(char **)&expr, opts));
+			CCS_VALIDATE(_ccs_json_embed_object(
+				obj, "expression",
+				data->objectives[i].expression, opts));
 			CCS_VALIDATE(_ccs_json_add_string(
 				obj, "type",
 				_ccs_json_objective_type_to_string(

--- a/src/tree.c
+++ b/src/tree.c
@@ -92,8 +92,7 @@ _ccs_serialize_json_ccs_tree(
 	cJSON                           *json,
 	_ccs_object_serialize_options_t *opts)
 {
-	_ccs_tree_data_t *data  = tree->data;
-	size_t            dummy = 0;
+	_ccs_tree_data_t *data = tree->data;
 	cJSON            *children;
 	size_t            i;
 
@@ -107,13 +106,8 @@ _ccs_serialize_json_ccs_tree(
 	CCS_REFUTE(!children, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	for (i = 0; i < data->arity; i++) {
 		if (data->children[i]) {
-			cJSON *child = cJSON_CreateObject();
-			CCS_REFUTE(!child, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-			cJSON_AddItemToArray(children, child);
-			dummy = 0;
-			CCS_VALIDATE(_ccs_object_serialize_with_opts(
-				data->children[i], CCS_SERIALIZE_FORMAT_JSON,
-				&dummy, (char **)&child, opts));
+			CCS_VALIDATE(_ccs_json_embed_array_object(
+				children, data->children[i], opts));
 		} else {
 			cJSON_AddItemToArray(children, cJSON_CreateNull());
 		}

--- a/src/tree_configuration.c
+++ b/src/tree_configuration.c
@@ -90,7 +90,6 @@ _ccs_serialize_json_ccs_tree_configuration(
 	_ccs_tree_configuration_data_t *data = tree_configuration->data;
 	char                            hex[sizeof(ccs_object_t) * 2 + 1];
 	cJSON                          *positions;
-	size_t                          dummy = 0;
 	size_t                          i;
 
 	_ccs_json_hex_encode_buf(&data->tree_space, sizeof(ccs_object_t), hex);
@@ -107,14 +106,9 @@ _ccs_serialize_json_ccs_tree_configuration(
 			CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	}
 
-	if (data->features) {
-		cJSON *feat = cJSON_AddObjectToObject(json, "features");
-		CCS_REFUTE(!feat, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		dummy = 0;
-		CCS_VALIDATE(_ccs_object_serialize_with_opts(
-			data->features, CCS_SERIALIZE_FORMAT_JSON, &dummy,
-			(char **)&feat, opts));
-	}
+	if (data->features)
+		CCS_VALIDATE(_ccs_json_embed_object(
+			json, "features", data->features, opts));
 
 	return CCS_RESULT_SUCCESS;
 }

--- a/src/tree_space_internal.h
+++ b/src/tree_space_internal.h
@@ -108,43 +108,25 @@ _ccs_serialize_json_ccs_tree_space_common_data(
 	_ccs_object_serialize_options_t *opts)
 {
 	const char *type_str;
-	cJSON      *rng_node;
-	cJSON      *tree_node;
-	size_t      dummy = 0;
 
-	type_str          = _ccs_json_tree_space_type_to_string(data->type);
+	type_str = _ccs_json_tree_space_type_to_string(data->type);
 	CCS_REFUTE(!type_str, CCS_RESULT_ERROR_INVALID_VALUE);
 	CCS_VALIDATE(_ccs_json_add_string(json, "tree_space_type", type_str));
 
 	CCS_VALIDATE(_ccs_json_add_string(json, "name", data->name));
 
-	rng_node = cJSON_AddObjectToObject(json, "rng");
-	CCS_REFUTE(!rng_node, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-	dummy = 0;
-	CCS_VALIDATE(_ccs_object_serialize_with_opts(
-		data->rng, CCS_SERIALIZE_FORMAT_JSON, &dummy,
-		(char **)&rng_node, opts));
+	CCS_VALIDATE(_ccs_json_embed_object(json, "rng", data->rng, opts));
 
-	tree_node = cJSON_AddObjectToObject(json, "tree");
-	CCS_REFUTE(!tree_node, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-	dummy = 0;
-	CCS_VALIDATE(_ccs_object_serialize_with_opts(
-		data->tree, CCS_SERIALIZE_FORMAT_JSON, &dummy,
-		(char **)&tree_node, opts));
+	CCS_VALIDATE(_ccs_json_embed_object(json, "tree", data->tree, opts));
 
 	if (data->feature_space) {
-		char   hex[sizeof(ccs_object_t) * 2 + 1];
-		cJSON *fs_node;
+		char hex[sizeof(ccs_object_t) * 2 + 1];
 		_ccs_json_hex_encode_buf(
 			&data->feature_space, sizeof(ccs_object_t), hex);
 		CCS_VALIDATE(_ccs_json_add_string(
 			json, "feature_space_handle", hex));
-		fs_node = cJSON_AddObjectToObject(json, "feature_space");
-		CCS_REFUTE(!fs_node, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		dummy = 0;
-		CCS_VALIDATE(_ccs_object_serialize_with_opts(
-			data->feature_space, CCS_SERIALIZE_FORMAT_JSON, &dummy,
-			(char **)&fs_node, opts));
+		CCS_VALIDATE(_ccs_json_embed_object(
+			json, "feature_space", data->feature_space, opts));
 	}
 
 	return CCS_RESULT_SUCCESS;

--- a/src/tuner_random.c
+++ b/src/tuner_random.c
@@ -160,7 +160,6 @@ _ccs_serialize_json_ccs_random_tuner(
 	_ccs_random_tuner_data_t *data =
 		(_ccs_random_tuner_data_t *)(tuner->data);
 	_ccs_hash_features_t *cur, *tmp;
-	size_t                dummy = 0;
 
 	/* tuner type + name */
 	CCS_VALIDATE(_ccs_json_add_string(json, "tuner_type", "random"));
@@ -168,13 +167,9 @@ _ccs_serialize_json_ccs_random_tuner(
 		_ccs_json_add_string(json, "name", data->common_data.name));
 
 	/* objective_space (inlined) */
-	{
-		cJSON *os = cJSON_AddObjectToObject(json, "objective_space");
-		CCS_REFUTE(!os, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		CCS_VALIDATE(_ccs_object_serialize_with_opts(
-			data->common_data.objective_space,
-			CCS_SERIALIZE_FORMAT_JSON, &dummy, (char **)&os, opts));
-	}
+	CCS_VALIDATE(_ccs_json_embed_object(
+		json, "objective_space", data->common_data.objective_space,
+		opts));
 
 	/* history (inlined evaluations) */
 	{
@@ -184,18 +179,9 @@ _ccs_serialize_json_ccs_random_tuner(
 		{
 			ccs_evaluation_t *e = NULL;
 			while ((e = (ccs_evaluation_t *)utarray_next(
-					cur->history, e))) {
-				cJSON *eval_obj = cJSON_CreateObject();
-				CCS_REFUTE(
-					!eval_obj,
-					CCS_RESULT_ERROR_OUT_OF_MEMORY);
-				CCS_REFUTE(
-					!cJSON_AddItemToArray(history, eval_obj),
-					CCS_RESULT_ERROR_OUT_OF_MEMORY);
-				CCS_VALIDATE(_ccs_object_serialize_with_opts(
-					*e, CCS_SERIALIZE_FORMAT_JSON, &dummy,
-					(char **)&eval_obj, opts));
-			}
+					cur->history, e)))
+				CCS_VALIDATE(_ccs_json_embed_array_object(
+					history, *e, opts));
 		}
 	}
 

--- a/src/tuner_user_defined.c
+++ b/src/tuner_user_defined.c
@@ -192,7 +192,6 @@ _ccs_serialize_json_ccs_user_defined_tuner(
 	size_t            history_size = 0;
 	size_t            num_optima   = 0;
 	size_t            state_size   = 0;
-	size_t            dummy        = 0;
 	ccs_evaluation_t *history      = NULL;
 	ccs_evaluation_t *optima       = NULL;
 
@@ -202,13 +201,9 @@ _ccs_serialize_json_ccs_user_defined_tuner(
 		_ccs_json_add_string(json, "name", data->common_data.name));
 
 	/* objective_space (inlined) */
-	{
-		cJSON *os = cJSON_AddObjectToObject(json, "objective_space");
-		CCS_REFUTE(!os, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		CCS_VALIDATE(_ccs_object_serialize_with_opts(
-			data->common_data.objective_space,
-			CCS_SERIALIZE_FORMAT_JSON, &dummy, (char **)&os, opts));
-	}
+	CCS_VALIDATE(_ccs_json_embed_object(
+		json, "objective_space", data->common_data.objective_space,
+		opts));
 
 	CCS_VALIDATE(
 		data->vector.get_history(tuner, NULL, 0, NULL, &history_size));
@@ -239,21 +234,12 @@ _ccs_serialize_json_ccs_user_defined_tuner(
 		cJSON *j_history = cJSON_AddArrayToObject(json, "history");
 		CCS_REFUTE_ERR_GOTO(
 			res, !j_history, CCS_RESULT_ERROR_OUT_OF_MEMORY, end);
-		for (size_t i = 0; i < history_size; i++) {
-			cJSON *eval_obj = cJSON_CreateObject();
-			CCS_REFUTE_ERR_GOTO(
-				res, !eval_obj, CCS_RESULT_ERROR_OUT_OF_MEMORY,
-				end);
-			CCS_REFUTE_ERR_GOTO(
-				res, !cJSON_AddItemToArray(j_history, eval_obj),
-				CCS_RESULT_ERROR_OUT_OF_MEMORY, end);
+		for (size_t i = 0; i < history_size; i++)
 			CCS_VALIDATE_ERR_GOTO(
 				res,
-				_ccs_object_serialize_with_opts(
-					history[i], CCS_SERIALIZE_FORMAT_JSON,
-					&dummy, (char **)&eval_obj, opts),
+				_ccs_json_embed_array_object(
+					j_history, history[i], opts),
 				end);
-		}
 	}
 
 	/* optima (handles) */


### PR DESCRIPTION
## Summary
- Introduce `_ccs_json_embed_object` and `_ccs_json_embed_array_object` helpers in `cconfigspace_internal.h`
- Replace repetitive serialize-side boilerplate (create object/array item, serialize into it) across 14 files
- Net reduction of 109 lines; serialize-side counterpart to the extract helpers from #105

## Test plan
- [x] All 30 tests pass with gcc, g++, and clang (`--enable-strict`)
- [x] No formatting regressions in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)