### PR TITLE
Allow inactive values in ccs_create_configuration

### DIFF
--- a/src/configuration.c
+++ b/src/configuration.c
@@ -231,13 +231,19 @@ _ccs_create_configuration(
 	}
 	if (values) {
 		ccs_bool_t is_valid;
-		for (size_t i = 0; i < num_values; i++)
-			CCS_VALIDATE_ERR_GOTO(
-				err,
-				ccs_context_validate_value(
-					(ccs_context_t)configuration_space, i,
-					values[i], config->data->values + i),
-				errinit);
+		for (size_t i = 0; i < num_values; i++) {
+			if (values[i].type == CCS_DATA_TYPE_INACTIVE)
+				config->data->values[i] = ccs_inactive;
+			else
+				CCS_VALIDATE_ERR_GOTO(
+					err,
+					ccs_context_validate_value(
+						(ccs_context_t)
+							configuration_space,
+						i, values[i],
+						config->data->values + i),
+					errinit);
+		}
 		CCS_VALIDATE_ERR_GOTO(
 			err,
 			_check_configuration(

--- a/tests/test_condition.c
+++ b/tests/test_condition.c
@@ -282,6 +282,84 @@ test_serialize_inactive(void)
 	assert(err == CCS_RESULT_SUCCESS);
 }
 
+void
+test_create_valid_invalid(void)
+{
+	ccs_parameter_t           parameter1, parameter2;
+	ccs_parameter_t           parameters[2];
+	ccs_expression_t          conditions[2] = {NULL, NULL};
+	ccs_configuration_space_t space;
+	ccs_configuration_t       configuration;
+	ccs_datum_t               values[2];
+	ccs_result_t              err;
+
+	/* condition: param2 is active only when param1 < 0 */
+	parameters[0] = parameter1 = create_numerical("param1", -1.0, 1.0);
+	parameters[1] = parameter2 = create_numerical("param2", -1.0, 1.0);
+	err                        = ccs_create_binary_expression(
+                CCS_EXPRESSION_TYPE_LESS, ccs_object(parameter1),
+                ccs_float(0.0), &conditions[1]);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	err = ccs_create_configuration_space(
+		"space", 2, parameters, conditions, 0, NULL, NULL, NULL,
+		&space);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	/* Valid: param1 < 0, param2 active */
+	values[0] = ccs_float(-0.5);
+	values[1] = ccs_float(0.3);
+	err = ccs_create_configuration(space, NULL, 2, values, &configuration);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_release_object(configuration);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	/* Valid: param1 >= 0, param2 inactive */
+	values[0] = ccs_float(0.5);
+	values[1] = ccs_inactive;
+	err = ccs_create_configuration(space, NULL, 2, values, &configuration);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_release_object(configuration);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	/* Invalid: param1 < 0 but param2 inactive (should be active) */
+	values[0] = ccs_float(-0.5);
+	values[1] = ccs_inactive;
+	err = ccs_create_configuration(space, NULL, 2, values, &configuration);
+	assert(err == CCS_RESULT_ERROR_INVALID_VALUE);
+	ccs_clear_thread_error();
+
+	/* Invalid: param1 >= 0 but param2 active (should be inactive) */
+	values[0] = ccs_float(0.5);
+	values[1] = ccs_float(0.3);
+	err = ccs_create_configuration(space, NULL, 2, values, &configuration);
+	assert(err == CCS_RESULT_ERROR_INVALID_VALUE);
+	ccs_clear_thread_error();
+
+	/* Invalid: param1 in range but param2 out of range */
+	values[0] = ccs_float(-0.5);
+	values[1] = ccs_float(5.0);
+	err = ccs_create_configuration(space, NULL, 2, values, &configuration);
+	assert(err == CCS_RESULT_ERROR_INVALID_VALUE);
+	ccs_clear_thread_error();
+
+	/* Invalid: param1 out of range */
+	values[0] = ccs_float(5.0);
+	values[1] = ccs_inactive;
+	err = ccs_create_configuration(space, NULL, 2, values, &configuration);
+	assert(err == CCS_RESULT_ERROR_INVALID_VALUE);
+	ccs_clear_thread_error();
+
+	err = ccs_release_object(conditions[1]);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_release_object(parameter1);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_release_object(parameter2);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_release_object(space);
+	assert(err == CCS_RESULT_SUCCESS);
+}
+
 int
 main(void)
 {
@@ -289,6 +367,7 @@ main(void)
 	test_simple();
 	test_transitive();
 	test_serialize_inactive();
+	test_create_valid_invalid();
 	ccs_clear_thread_error();
 	ccs_fini();
 	return 0;

--- a/tests/test_condition.c
+++ b/tests/test_condition.c
@@ -181,12 +181,114 @@ test_transitive(void)
 	assert(err == CCS_RESULT_SUCCESS);
 }
 
+void
+test_serialize_inactive(void)
+{
+	ccs_parameter_t           parameter1, parameter2;
+	ccs_parameter_t           parameters[2];
+	ccs_expression_t          conditions[2] = {NULL, NULL};
+	ccs_configuration_space_t space;
+	ccs_configuration_t       configuration;
+	ccs_datum_t               values[2];
+	ccs_result_t              err;
+
+	parameters[0] = parameter1 = create_numerical("param1", -1.0, 1.0);
+	parameters[1] = parameter2 = create_numerical("param2", -1.0, 1.0);
+	err                        = ccs_create_binary_expression(
+                CCS_EXPRESSION_TYPE_LESS, ccs_object(parameter1),
+                ccs_float(0.0), &conditions[1]);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	err = ccs_create_configuration_space(
+		"space", 2, parameters, conditions, 0, NULL, NULL, NULL,
+		&space);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	/* Create a configuration where param1 >= 0 so param2 is inactive */
+	values[0] = ccs_float(0.5);
+	values[1] = ccs_inactive;
+	err = ccs_create_configuration(space, NULL, 2, values, &configuration);
+	assert(err == CCS_RESULT_SUCCESS);
+
+	{
+		ccs_serialize_format_t formats[] = {
+			CCS_SERIALIZE_FORMAT_BINARY, CCS_SERIALIZE_FORMAT_JSON};
+		size_t num_formats = sizeof(formats) / sizeof(formats[0]);
+		for (size_t f = 0; f < num_formats; f++) {
+			ccs_configuration_space_t space2;
+			ccs_configuration_t       config2;
+			ccs_datum_t               vals2[2];
+			ccs_map_t                 map;
+			char                     *buff;
+			size_t                    buff_size;
+
+			err = ccs_create_map(&map);
+			assert(err == CCS_RESULT_SUCCESS);
+
+			err = ccs_object_serialize(
+				space, formats[f],
+				CCS_SERIALIZE_OPERATION_BUFFER, &buff,
+				&buff_size, CCS_SERIALIZE_OPTION_END);
+			assert(err == CCS_RESULT_SUCCESS);
+			err = ccs_object_deserialize(
+				(ccs_object_t *)&space2, formats[f],
+				CCS_DESERIALIZE_OPERATION_MEMORY, buff_size,
+				buff, CCS_DESERIALIZE_OPTION_MAP_HANDLES,
+				CCS_DESERIALIZE_OPTION_HANDLE_MAP, map,
+				CCS_DESERIALIZE_OPTION_END);
+			assert(err == CCS_RESULT_SUCCESS);
+			err = ccs_release_buffer(buff);
+			assert(err == CCS_RESULT_SUCCESS);
+
+			err = ccs_object_serialize(
+				configuration, formats[f],
+				CCS_SERIALIZE_OPERATION_BUFFER, &buff,
+				&buff_size, CCS_SERIALIZE_OPTION_END);
+			assert(err == CCS_RESULT_SUCCESS);
+			err = ccs_object_deserialize(
+				(ccs_object_t *)&config2, formats[f],
+				CCS_DESERIALIZE_OPERATION_MEMORY, buff_size,
+				buff, CCS_DESERIALIZE_OPTION_HANDLE_MAP, map,
+				CCS_DESERIALIZE_OPTION_END);
+			assert(err == CCS_RESULT_SUCCESS);
+
+			err = ccs_binding_get_values(
+				(ccs_binding_t)config2, 2, vals2, NULL);
+			assert(err == CCS_RESULT_SUCCESS);
+			assert(vals2[0].type == CCS_DATA_TYPE_FLOAT);
+			assert(vals2[0].value.f == 0.5);
+			assert(vals2[1].type == CCS_DATA_TYPE_INACTIVE);
+
+			err = ccs_release_buffer(buff);
+			assert(err == CCS_RESULT_SUCCESS);
+			err = ccs_release_object(config2);
+			assert(err == CCS_RESULT_SUCCESS);
+			err = ccs_release_object(map);
+			assert(err == CCS_RESULT_SUCCESS);
+			err = ccs_release_object(space2);
+			assert(err == CCS_RESULT_SUCCESS);
+		}
+	}
+
+	err = ccs_release_object(configuration);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_release_object(conditions[1]);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_release_object(parameter1);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_release_object(parameter2);
+	assert(err == CCS_RESULT_SUCCESS);
+	err = ccs_release_object(space);
+	assert(err == CCS_RESULT_SUCCESS);
+}
+
 int
 main(void)
 {
 	ccs_init();
 	test_simple();
 	test_transitive();
+	test_serialize_inactive();
 	ccs_clear_thread_error();
 	ccs_fini();
 	return 0;


### PR DESCRIPTION
## Summary
- Skip `ccs_context_validate_value` for inactive values in `_ccs_create_configuration` — `_check_configuration` already validates active/inactive consistency against conditions
- This fixes deserialization of configurations containing inactive parameters (both binary and JSON)
- Add `test_serialize_inactive` in `test_condition.c` exercising the roundtrip

## Test plan
- [x] All 30 tests pass with gcc, g++, and clang (`--enable-strict`)
- [x] Formatted with clang-format-17

🤖 Generated with [Claude Code](https://claude.com/claude-code)