### PR TITLE
Add JSON array item helpers, update all call sites

### DIFF
--- a/src/cconfigspace_internal.h
+++ b/src/cconfigspace_internal.h
@@ -1753,9 +1753,8 @@ _ccs_json_embed_array_object(
 	_ccs_object_serialize_options_t *opts)
 {
 	size_t dummy = 0;
-	cJSON *child = cJSON_CreateObject();
-	CCS_REFUTE(!child, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-	cJSON_AddItemToArray(array, child);
+	cJSON *child;
+	CCS_VALIDATE(_ccs_json_add_object_to_array(array, &child));
 	CCS_VALIDATE(_ccs_object_serialize_with_opts(
 		object, CCS_SERIALIZE_FORMAT_JSON, &dummy, (char **)&child,
 		opts));

--- a/src/cconfigspace_json.h
+++ b/src/cconfigspace_json.h
@@ -599,48 +599,65 @@ _ccs_json_extract_array(
 static inline ccs_result_t
 _ccs_json_add_object_to_array(cJSON *array, cJSON **object_ret)
 {
-	*object_ret = cJSON_CreateObject();
+	ccs_result_t err = CCS_RESULT_SUCCESS;
+	*object_ret      = cJSON_CreateObject();
 	CCS_REFUTE(!*object_ret, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-	CCS_REFUTE(
-		!cJSON_AddItemToArray(array, *object_ret),
-		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	CCS_REFUTE_ERR_GOTO(
+		err, !cJSON_AddItemToArray(array, *object_ret),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY, err_item);
 	return CCS_RESULT_SUCCESS;
+err_item:
+	cJSON_Delete(*object_ret);
+	*object_ret = NULL;
+	return err;
 }
 
 /* Append an integer value to a JSON array. */
 static inline ccs_result_t
 _ccs_json_add_int_to_array(cJSON *array, ccs_int_t value)
 {
-	cJSON *item;
+	ccs_result_t err = CCS_RESULT_SUCCESS;
+	cJSON       *item;
 	CCS_VALIDATE(_ccs_json_create_int(value, &item));
-	CCS_REFUTE(
-		!cJSON_AddItemToArray(array, item),
-		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	CCS_REFUTE_ERR_GOTO(
+		err, !cJSON_AddItemToArray(array, item),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY, err_item);
 	return CCS_RESULT_SUCCESS;
+err_item:
+	cJSON_Delete(item);
+	return err;
 }
 
 /* Append a float value to a JSON array. */
 static inline ccs_result_t
 _ccs_json_add_float_to_array(cJSON *array, double value)
 {
-	cJSON *item;
+	ccs_result_t err = CCS_RESULT_SUCCESS;
+	cJSON       *item;
 	CCS_VALIDATE(_ccs_json_create_float(value, &item));
-	CCS_REFUTE(
-		!cJSON_AddItemToArray(array, item),
-		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	CCS_REFUTE_ERR_GOTO(
+		err, !cJSON_AddItemToArray(array, item),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY, err_item);
 	return CCS_RESULT_SUCCESS;
+err_item:
+	cJSON_Delete(item);
+	return err;
 }
 
 /* Append a string value to a JSON array. */
 static inline ccs_result_t
 _ccs_json_add_string_to_array(cJSON *array, const char *value)
 {
-	cJSON *item;
+	ccs_result_t err = CCS_RESULT_SUCCESS;
+	cJSON       *item;
 	CCS_VALIDATE(_ccs_json_create_string(value, &item));
-	CCS_REFUTE(
-		!cJSON_AddItemToArray(array, item),
-		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	CCS_REFUTE_ERR_GOTO(
+		err, !cJSON_AddItemToArray(array, item),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY, err_item);
 	return CCS_RESULT_SUCCESS;
+err_item:
+	cJSON_Delete(item);
+	return err;
 }
 
 /*============================================================================
@@ -722,23 +739,31 @@ err_item:
 static inline ccs_result_t
 _ccs_json_add_datum(cJSON *json, const char *key, ccs_datum_t datum)
 {
-	cJSON *item = NULL;
+	ccs_result_t err  = CCS_RESULT_SUCCESS;
+	cJSON       *item = NULL;
 	CCS_VALIDATE(_ccs_json_datum_to_cjson(datum, &item));
-	CCS_REFUTE(
-		!cJSON_AddItemToObject(json, key, item),
-		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	CCS_REFUTE_ERR_GOTO(
+		err, !cJSON_AddItemToObject(json, key, item),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY, err_item);
 	return CCS_RESULT_SUCCESS;
+err_item:
+	cJSON_Delete(item);
+	return err;
 }
 
 static inline ccs_result_t
 _ccs_json_add_datum_to_array(cJSON *array, ccs_datum_t datum)
 {
-	cJSON *item = NULL;
+	ccs_result_t err  = CCS_RESULT_SUCCESS;
+	cJSON       *item = NULL;
 	CCS_VALIDATE(_ccs_json_datum_to_cjson(datum, &item));
-	CCS_REFUTE(
-		!cJSON_AddItemToArray(array, item),
-		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	CCS_REFUTE_ERR_GOTO(
+		err, !cJSON_AddItemToArray(array, item),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY, err_item);
 	return CCS_RESULT_SUCCESS;
+err_item:
+	cJSON_Delete(item);
+	return err;
 }
 
 static inline ccs_result_t

--- a/src/cconfigspace_json.h
+++ b/src/cconfigspace_json.h
@@ -595,6 +595,54 @@ _ccs_json_extract_array(
 	return CCS_RESULT_SUCCESS;
 }
 
+/* Create an empty JSON object and append it to a JSON array. */
+static inline ccs_result_t
+_ccs_json_add_object_to_array(cJSON *array, cJSON **object_ret)
+{
+	*object_ret = cJSON_CreateObject();
+	CCS_REFUTE(!*object_ret, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	CCS_REFUTE(
+		!cJSON_AddItemToArray(array, *object_ret),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	return CCS_RESULT_SUCCESS;
+}
+
+/* Append an integer value to a JSON array. */
+static inline ccs_result_t
+_ccs_json_add_int_to_array(cJSON *array, ccs_int_t value)
+{
+	cJSON *item;
+	CCS_VALIDATE(_ccs_json_create_int(value, &item));
+	CCS_REFUTE(
+		!cJSON_AddItemToArray(array, item),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	return CCS_RESULT_SUCCESS;
+}
+
+/* Append a float value to a JSON array. */
+static inline ccs_result_t
+_ccs_json_add_float_to_array(cJSON *array, double value)
+{
+	cJSON *item;
+	CCS_VALIDATE(_ccs_json_create_float(value, &item));
+	CCS_REFUTE(
+		!cJSON_AddItemToArray(array, item),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	return CCS_RESULT_SUCCESS;
+}
+
+/* Append a string value to a JSON array. */
+static inline ccs_result_t
+_ccs_json_add_string_to_array(cJSON *array, const char *value)
+{
+	cJSON *item;
+	CCS_VALIDATE(_ccs_json_create_string(value, &item));
+	CCS_REFUTE(
+		!cJSON_AddItemToArray(array, item),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	return CCS_RESULT_SUCCESS;
+}
+
 /*============================================================================
  * ccs_datum_t JSON helpers
  *============================================================================*/

--- a/src/configuration_space.c
+++ b/src/configuration_space.c
@@ -233,10 +233,9 @@ _ccs_serialize_json_ccs_configuration_space(
 		CCS_VALIDATE(_ccs_json_add_array(json, "conditions", &conds));
 		for (size_t i = 0; i < data->num_parameters; i++) {
 			if (data->conditions[i]) {
-				cJSON *cond = cJSON_CreateObject();
-				CCS_REFUTE(
-					!cond, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-				cJSON_AddItemToArray(conds, cond);
+				cJSON *cond;
+				CCS_VALIDATE(_ccs_json_add_object_to_array(
+					conds, &cond));
 				CCS_VALIDATE(_ccs_json_add_int(
 					cond, "index", (ccs_int_t)i));
 				CCS_VALIDATE(_ccs_json_embed_object(

--- a/src/distribution_mixture.c
+++ b/src/distribution_mixture.c
@@ -109,14 +109,9 @@ _ccs_serialize_json_ccs_distribution_mixture(
 	CCS_VALIDATE(
 		_ccs_json_add_string(json, "distribution_type", "mixture"));
 	CCS_VALIDATE(_ccs_json_add_array(json, "weights", &weights));
-	for (size_t i = 0; i < data->num_distributions; i++) {
-		cJSON *w_item = NULL;
-		CCS_VALIDATE(_ccs_json_create_float(
-			data->weights[i + 1] - data->weights[i], &w_item));
-		CCS_REFUTE(
-			!cJSON_AddItemToArray(weights, w_item),
-			CCS_RESULT_ERROR_OUT_OF_MEMORY);
-	}
+	for (size_t i = 0; i < data->num_distributions; i++)
+		CCS_VALIDATE(_ccs_json_add_float_to_array(
+			weights, data->weights[i + 1] - data->weights[i]));
 	CCS_VALIDATE(
 		_ccs_json_add_array(json, "distributions", &distributions));
 	for (size_t i = 0; i < data->num_distributions; i++)

--- a/src/distribution_roulette.c
+++ b/src/distribution_roulette.c
@@ -84,14 +84,9 @@ _ccs_serialize_json_ccs_distribution_roulette(
 	CCS_VALIDATE(
 		_ccs_json_add_string(json, "distribution_type", "roulette"));
 	CCS_VALIDATE(_ccs_json_add_array(json, "areas", &areas));
-	for (size_t i = 0; i < data->num_areas; i++) {
-		cJSON *a_item = NULL;
-		CCS_VALIDATE(_ccs_json_create_float(
-			data->areas[i + 1] - data->areas[i], &a_item));
-		CCS_REFUTE(
-			!cJSON_AddItemToArray(areas, a_item),
-			CCS_RESULT_ERROR_OUT_OF_MEMORY);
-	}
+	for (size_t i = 0; i < data->num_areas; i++)
+		CCS_VALIDATE(_ccs_json_add_float_to_array(
+			areas, data->areas[i + 1] - data->areas[i]));
 	return CCS_RESULT_SUCCESS;
 }
 

--- a/src/distribution_space.c
+++ b/src/distribution_space.c
@@ -124,26 +124,17 @@ _ccs_serialize_json_ccs_distribution_space(
 	dw = NULL;
 	DL_FOREACH(data->distribution_list, dw)
 	{
-		cJSON *entry = cJSON_CreateObject();
+		cJSON *entry;
 		cJSON *indices;
-		CCS_REFUTE(!entry, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		CCS_REFUTE(
-			!cJSON_AddItemToArray(distribs, entry),
-			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		CCS_VALIDATE(_ccs_json_add_object_to_array(distribs, &entry));
 
 		CCS_VALIDATE(_ccs_json_embed_object(
 			entry, "distribution", dw->distribution, opts));
 		CCS_VALIDATE(_ccs_json_add_array(
 			entry, "parameter_indices", &indices));
-		for (size_t i = 0; i < dw->dimension; i++) {
-			cJSON *idx_item;
-			CCS_VALIDATE(_ccs_json_create_int(
-				(ccs_int_t)dw->parameter_indexes[i],
-				&idx_item));
-			CCS_REFUTE(
-				!cJSON_AddItemToArray(indices, idx_item),
-				CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		}
+		for (size_t i = 0; i < dw->dimension; i++)
+			CCS_VALIDATE(_ccs_json_add_int_to_array(
+				indices, (ccs_int_t)dw->parameter_indexes[i]));
 	}
 
 	return CCS_RESULT_SUCCESS;

--- a/src/map.c
+++ b/src/map.c
@@ -106,11 +106,8 @@ _ccs_serialize_json_ccs_map(ccs_map_t map, cJSON *json)
 
 	HASH_ITER(hh, data->map, current, tmp)
 	{
-		cJSON *pair = cJSON_CreateObject();
-		CCS_REFUTE(!pair, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-		CCS_REFUTE(
-			!cJSON_AddItemToArray(pairs, pair),
-			CCS_RESULT_ERROR_OUT_OF_MEMORY);
+		cJSON *pair;
+		CCS_VALIDATE(_ccs_json_add_object_to_array(pairs, &pair));
 
 		CCS_VALIDATE(_ccs_json_add_datum(pair, "key", current->key));
 		CCS_VALIDATE(

--- a/src/objective_space.c
+++ b/src/objective_space.c
@@ -171,9 +171,8 @@ _ccs_serialize_json_ccs_objective_space(
 		cJSON *objs;
 		CCS_VALIDATE(_ccs_json_add_array(json, "objectives", &objs));
 		for (size_t i = 0; i < data->num_objectives; i++) {
-			cJSON *obj = cJSON_CreateObject();
-			CCS_REFUTE(!obj, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-			cJSON_AddItemToArray(objs, obj);
+			cJSON *obj;
+			CCS_VALIDATE(_ccs_json_add_object_to_array(objs, &obj));
 			CCS_VALIDATE(_ccs_json_embed_object(
 				obj, "expression",
 				data->objectives[i].expression, opts));

--- a/src/tree_configuration.c
+++ b/src/tree_configuration.c
@@ -96,14 +96,9 @@ _ccs_serialize_json_ccs_tree_configuration(
 	CCS_VALIDATE(_ccs_json_add_string(json, "tree_space", hex));
 
 	CCS_VALIDATE(_ccs_json_add_array(json, "position", &positions));
-	for (i = 0; i < data->position_size; i++) {
-		cJSON *pos_item;
-		CCS_VALIDATE(_ccs_json_create_int(
-			(ccs_int_t)data->position[i], &pos_item));
-		CCS_REFUTE(
-			!cJSON_AddItemToArray(positions, pos_item),
-			CCS_RESULT_ERROR_OUT_OF_MEMORY);
-	}
+	for (i = 0; i < data->position_size; i++)
+		CCS_VALIDATE(_ccs_json_add_int_to_array(
+			positions, (ccs_int_t)data->position[i]));
 
 	if (data->features)
 		CCS_VALIDATE(_ccs_json_embed_object(

--- a/src/tuner_random.c
+++ b/src/tuner_random.c
@@ -197,11 +197,8 @@ _ccs_serialize_json_ccs_random_tuner(
 				char hex[sizeof(ccs_object_t) * 2 + 1];
 				_ccs_json_hex_encode_buf(
 					e, sizeof(ccs_object_t), hex);
-				cJSON *h = NULL;
-				CCS_VALIDATE(_ccs_json_create_string(hex, &h));
-				CCS_REFUTE(
-					!cJSON_AddItemToArray(optima, h),
-					CCS_RESULT_ERROR_OUT_OF_MEMORY);
+				CCS_VALIDATE(_ccs_json_add_string_to_array(
+					optima, hex));
 			}
 		}
 	}

--- a/src/tuner_user_defined.c
+++ b/src/tuner_user_defined.c
@@ -253,12 +253,10 @@ _ccs_serialize_json_ccs_user_defined_tuner(
 			char hex[sizeof(ccs_object_t) * 2 + 1];
 			_ccs_json_hex_encode_buf(
 				&optima[i], sizeof(ccs_object_t), hex);
-			cJSON *h = NULL;
 			CCS_VALIDATE_ERR_GOTO(
-				res, _ccs_json_create_string(hex, &h), end);
-			CCS_REFUTE_ERR_GOTO(
-				res, !cJSON_AddItemToArray(j_optima, h),
-				CCS_RESULT_ERROR_OUT_OF_MEMORY, end);
+				res,
+				_ccs_json_add_string_to_array(j_optima, hex),
+				end);
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Add `_ccs_json_add_object_to_array` — create empty JSON object and append to array (5 call sites)
- Add `_ccs_json_add_int_to_array`, `_ccs_json_add_float_to_array`, `_ccs_json_add_string_to_array` — create typed item and append to array (6 call sites)
- Update `_ccs_json_embed_array_object` to use `_ccs_json_add_object_to_array` internally
- Replace boilerplate across 10 files

## Test plan
- [x] All 30 tests pass with gcc, g++, and clang (`--enable-strict`)
- [x] Formatted with clang-format-17

🤖 Generated with [Claude Code](https://claude.com/claude-code)