### PR TITLE
Add JSON array helpers, update all call sites

### DIFF
--- a/src/binding_internal.h
+++ b/src/binding_internal.h
@@ -174,9 +174,9 @@ _ccs_serialize_json_ccs_binding(ccs_binding_t binding, cJSON *json)
 {
 	_ccs_binding_data_t *data = binding->data;
 	char                 hex[sizeof(ccs_object_t) * 2 + 1];
+	cJSON               *values;
 	_ccs_json_hex_encode_buf(&data->context, sizeof(ccs_object_t), hex);
 	CCS_VALIDATE(_ccs_json_add_string(json, "context", hex));
-	cJSON *values;
 	CCS_VALIDATE(_ccs_json_add_array(json, "values", &values));
 	for (size_t i = 0; i < data->num_values; i++)
 		CCS_VALIDATE(

--- a/src/binding_internal.h
+++ b/src/binding_internal.h
@@ -176,8 +176,8 @@ _ccs_serialize_json_ccs_binding(ccs_binding_t binding, cJSON *json)
 	char                 hex[sizeof(ccs_object_t) * 2 + 1];
 	_ccs_json_hex_encode_buf(&data->context, sizeof(ccs_object_t), hex);
 	CCS_VALIDATE(_ccs_json_add_string(json, "context", hex));
-	cJSON *values = cJSON_AddArrayToObject(json, "values");
-	CCS_REFUTE(!values, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	cJSON *values;
+	CCS_VALIDATE(_ccs_json_add_array(json, "values", &values));
 	for (size_t i = 0; i < data->num_values; i++)
 		CCS_VALIDATE(
 			_ccs_json_add_datum_to_array(values, data->values[i]));
@@ -229,15 +229,13 @@ static inline ccs_result_t
 _ccs_deserialize_json_ccs_binding_data(_ccs_binding_data_t *data, cJSON *json)
 {
 	size_t      num;
-	cJSON      *j_values = cJSON_GetObjectItemCaseSensitive(json, "values");
+	cJSON      *j_values;
 	const char *context_str;
 	data->context    = NULL;
 	data->num_values = 0;
 	data->values     = NULL;
 	CCS_VALIDATE(_ccs_json_extract_string(json, "context", &context_str));
-	CCS_REFUTE(
-		!j_values || !cJSON_IsArray(j_values),
-		CCS_RESULT_ERROR_INVALID_VALUE);
+	CCS_VALIDATE(_ccs_json_extract_array(json, "values", &j_values, &num));
 	CCS_REFUTE(
 		strlen(context_str) != sizeof(ccs_object_t) * 2,
 		CCS_RESULT_ERROR_INVALID_VALUE);
@@ -245,7 +243,6 @@ _ccs_deserialize_json_ccs_binding_data(_ccs_binding_data_t *data, cJSON *json)
 		_ccs_json_hex_decode_buf(
 			context_str, sizeof(ccs_object_t) * 2, &data->context),
 		CCS_RESULT_ERROR_INVALID_VALUE);
-	num              = (size_t)cJSON_GetArraySize(j_values);
 	data->num_values = num;
 	if (num) {
 		data->values = (ccs_datum_t *)calloc(num, sizeof(ccs_datum_t));

--- a/src/cconfigspace_json.h
+++ b/src/cconfigspace_json.h
@@ -567,6 +567,35 @@ _ccs_json_extract_datum(cJSON *json, const char *key, ccs_datum_t *value_ret)
 }
 
 /*============================================================================
+ * Array JSON helpers
+ *============================================================================*/
+
+/* Add an array to a JSON object and return a pointer to it. */
+static inline ccs_result_t
+_ccs_json_add_array(cJSON *json, const char *key, cJSON **array_ret)
+{
+	*array_ret = cJSON_AddArrayToObject(json, key);
+	CCS_REFUTE(!*array_ret, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	return CCS_RESULT_SUCCESS;
+}
+
+/* Look up an array by key in a JSON object and return it with its size. */
+static inline ccs_result_t
+_ccs_json_extract_array(
+	cJSON      *json,
+	const char *key,
+	cJSON     **array_ret,
+	size_t     *count_ret)
+{
+	cJSON *item = cJSON_GetObjectItemCaseSensitive(json, key);
+	CCS_REFUTE(
+		!item || !cJSON_IsArray(item), CCS_RESULT_ERROR_INVALID_VALUE);
+	*array_ret = item;
+	*count_ret = (size_t)cJSON_GetArraySize(item);
+	return CCS_RESULT_SUCCESS;
+}
+
+/*============================================================================
  * ccs_datum_t JSON helpers
  *============================================================================*/
 

--- a/src/configuration_space.c
+++ b/src/configuration_space.c
@@ -220,8 +220,8 @@ _ccs_serialize_json_ccs_configuration_space(
 
 	/* parameters */
 	{
-		cJSON *params = cJSON_AddArrayToObject(json, "parameters");
-		CCS_REFUTE(!params, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		cJSON *params;
+		CCS_VALIDATE(_ccs_json_add_array(json, "parameters", &params));
 		for (size_t i = 0; i < data->num_parameters; i++)
 			CCS_VALIDATE(_ccs_json_embed_array_object(
 				params, data->parameters[i], opts));
@@ -229,8 +229,8 @@ _ccs_serialize_json_ccs_configuration_space(
 
 	/* conditions -- array of {index, expression} */
 	{
-		cJSON *conds = cJSON_AddArrayToObject(json, "conditions");
-		CCS_REFUTE(!conds, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		cJSON *conds;
+		CCS_VALIDATE(_ccs_json_add_array(json, "conditions", &conds));
 		for (size_t i = 0; i < data->num_parameters; i++) {
 			if (data->conditions[i]) {
 				cJSON *cond = cJSON_CreateObject();
@@ -248,9 +248,9 @@ _ccs_serialize_json_ccs_configuration_space(
 
 	/* forbidden clauses */
 	{
-		cJSON *forbids =
-			cJSON_AddArrayToObject(json, "forbidden_clauses");
-		CCS_REFUTE(!forbids, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		cJSON *forbids;
+		CCS_VALIDATE(_ccs_json_add_array(
+			json, "forbidden_clauses", &forbids));
 		for (size_t i = 0; i < data->num_forbidden_clauses; i++)
 			CCS_VALIDATE(_ccs_json_embed_array_object(
 				forbids, data->forbidden_clauses[i], opts));

--- a/src/configuration_space_deserialize.h
+++ b/src/configuration_space_deserialize.h
@@ -192,27 +192,18 @@ _ccs_deserialize_json_ccs_configuration_space_data(
 		(ccs_object_t *)&data->rng, opts));
 
 	/* parameters */
-	j_params = cJSON_GetObjectItemCaseSensitive(json, "parameters");
-	CCS_REFUTE(
-		!j_params || !cJSON_IsArray(j_params),
-		CCS_RESULT_ERROR_INVALID_VALUE);
-	num                  = (size_t)cJSON_GetArraySize(j_params);
+	CCS_VALIDATE(
+		_ccs_json_extract_array(json, "parameters", &j_params, &num));
 	data->num_parameters = num;
 
 	/* conditions */
-	j_conds = cJSON_GetObjectItemCaseSensitive(json, "conditions");
-	CCS_REFUTE(
-		!j_conds || !cJSON_IsArray(j_conds),
-		CCS_RESULT_ERROR_INVALID_VALUE);
-	num_conds            = (size_t)cJSON_GetArraySize(j_conds);
+	CCS_VALIDATE(_ccs_json_extract_array(
+		json, "conditions", &j_conds, &num_conds));
 	data->num_conditions = num_conds;
 
 	/* forbidden clauses */
-	j_forbids = cJSON_GetObjectItemCaseSensitive(json, "forbidden_clauses");
-	CCS_REFUTE(
-		!j_forbids || !cJSON_IsArray(j_forbids),
-		CCS_RESULT_ERROR_INVALID_VALUE);
-	num_forbids                 = (size_t)cJSON_GetArraySize(j_forbids);
+	CCS_VALIDATE(_ccs_json_extract_array(
+		json, "forbidden_clauses", &j_forbids, &num_forbids));
 	data->num_forbidden_clauses = num_forbids;
 
 	if (!(num + num_conds + num_forbids))

--- a/src/context_deserialize.h
+++ b/src/context_deserialize.h
@@ -43,17 +43,15 @@ _ccs_deserialize_json_ccs_context_data(
 	cJSON                             *json,
 	_ccs_object_deserialize_options_t *opts)
 {
-	size_t num;
-	cJSON *j_params = cJSON_GetObjectItemCaseSensitive(json, "parameters");
+	size_t      num;
+	cJSON      *j_params;
 	const char *name_str;
 	data->num_parameters = 0;
 	data->parameters     = NULL;
 	CCS_VALIDATE(_ccs_json_extract_string(json, "name", &name_str));
-	CCS_REFUTE(
-		!j_params || !cJSON_IsArray(j_params),
-		CCS_RESULT_ERROR_INVALID_VALUE);
+	CCS_VALIDATE(
+		_ccs_json_extract_array(json, "parameters", &j_params, &num));
 	data->name           = name_str;
-	num                  = (size_t)cJSON_GetArraySize(j_params);
 	data->num_parameters = num;
 	if (num) {
 		data->parameters =

--- a/src/context_internal.h
+++ b/src/context_internal.h
@@ -311,8 +311,8 @@ _ccs_serialize_json_ccs_context(
 {
 	_ccs_context_data_t *data = context->data;
 	CCS_VALIDATE(_ccs_json_add_string(json, "name", data->name));
-	cJSON *parameters = cJSON_AddArrayToObject(json, "parameters");
-	CCS_REFUTE(!parameters, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	cJSON *parameters;
+	CCS_VALIDATE(_ccs_json_add_array(json, "parameters", &parameters));
 	for (size_t i = 0; i < data->num_parameters; i++)
 		CCS_VALIDATE(_ccs_json_embed_array_object(
 			parameters, data->parameters[i], opts));

--- a/src/context_internal.h
+++ b/src/context_internal.h
@@ -310,8 +310,8 @@ _ccs_serialize_json_ccs_context(
 	_ccs_object_serialize_options_t *opts)
 {
 	_ccs_context_data_t *data = context->data;
+	cJSON               *parameters;
 	CCS_VALIDATE(_ccs_json_add_string(json, "name", data->name));
-	cJSON *parameters;
 	CCS_VALIDATE(_ccs_json_add_array(json, "parameters", &parameters));
 	for (size_t i = 0; i < data->num_parameters; i++)
 		CCS_VALIDATE(_ccs_json_embed_array_object(

--- a/src/distribution_deserialize.h
+++ b/src/distribution_deserialize.h
@@ -411,13 +411,12 @@ _ccs_deserialize_json_distribution_roulette(
 	ccs_distribution_t *distribution_ret,
 	cJSON              *json)
 {
-	ccs_result_t res     = CCS_RESULT_SUCCESS;
-	ccs_float_t *areas   = NULL;
-	cJSON       *j_areas = cJSON_GetObjectItemCaseSensitive(json, "areas");
-	CCS_REFUTE(
-		!j_areas || !cJSON_IsArray(j_areas),
-		CCS_RESULT_ERROR_INVALID_VALUE);
-	size_t num_areas = (size_t)cJSON_GetArraySize(j_areas);
+	ccs_result_t res   = CCS_RESULT_SUCCESS;
+	ccs_float_t *areas = NULL;
+	cJSON       *j_areas;
+	size_t       num_areas;
+	CCS_VALIDATE(
+		_ccs_json_extract_array(json, "areas", &j_areas, &num_areas));
 	areas = (ccs_float_t *)calloc(num_areas, sizeof(ccs_float_t));
 	CCS_REFUTE(!areas, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	for (size_t i = 0; i < num_areas; i++) {
@@ -451,20 +450,15 @@ _ccs_deserialize_json_distribution_mixture(
 	_ccs_object_deserialize_options_t new_opts      = *opts;
 	new_opts.handle_map                             = NULL;
 
-	cJSON *j_weights = cJSON_GetObjectItemCaseSensitive(json, "weights");
-	cJSON *j_distributions =
-		cJSON_GetObjectItemCaseSensitive(json, "distributions");
-	CCS_REFUTE(
-		!j_weights || !cJSON_IsArray(j_weights),
-		CCS_RESULT_ERROR_INVALID_VALUE);
-	CCS_REFUTE(
-		!j_distributions || !cJSON_IsArray(j_distributions),
-		CCS_RESULT_ERROR_INVALID_VALUE);
-
-	size_t num = (size_t)cJSON_GetArraySize(j_distributions);
-	CCS_REFUTE(
-		(size_t)cJSON_GetArraySize(j_weights) != num,
-		CCS_RESULT_ERROR_INVALID_VALUE);
+	cJSON *j_weights;
+	cJSON *j_distributions;
+	size_t num;
+	size_t num_weights;
+	CCS_VALIDATE(_ccs_json_extract_array(
+		json, "distributions", &j_distributions, &num));
+	CCS_VALIDATE(_ccs_json_extract_array(
+		json, "weights", &j_weights, &num_weights));
+	CCS_REFUTE(num_weights != num, CCS_RESULT_ERROR_INVALID_VALUE);
 
 	distributions =
 		(ccs_distribution_t *)calloc(num, sizeof(ccs_distribution_t));
@@ -518,13 +512,10 @@ _ccs_deserialize_json_distribution_multivariate(
 	_ccs_object_deserialize_options_t new_opts      = *opts;
 	new_opts.handle_map                             = NULL;
 
-	cJSON *j_distributions =
-		cJSON_GetObjectItemCaseSensitive(json, "distributions");
-	CCS_REFUTE(
-		!j_distributions || !cJSON_IsArray(j_distributions),
-		CCS_RESULT_ERROR_INVALID_VALUE);
-
-	size_t num = (size_t)cJSON_GetArraySize(j_distributions);
+	cJSON *j_distributions;
+	size_t num;
+	CCS_VALIDATE(_ccs_json_extract_array(
+		json, "distributions", &j_distributions, &num));
 	distributions =
 		(ccs_distribution_t *)calloc(num, sizeof(ccs_distribution_t));
 	CCS_REFUTE(!distributions, CCS_RESULT_ERROR_OUT_OF_MEMORY);

--- a/src/distribution_mixture.c
+++ b/src/distribution_mixture.c
@@ -106,8 +106,8 @@ _ccs_serialize_json_ccs_distribution_mixture(
 		(_ccs_distribution_mixture_data_t *)(distribution->data);
 	CCS_VALIDATE(
 		_ccs_json_add_string(json, "distribution_type", "mixture"));
-	cJSON *weights = cJSON_AddArrayToObject(json, "weights");
-	CCS_REFUTE(!weights, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	cJSON *weights;
+	CCS_VALIDATE(_ccs_json_add_array(json, "weights", &weights));
 	for (size_t i = 0; i < data->num_distributions; i++) {
 		cJSON *w_item = NULL;
 		CCS_VALIDATE(_ccs_json_create_float(
@@ -116,8 +116,9 @@ _ccs_serialize_json_ccs_distribution_mixture(
 			!cJSON_AddItemToArray(weights, w_item),
 			CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	}
-	cJSON *distributions = cJSON_AddArrayToObject(json, "distributions");
-	CCS_REFUTE(!distributions, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	cJSON *distributions;
+	CCS_VALIDATE(
+		_ccs_json_add_array(json, "distributions", &distributions));
 	for (size_t i = 0; i < data->num_distributions; i++)
 		CCS_VALIDATE(_ccs_json_embed_array_object(
 			distributions, data->distributions[i], opts));

--- a/src/distribution_mixture.c
+++ b/src/distribution_mixture.c
@@ -104,9 +104,10 @@ _ccs_serialize_json_ccs_distribution_mixture(
 {
 	_ccs_distribution_mixture_data_t *data =
 		(_ccs_distribution_mixture_data_t *)(distribution->data);
+	cJSON *weights;
+	cJSON *distributions;
 	CCS_VALIDATE(
 		_ccs_json_add_string(json, "distribution_type", "mixture"));
-	cJSON *weights;
 	CCS_VALIDATE(_ccs_json_add_array(json, "weights", &weights));
 	for (size_t i = 0; i < data->num_distributions; i++) {
 		cJSON *w_item = NULL;
@@ -116,7 +117,6 @@ _ccs_serialize_json_ccs_distribution_mixture(
 			!cJSON_AddItemToArray(weights, w_item),
 			CCS_RESULT_ERROR_OUT_OF_MEMORY);
 	}
-	cJSON *distributions;
 	CCS_VALIDATE(
 		_ccs_json_add_array(json, "distributions", &distributions));
 	for (size_t i = 0; i < data->num_distributions; i++)

--- a/src/distribution_multivariate.c
+++ b/src/distribution_multivariate.c
@@ -99,8 +99,9 @@ _ccs_serialize_json_ccs_distribution_multivariate(
 		(_ccs_distribution_multivariate_data_t *)(distribution->data);
 	CCS_VALIDATE(_ccs_json_add_string(
 		json, "distribution_type", "multivariate"));
-	cJSON *distributions = cJSON_AddArrayToObject(json, "distributions");
-	CCS_REFUTE(!distributions, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	cJSON *distributions;
+	CCS_VALIDATE(
+		_ccs_json_add_array(json, "distributions", &distributions));
 	for (size_t i = 0; i < data->num_distributions; i++)
 		CCS_VALIDATE(_ccs_json_embed_array_object(
 			distributions, data->distributions[i], opts));

--- a/src/distribution_multivariate.c
+++ b/src/distribution_multivariate.c
@@ -97,9 +97,9 @@ _ccs_serialize_json_ccs_distribution_multivariate(
 {
 	_ccs_distribution_multivariate_data_t *data =
 		(_ccs_distribution_multivariate_data_t *)(distribution->data);
+	cJSON *distributions;
 	CCS_VALIDATE(_ccs_json_add_string(
 		json, "distribution_type", "multivariate"));
-	cJSON *distributions;
 	CCS_VALIDATE(
 		_ccs_json_add_array(json, "distributions", &distributions));
 	for (size_t i = 0; i < data->num_distributions; i++)

--- a/src/distribution_roulette.c
+++ b/src/distribution_roulette.c
@@ -80,9 +80,9 @@ _ccs_serialize_json_ccs_distribution_roulette(
 {
 	_ccs_distribution_roulette_data_t *data =
 		(_ccs_distribution_roulette_data_t *)(distribution->data);
+	cJSON *areas;
 	CCS_VALIDATE(
 		_ccs_json_add_string(json, "distribution_type", "roulette"));
-	cJSON *areas;
 	CCS_VALIDATE(_ccs_json_add_array(json, "areas", &areas));
 	for (size_t i = 0; i < data->num_areas; i++) {
 		cJSON *a_item = NULL;

--- a/src/distribution_roulette.c
+++ b/src/distribution_roulette.c
@@ -82,8 +82,8 @@ _ccs_serialize_json_ccs_distribution_roulette(
 		(_ccs_distribution_roulette_data_t *)(distribution->data);
 	CCS_VALIDATE(
 		_ccs_json_add_string(json, "distribution_type", "roulette"));
-	cJSON *areas = cJSON_AddArrayToObject(json, "areas");
-	CCS_REFUTE(!areas, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	cJSON *areas;
+	CCS_VALIDATE(_ccs_json_add_array(json, "areas", &areas));
 	for (size_t i = 0; i < data->num_areas; i++) {
 		cJSON *a_item = NULL;
 		CCS_VALIDATE(_ccs_json_create_float(

--- a/src/distribution_space.c
+++ b/src/distribution_space.c
@@ -119,8 +119,8 @@ _ccs_serialize_json_ccs_distribution_space(
 		&data->configuration_space, sizeof(ccs_object_t), hex);
 	CCS_VALIDATE(_ccs_json_add_string(json, "configuration_space", hex));
 
-	cJSON *distribs = cJSON_AddArrayToObject(json, "distributions");
-	CCS_REFUTE(!distribs, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	cJSON *distribs;
+	CCS_VALIDATE(_ccs_json_add_array(json, "distributions", &distribs));
 
 	dw = NULL;
 	DL_FOREACH(data->distribution_list, dw)
@@ -134,9 +134,9 @@ _ccs_serialize_json_ccs_distribution_space(
 		CCS_VALIDATE(_ccs_json_embed_object(
 			entry, "distribution", dw->distribution, opts));
 
-		cJSON *indices =
-			cJSON_AddArrayToObject(entry, "parameter_indices");
-		CCS_REFUTE(!indices, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		cJSON *indices;
+		CCS_VALIDATE(_ccs_json_add_array(
+			entry, "parameter_indices", &indices));
 		for (size_t i = 0; i < dw->dimension; i++) {
 			cJSON *idx_item;
 			CCS_VALIDATE(_ccs_json_create_int(

--- a/src/distribution_space.c
+++ b/src/distribution_space.c
@@ -114,18 +114,18 @@ _ccs_serialize_json_ccs_distribution_space(
 	_ccs_distribution_space_data_t *data = distribution_space->data;
 	_ccs_distribution_wrapper_t    *dw;
 	char                            hex[sizeof(ccs_object_t) * 2 + 1];
+	cJSON                          *distribs;
 
 	_ccs_json_hex_encode_buf(
 		&data->configuration_space, sizeof(ccs_object_t), hex);
 	CCS_VALIDATE(_ccs_json_add_string(json, "configuration_space", hex));
-
-	cJSON *distribs;
 	CCS_VALIDATE(_ccs_json_add_array(json, "distributions", &distribs));
 
 	dw = NULL;
 	DL_FOREACH(data->distribution_list, dw)
 	{
 		cJSON *entry = cJSON_CreateObject();
+		cJSON *indices;
 		CCS_REFUTE(!entry, CCS_RESULT_ERROR_OUT_OF_MEMORY);
 		CCS_REFUTE(
 			!cJSON_AddItemToArray(distribs, entry),
@@ -133,8 +133,6 @@ _ccs_serialize_json_ccs_distribution_space(
 
 		CCS_VALIDATE(_ccs_json_embed_object(
 			entry, "distribution", dw->distribution, opts));
-
-		cJSON *indices;
 		CCS_VALIDATE(_ccs_json_add_array(
 			entry, "parameter_indices", &indices));
 		for (size_t i = 0; i < dw->dimension; i++) {

--- a/src/distribution_space_deserialize.h
+++ b/src/distribution_space_deserialize.h
@@ -168,11 +168,8 @@ _ccs_deserialize_json_ccs_distribution_space_data(
 		CCS_RESULT_ERROR_INVALID_VALUE);
 
 	/* distributions array */
-	j_distribs = cJSON_GetObjectItemCaseSensitive(json, "distributions");
-	CCS_REFUTE(
-		!j_distribs || !cJSON_IsArray(j_distribs),
-		CCS_RESULT_ERROR_INVALID_VALUE);
-	num                     = (size_t)cJSON_GetArraySize(j_distribs);
+	CCS_VALIDATE(_ccs_json_extract_array(
+		json, "distributions", &j_distribs, &num));
 	data->num_distributions = num;
 
 	if (!num)
@@ -180,13 +177,12 @@ _ccs_deserialize_json_ccs_distribution_space_data(
 
 	/* First pass: count total indices */
 	for (size_t i = 0; i < num; i++) {
-		cJSON *entry     = cJSON_GetArrayItem(j_distribs, (int)i);
-		cJSON *j_indices = cJSON_GetObjectItemCaseSensitive(
-			entry, "parameter_indices");
-		CCS_REFUTE(
-			!j_indices || !cJSON_IsArray(j_indices),
-			CCS_RESULT_ERROR_INVALID_VALUE);
-		total_indices += (size_t)cJSON_GetArraySize(j_indices);
+		cJSON *entry = cJSON_GetArrayItem(j_distribs, (int)i);
+		cJSON *j_indices;
+		size_t dim;
+		CCS_VALIDATE(_ccs_json_extract_array(
+			entry, "parameter_indices", &j_indices, &dim));
+		total_indices += dim;
 	}
 	data->num_parameters = total_indices;
 
@@ -211,9 +207,8 @@ _ccs_deserialize_json_ccs_distribution_space_data(
 
 	size_t *indices = data->distrib_parameter_indices;
 	for (size_t i = 0; i < num; i++) {
-		cJSON *entry     = cJSON_GetArrayItem(j_distribs, (int)i);
-		cJSON *j_indices = cJSON_GetObjectItemCaseSensitive(
-			entry, "parameter_indices");
+		cJSON *entry = cJSON_GetArrayItem(j_distribs, (int)i);
+		cJSON *j_indices;
 		size_t dim;
 
 		CCS_VALIDATE(_ccs_json_extract_object(
@@ -221,7 +216,8 @@ _ccs_deserialize_json_ccs_distribution_space_data(
 			version, (ccs_object_t *)data->distributions + i,
 			opts));
 
-		dim                 = (size_t)cJSON_GetArraySize(j_indices);
+		CCS_VALIDATE(_ccs_json_extract_array(
+			entry, "parameter_indices", &j_indices, &dim));
 		data->dimensions[i] = dim;
 		for (size_t j = 0; j < dim; j++) {
 			ccs_int_t idx_val;

--- a/src/expression.c
+++ b/src/expression.c
@@ -173,10 +173,10 @@ _ccs_serialize_json_ccs_expression(
 {
 	_ccs_expression_data_t *data =
 		(_ccs_expression_data_t *)(expression->data);
+	cJSON *nodes;
 	CCS_VALIDATE(_ccs_json_add_string(
 		json, "expression_type",
 		_ccs_json_expression_type_to_string(data->type)));
-	cJSON *nodes;
 	CCS_VALIDATE(_ccs_json_add_array(json, "nodes", &nodes));
 	for (size_t i = 0; i < data->num_nodes; i++)
 		CCS_VALIDATE(_ccs_json_embed_array_object(
@@ -1436,11 +1436,11 @@ _ccs_serialize_json_ccs_expression_user_defined(
 {
 	_ccs_expression_user_defined_data_t *data =
 		(_ccs_expression_user_defined_data_t *)(expression->data);
+	cJSON *nodes;
 	CCS_VALIDATE(
 		_ccs_json_add_string(json, "expression_type", "user_defined"));
 	CCS_VALIDATE(_ccs_json_add_string(json, "name", data->name));
 	/* serialize child nodes */
-	cJSON *nodes;
 	CCS_VALIDATE(_ccs_json_add_array(json, "nodes", &nodes));
 	for (size_t i = 0; i < data->expr.num_nodes; i++)
 		CCS_VALIDATE(_ccs_json_embed_array_object(

--- a/src/expression.c
+++ b/src/expression.c
@@ -176,8 +176,8 @@ _ccs_serialize_json_ccs_expression(
 	CCS_VALIDATE(_ccs_json_add_string(
 		json, "expression_type",
 		_ccs_json_expression_type_to_string(data->type)));
-	cJSON *nodes = cJSON_AddArrayToObject(json, "nodes");
-	CCS_REFUTE(!nodes, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	cJSON *nodes;
+	CCS_VALIDATE(_ccs_json_add_array(json, "nodes", &nodes));
 	for (size_t i = 0; i < data->num_nodes; i++)
 		CCS_VALIDATE(_ccs_json_embed_array_object(
 			nodes, data->nodes[i], opts));
@@ -1440,8 +1440,8 @@ _ccs_serialize_json_ccs_expression_user_defined(
 		_ccs_json_add_string(json, "expression_type", "user_defined"));
 	CCS_VALIDATE(_ccs_json_add_string(json, "name", data->name));
 	/* serialize child nodes */
-	cJSON *nodes = cJSON_AddArrayToObject(json, "nodes");
-	CCS_REFUTE(!nodes, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	cJSON *nodes;
+	CCS_VALIDATE(_ccs_json_add_array(json, "nodes", &nodes));
 	for (size_t i = 0; i < data->expr.num_nodes; i++)
 		CCS_VALIDATE(_ccs_json_embed_array_object(
 			nodes, data->expr.nodes[i], opts));

--- a/src/expression_deserialize.h
+++ b/src/expression_deserialize.h
@@ -347,11 +347,8 @@ _ccs_deserialize_json_expression_general(
 	data.num_nodes                             = 0;
 	data.nodes                                 = NULL;
 
-	j_nodes = cJSON_GetObjectItemCaseSensitive(json, "nodes");
-	CCS_REFUTE(
-		!j_nodes || !cJSON_IsArray(j_nodes),
-		CCS_RESULT_ERROR_INVALID_VALUE);
-	num_nodes      = (size_t)cJSON_GetArraySize(j_nodes);
+	CCS_VALIDATE(
+		_ccs_json_extract_array(json, "nodes", &j_nodes, &num_nodes));
 	data.num_nodes = num_nodes;
 	if (num_nodes) {
 		data.nodes =
@@ -407,11 +404,8 @@ _ccs_deserialize_json_expression_user_defined(
 
 	CCS_VALIDATE(_ccs_json_extract_string(json, "name", &name));
 
-	j_nodes = cJSON_GetObjectItemCaseSensitive(json, "nodes");
-	CCS_REFUTE(
-		!j_nodes || !cJSON_IsArray(j_nodes),
-		CCS_RESULT_ERROR_INVALID_VALUE);
-	num_nodes      = (size_t)cJSON_GetArraySize(j_nodes);
+	CCS_VALIDATE(
+		_ccs_json_extract_array(json, "nodes", &j_nodes, &num_nodes));
 	data.num_nodes = num_nodes;
 	if (num_nodes) {
 		data.nodes =

--- a/src/map.c
+++ b/src/map.c
@@ -101,7 +101,6 @@ _ccs_serialize_json_ccs_map(ccs_map_t map, cJSON *json)
 {
 	_ccs_map_data_t  *data = (_ccs_map_data_t *)(map->data);
 	_ccs_map_datum_t *current, *tmp;
-
 	cJSON            *pairs;
 	CCS_VALIDATE(_ccs_json_add_array(json, "pairs", &pairs));
 

--- a/src/map.c
+++ b/src/map.c
@@ -102,8 +102,8 @@ _ccs_serialize_json_ccs_map(ccs_map_t map, cJSON *json)
 	_ccs_map_data_t  *data = (_ccs_map_data_t *)(map->data);
 	_ccs_map_datum_t *current, *tmp;
 
-	cJSON            *pairs = cJSON_AddArrayToObject(json, "pairs");
-	CCS_REFUTE(!pairs, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	cJSON            *pairs;
+	CCS_VALIDATE(_ccs_json_add_array(json, "pairs", &pairs));
 
 	HASH_ITER(hh, data->map, current, tmp)
 	{

--- a/src/map_deserialize.h
+++ b/src/map_deserialize.h
@@ -94,12 +94,8 @@ _ccs_deserialize_json_map(
 	cJSON       *j_pairs;
 	size_t       num;
 
-	json    = *(cJSON **)buffer;
-	j_pairs = cJSON_GetObjectItemCaseSensitive(json, "pairs");
-	CCS_REFUTE(
-		!j_pairs || !cJSON_IsArray(j_pairs),
-		CCS_RESULT_ERROR_INVALID_VALUE);
-	num = (size_t)cJSON_GetArraySize(j_pairs);
+	json = *(cJSON **)buffer;
+	CCS_VALIDATE(_ccs_json_extract_array(json, "pairs", &j_pairs, &num));
 
 	CCS_VALIDATE(ccs_create_map(map_ret));
 	for (size_t i = 0; i < num; i++) {

--- a/src/objective_space.c
+++ b/src/objective_space.c
@@ -159,8 +159,8 @@ _ccs_serialize_json_ccs_objective_space(
 
 	/* parameters */
 	{
-		cJSON *params = cJSON_AddArrayToObject(json, "parameters");
-		CCS_REFUTE(!params, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		cJSON *params;
+		CCS_VALIDATE(_ccs_json_add_array(json, "parameters", &params));
 		for (size_t i = 0; i < data->num_parameters; i++)
 			CCS_VALIDATE(_ccs_json_embed_array_object(
 				params, data->parameters[i], opts));
@@ -168,8 +168,8 @@ _ccs_serialize_json_ccs_objective_space(
 
 	/* objectives: expression + type */
 	{
-		cJSON *objs = cJSON_AddArrayToObject(json, "objectives");
-		CCS_REFUTE(!objs, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		cJSON *objs;
+		CCS_VALIDATE(_ccs_json_add_array(json, "objectives", &objs));
 		for (size_t i = 0; i < data->num_objectives; i++) {
 			cJSON *obj = cJSON_CreateObject();
 			CCS_REFUTE(!obj, CCS_RESULT_ERROR_OUT_OF_MEMORY);

--- a/src/objective_space_deserialize.h
+++ b/src/objective_space_deserialize.h
@@ -149,19 +149,13 @@ _ccs_deserialize_json_ccs_objective_space_data(
 		(ccs_object_t *)&data->search_space, opts));
 
 	/* parameters */
-	j_params = cJSON_GetObjectItemCaseSensitive(json, "parameters");
-	CCS_REFUTE(
-		!j_params || !cJSON_IsArray(j_params),
-		CCS_RESULT_ERROR_INVALID_VALUE);
-	num                  = (size_t)cJSON_GetArraySize(j_params);
+	CCS_VALIDATE(
+		_ccs_json_extract_array(json, "parameters", &j_params, &num));
 	data->num_parameters = num;
 
 	/* objectives */
-	j_objs = cJSON_GetObjectItemCaseSensitive(json, "objectives");
-	CCS_REFUTE(
-		!j_objs || !cJSON_IsArray(j_objs),
-		CCS_RESULT_ERROR_INVALID_VALUE);
-	num_objs             = (size_t)cJSON_GetArraySize(j_objs);
+	CCS_VALIDATE(_ccs_json_extract_array(
+		json, "objectives", &j_objs, &num_objs));
 	data->num_objectives = num_objs;
 
 	if (!(num + num_objs))

--- a/src/parameter_categorical.c
+++ b/src/parameter_categorical.c
@@ -81,6 +81,7 @@ _ccs_serialize_json_ccs_parameter_categorical(
 {
 	_ccs_parameter_categorical_data_t *data =
 		(_ccs_parameter_categorical_data_t *)(parameter->data);
+	cJSON *j_values;
 	CCS_VALIDATE(_ccs_json_add_string(
 		json, "parameter_type",
 		_ccs_json_parameter_type_to_string(data->common_data.type)));
@@ -88,7 +89,6 @@ _ccs_serialize_json_ccs_parameter_categorical(
 		_ccs_json_add_string(json, "name", data->common_data.name));
 	CCS_VALIDATE(_ccs_json_add_datum(
 		json, "default_value", data->common_data.default_value));
-	cJSON *j_values;
 	CCS_VALIDATE(_ccs_json_add_array(json, "possible_values", &j_values));
 	for (size_t i = 0; i < data->num_possible_values; i++)
 		CCS_VALIDATE(_ccs_json_add_datum_to_array(

--- a/src/parameter_categorical.c
+++ b/src/parameter_categorical.c
@@ -88,8 +88,8 @@ _ccs_serialize_json_ccs_parameter_categorical(
 		_ccs_json_add_string(json, "name", data->common_data.name));
 	CCS_VALIDATE(_ccs_json_add_datum(
 		json, "default_value", data->common_data.default_value));
-	cJSON *j_values = cJSON_AddArrayToObject(json, "possible_values");
-	CCS_REFUTE(!j_values, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	cJSON *j_values;
+	CCS_VALIDATE(_ccs_json_add_array(json, "possible_values", &j_values));
 	for (size_t i = 0; i < data->num_possible_values; i++)
 		CCS_VALIDATE(_ccs_json_add_datum_to_array(
 			j_values, data->possible_values[i].d));

--- a/src/parameter_deserialize.h
+++ b/src/parameter_deserialize.h
@@ -220,16 +220,13 @@ _ccs_deserialize_json_parameter_categorical(
 	ccs_datum_t  default_datum;
 	int          found               = 0;
 	size_t       default_value_index = 0;
-	cJSON       *j_possible_values =
-		cJSON_GetObjectItemCaseSensitive(json, "possible_values");
+	cJSON       *j_possible_values;
 
-	const char *name_str;
+	const char  *name_str;
 	CCS_VALIDATE(_ccs_json_extract_string(json, "name", &name_str));
-	CCS_REFUTE(
-		!j_possible_values || !cJSON_IsArray(j_possible_values),
-		CCS_RESULT_ERROR_INVALID_VALUE);
-
-	num_possible_values = (size_t)cJSON_GetArraySize(j_possible_values);
+	CCS_VALIDATE(_ccs_json_extract_array(
+		json, "possible_values", &j_possible_values,
+		&num_possible_values));
 	possible_values =
 		(ccs_datum_t *)calloc(num_possible_values, sizeof(ccs_datum_t));
 	CCS_REFUTE(!possible_values, CCS_RESULT_ERROR_OUT_OF_MEMORY);

--- a/src/tree.c
+++ b/src/tree.c
@@ -102,8 +102,7 @@ _ccs_serialize_json_ccs_tree(
 	CCS_VALIDATE(_ccs_json_add_float(json, "bias", data->bias));
 	CCS_VALIDATE(_ccs_json_add_datum(json, "value", data->value));
 
-	children = cJSON_AddArrayToObject(json, "children");
-	CCS_REFUTE(!children, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	CCS_VALIDATE(_ccs_json_add_array(json, "children", &children));
 	for (i = 0; i < data->arity; i++) {
 		if (data->children[i]) {
 			CCS_VALIDATE(_ccs_json_embed_array_object(

--- a/src/tree_configuration.c
+++ b/src/tree_configuration.c
@@ -95,8 +95,7 @@ _ccs_serialize_json_ccs_tree_configuration(
 	_ccs_json_hex_encode_buf(&data->tree_space, sizeof(ccs_object_t), hex);
 	CCS_VALIDATE(_ccs_json_add_string(json, "tree_space", hex));
 
-	positions = cJSON_AddArrayToObject(json, "position");
-	CCS_REFUTE(!positions, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	CCS_VALIDATE(_ccs_json_add_array(json, "position", &positions));
 	for (i = 0; i < data->position_size; i++) {
 		cJSON *pos_item;
 		CCS_VALIDATE(_ccs_json_create_int(

--- a/src/tree_configuration_deserialize.h
+++ b/src/tree_configuration_deserialize.h
@@ -113,8 +113,8 @@ _ccs_deserialize_json_tree_configuration(
 	ccs_object_t     ts_handle;
 	size_t          *position = NULL;
 	ccs_features_t   features = NULL;
-	int              pos_count;
-	int              i;
+	size_t           pos_count;
+	size_t           i;
 	const char      *ts_str;
 
 	(void)buffer_size;
@@ -140,14 +140,14 @@ _ccs_deserialize_json_tree_configuration(
 		CCS_RESULT_ERROR_INVALID_HANDLE, end);
 	tree_space = (ccs_tree_space_t)(d.value.o);
 
-	j_position = cJSON_GetObjectItemCaseSensitive(json, "position");
-	CCS_REFUTE_ERR_GOTO(
-		res, !j_position || !cJSON_IsArray(j_position),
-		CCS_RESULT_ERROR_INVALID_VALUE, end);
-	pos_count = cJSON_GetArraySize(j_position);
+	CCS_VALIDATE_ERR_GOTO(
+		res,
+		_ccs_json_extract_array(
+			json, "position", &j_position, &pos_count),
+		end);
 
-	if (pos_count > 0) {
-		position = (size_t *)calloc((size_t)pos_count, sizeof(size_t));
+	if (pos_count) {
+		position = (size_t *)calloc(pos_count, sizeof(size_t));
 		CCS_REFUTE_ERR_GOTO(
 			res, !position, CCS_RESULT_ERROR_OUT_OF_MEMORY, end);
 		for (i = 0; i < pos_count; i++) {
@@ -177,7 +177,7 @@ _ccs_deserialize_json_tree_configuration(
 	CCS_VALIDATE_ERR_GOTO(
 		res,
 		ccs_create_tree_configuration(
-			tree_space, features, (size_t)pos_count, position,
+			tree_space, features, pos_count, position,
 			configuration_ret),
 		end);
 

--- a/src/tree_deserialize.h
+++ b/src/tree_deserialize.h
@@ -113,8 +113,8 @@ _ccs_deserialize_json_tree(
 	cJSON                            *j_children;
 	ccs_tree_t                        tree = NULL;
 	_ccs_tree_data_mock_t             data;
-	int                               num_children;
-	int                               i;
+	size_t                            num_children;
+	size_t                            i;
 	ccs_int_t                         arity_val;
 
 	(void)buffer_size;
@@ -133,14 +133,14 @@ _ccs_deserialize_json_tree(
 	CCS_VALIDATE_ERR_GOTO(
 		res, _ccs_json_extract_datum(json, "value", &data.value), end);
 
-	j_children = cJSON_GetObjectItemCaseSensitive(json, "children");
+	CCS_VALIDATE_ERR_GOTO(
+		res,
+		_ccs_json_extract_array(
+			json, "children", &j_children, &num_children),
+		end);
 	CCS_REFUTE_ERR_GOTO(
-		res, !j_children || !cJSON_IsArray(j_children),
-		CCS_RESULT_ERROR_INVALID_VALUE, end);
-	num_children = cJSON_GetArraySize(j_children);
-	CCS_REFUTE_ERR_GOTO(
-		res, (size_t)num_children != data.arity,
-		CCS_RESULT_ERROR_INVALID_VALUE, end);
+		res, num_children != data.arity, CCS_RESULT_ERROR_INVALID_VALUE,
+		end);
 
 	if (data.arity) {
 		data.children =
@@ -149,7 +149,8 @@ _ccs_deserialize_json_tree(
 			res, !data.children, CCS_RESULT_ERROR_OUT_OF_MEMORY,
 			end);
 		for (i = 0; i < num_children; i++) {
-			cJSON *child_item = cJSON_GetArrayItem(j_children, i);
+			cJSON *child_item =
+				cJSON_GetArrayItem(j_children, (int)i);
 			if (!cJSON_IsNull(child_item))
 				CCS_VALIDATE_ERR_GOTO(
 					res,

--- a/src/tuner_deserialize.h
+++ b/src/tuner_deserialize.h
@@ -241,18 +241,12 @@ _ccs_deserialize_json_ccs_random_tuner_data(
 		opts));
 
 	/* history */
-	j_history = cJSON_GetObjectItemCaseSensitive(json, "history");
-	CCS_REFUTE(
-		!j_history || !cJSON_IsArray(j_history),
-		CCS_RESULT_ERROR_INVALID_VALUE);
-	data->history_size = (size_t)cJSON_GetArraySize(j_history);
+	CCS_VALIDATE(_ccs_json_extract_array(
+		json, "history", &j_history, &data->history_size));
 
 	/* optima */
-	j_optima           = cJSON_GetObjectItemCaseSensitive(json, "optima");
-	CCS_REFUTE(
-		!j_optima || !cJSON_IsArray(j_optima),
-		CCS_RESULT_ERROR_INVALID_VALUE);
-	data->size_optima = (size_t)cJSON_GetArraySize(j_optima);
+	CCS_VALIDATE(_ccs_json_extract_array(
+		json, "optima", &j_optima, &data->size_optima));
 
 	if (!(data->history_size + data->size_optima))
 		return CCS_RESULT_SUCCESS;

--- a/src/tuner_random.c
+++ b/src/tuner_random.c
@@ -173,8 +173,8 @@ _ccs_serialize_json_ccs_random_tuner(
 
 	/* history (inlined evaluations) */
 	{
-		cJSON *history = cJSON_AddArrayToObject(json, "history");
-		CCS_REFUTE(!history, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		cJSON *history;
+		CCS_VALIDATE(_ccs_json_add_array(json, "history", &history));
 		HASH_ITER(hh, data->features_hash, cur, tmp)
 		{
 			ccs_evaluation_t *e = NULL;
@@ -187,8 +187,8 @@ _ccs_serialize_json_ccs_random_tuner(
 
 	/* optima (handles referencing history evaluations) */
 	{
-		cJSON *optima = cJSON_AddArrayToObject(json, "optima");
-		CCS_REFUTE(!optima, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		cJSON *optima;
+		CCS_VALIDATE(_ccs_json_add_array(json, "optima", &optima));
 		HASH_ITER(hh, data->features_hash, cur, tmp)
 		{
 			ccs_evaluation_t *e = NULL;

--- a/src/tuner_user_defined.c
+++ b/src/tuner_user_defined.c
@@ -231,9 +231,10 @@ _ccs_serialize_json_ccs_user_defined_tuner(
 
 	/* history (inlined evaluations) */
 	{
-		cJSON *j_history = cJSON_AddArrayToObject(json, "history");
-		CCS_REFUTE_ERR_GOTO(
-			res, !j_history, CCS_RESULT_ERROR_OUT_OF_MEMORY, end);
+		cJSON *j_history;
+		CCS_VALIDATE_ERR_GOTO(
+			res, _ccs_json_add_array(json, "history", &j_history),
+			end);
 		for (size_t i = 0; i < history_size; i++)
 			CCS_VALIDATE_ERR_GOTO(
 				res,
@@ -244,9 +245,10 @@ _ccs_serialize_json_ccs_user_defined_tuner(
 
 	/* optima (handles) */
 	{
-		cJSON *j_optima = cJSON_AddArrayToObject(json, "optima");
-		CCS_REFUTE_ERR_GOTO(
-			res, !j_optima, CCS_RESULT_ERROR_OUT_OF_MEMORY, end);
+		cJSON *j_optima;
+		CCS_VALIDATE_ERR_GOTO(
+			res, _ccs_json_add_array(json, "optima", &j_optima),
+			end);
 		for (size_t i = 0; i < num_optima; i++) {
 			char hex[sizeof(ccs_object_t) * 2 + 1];
 			_ccs_json_hex_encode_buf(


### PR DESCRIPTION
## Summary
- Add `_ccs_json_add_array` (serialize: create array + NULL check) and `_ccs_json_extract_array` (deserialize: lookup + IsArray check + GetArraySize) to `cconfigspace_json.h`
- Replace boilerplate across 26 files on both serialize and deserialize sides
- Also cleaned up `int` loop variables to `size_t` in tree and tree_configuration deserializers where the helper now provides `size_t` counts

## Test plan
- [x] All 30 tests pass with gcc, g++, and clang (`--enable-strict`)
- [x] Formatted with clang-format-17

🤖 Generated with [Claude Code](https://claude.com/claude-code)