### PR TITLE
Fix unchecked errors in tree JSON serialization and numerical sampling

### DIFF
--- a/src/cconfigspace_json.h
+++ b/src/cconfigspace_json.h
@@ -660,6 +660,22 @@ err_item:
 	return err;
 }
 
+/* Append a null value to a JSON array. */
+static inline ccs_result_t
+_ccs_json_add_null_to_array(cJSON *array)
+{
+	ccs_result_t err  = CCS_RESULT_SUCCESS;
+	cJSON       *item = cJSON_CreateNull();
+	CCS_REFUTE(!item, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+	CCS_REFUTE_ERR_GOTO(
+		err, !cJSON_AddItemToArray(array, item),
+		CCS_RESULT_ERROR_OUT_OF_MEMORY, err_item);
+	return CCS_RESULT_SUCCESS;
+err_item:
+	cJSON_Delete(item);
+	return err;
+}
+
 /*============================================================================
  * ccs_datum_t JSON helpers
  *============================================================================*/

--- a/src/parameter_numerical.c
+++ b/src/parameter_numerical.c
@@ -198,10 +198,21 @@ _ccs_parameter_numerical_samples(
 			CCS_REFUTE_ERR_GOTO(
 				err, coeff > 32,
 				CCS_RESULT_ERROR_SAMPLING_UNSUCCESSFUL, errmem);
-			size_t         buff_sz = (num_values - found) * coeff;
-			ccs_numeric_t *oldvs   = vs;
-			vs                     = (ccs_numeric_t *)realloc(
-                                oldvs, sizeof(ccs_numeric_t) * buff_sz);
+			size_t         buff_sz;
+			size_t         alloc_sz;
+			ccs_numeric_t *oldvs = vs;
+			CCS_REFUTE_ERR_GOTO(
+				err,
+				_ccs_size_mul(
+					num_values - found, coeff, &buff_sz),
+				CCS_RESULT_ERROR_OUT_OF_MEMORY, errmem);
+			CCS_REFUTE_ERR_GOTO(
+				err,
+				_ccs_size_mul(
+					sizeof(ccs_numeric_t), buff_sz,
+					&alloc_sz),
+				CCS_RESULT_ERROR_OUT_OF_MEMORY, errmem);
+			vs = (ccs_numeric_t *)realloc(oldvs, alloc_sz);
 			if (CCS_UNLIKELY(!vs)) {
 				if (oldvs)
 					free(oldvs);

--- a/src/tree.c
+++ b/src/tree.c
@@ -108,17 +108,7 @@ _ccs_serialize_json_ccs_tree(
 			CCS_VALIDATE(_ccs_json_embed_array_object(
 				children, data->children[i], opts));
 		} else {
-			ccs_result_t null_err  = CCS_RESULT_SUCCESS;
-			cJSON       *null_item = cJSON_CreateNull();
-			CCS_REFUTE(!null_item, CCS_RESULT_ERROR_OUT_OF_MEMORY);
-			CCS_REFUTE_ERR_GOTO(
-				null_err,
-				!cJSON_AddItemToArray(children, null_item),
-				CCS_RESULT_ERROR_OUT_OF_MEMORY, err_null);
-			continue;
-		err_null:
-			cJSON_Delete(null_item);
-			return null_err;
+			CCS_VALIDATE(_ccs_json_add_null_to_array(children));
 		}
 	}
 	return CCS_RESULT_SUCCESS;

--- a/src/tree.c
+++ b/src/tree.c
@@ -108,7 +108,17 @@ _ccs_serialize_json_ccs_tree(
 			CCS_VALIDATE(_ccs_json_embed_array_object(
 				children, data->children[i], opts));
 		} else {
-			cJSON_AddItemToArray(children, cJSON_CreateNull());
+			ccs_result_t null_err  = CCS_RESULT_SUCCESS;
+			cJSON       *null_item = cJSON_CreateNull();
+			CCS_REFUTE(!null_item, CCS_RESULT_ERROR_OUT_OF_MEMORY);
+			CCS_REFUTE_ERR_GOTO(
+				null_err,
+				!cJSON_AddItemToArray(children, null_item),
+				CCS_RESULT_ERROR_OUT_OF_MEMORY, err_null);
+			continue;
+		err_null:
+			cJSON_Delete(null_item);
+			return null_err;
 		}
 	}
 	return CCS_RESULT_SUCCESS;


### PR DESCRIPTION
## Summary
- **tree.c**: `cJSON_CreateNull()` and `cJSON_AddItemToArray()` were called without error checks when serializing NULL tree children to JSON. Added NULL check and proper cleanup on insertion failure.
- **parameter_numerical.c**: Buffer size computation during oversampling (`(num_values - found) * coeff` and `sizeof(ccs_numeric_t) * buff_sz`) used unchecked multiplication that could overflow. Added `_ccs_size_mul()` guards, consistent with the pattern used in `parameter_categorical.c`.

## Test plan
- [x] All 30 tests pass with gcc, g++, and clang (`--enable-strict`)
- [x] Formatted with clang-format-17

🤖 Generated with [Claude Code](https://claude.com/claude-code)