### PR TITLE
Add more invalid configuration test cases with inactive parameters

### DIFF
--- a/tests/test_condition.c
+++ b/tests/test_condition.c
@@ -350,14 +350,14 @@ test_create_valid_invalid(void)
 	assert(err == CCS_RESULT_ERROR_INVALID_VALUE);
 	ccs_clear_thread_error();
 
-	/* Invalid: param1 inactive (unconditional parameter) */
+	/* Invalid: both inactive */
 	values[0] = ccs_inactive;
 	values[1] = ccs_inactive;
 	err = ccs_create_configuration(space, NULL, 2, values, &configuration);
 	assert(err == CCS_RESULT_ERROR_INVALID_VALUE);
 	ccs_clear_thread_error();
 
-	/* Invalid: both inactive */
+	/* Invalid: param1 inactive (unconditional parameter) */
 	values[0] = ccs_inactive;
 	values[1] = ccs_float(0.3);
 	err = ccs_create_configuration(space, NULL, 2, values, &configuration);

--- a/tests/test_condition.c
+++ b/tests/test_condition.c
@@ -350,6 +350,27 @@ test_create_valid_invalid(void)
 	assert(err == CCS_RESULT_ERROR_INVALID_VALUE);
 	ccs_clear_thread_error();
 
+	/* Invalid: param1 inactive (unconditional parameter) */
+	values[0] = ccs_inactive;
+	values[1] = ccs_inactive;
+	err = ccs_create_configuration(space, NULL, 2, values, &configuration);
+	assert(err == CCS_RESULT_ERROR_INVALID_VALUE);
+	ccs_clear_thread_error();
+
+	/* Invalid: both inactive */
+	values[0] = ccs_inactive;
+	values[1] = ccs_float(0.3);
+	err = ccs_create_configuration(space, NULL, 2, values, &configuration);
+	assert(err == CCS_RESULT_ERROR_INVALID_VALUE);
+	ccs_clear_thread_error();
+
+	/* Invalid: param1 out of range, param2 active */
+	values[0] = ccs_float(-5.0);
+	values[1] = ccs_float(0.3);
+	err = ccs_create_configuration(space, NULL, 2, values, &configuration);
+	assert(err == CCS_RESULT_ERROR_INVALID_VALUE);
+	ccs_clear_thread_error();
+
 	err = ccs_release_object(conditions[1]);
 	assert(err == CCS_RESULT_SUCCESS);
 	err = ccs_release_object(parameter1);


### PR DESCRIPTION
## Summary
- Add three more test cases to `test_create_valid_invalid` in `test_condition.c`:
  - Both parameters inactive (unconditional param1 cannot be inactive)
  - param1 inactive with param2 active
  - param1 out of range with param2 active

## Test plan
- [x] All 30 tests pass with gcc, g++, and clang

🤖 Generated with [Claude Code](https://claude.com/claude-code)