### PR TITLE
Fix critical bugs in Ruby and Python bindings

### DIFF
--- a/bindings/python/cconfigspace/configuration_space.py
+++ b/bindings/python/cconfigspace/configuration_space.py
@@ -50,7 +50,7 @@ class ConfigurationSpace(Context):
           if isinstance(k, Parameter):
             cv[indexdict[k]] = v.handle.value
           elif isinstance(k, str):
-            cv[indexdict[namedict[k]]] = v.handle.value
+            cv[indexdict[ctx[k]]] = v.handle.value
           else:
             cv[k] = v.handle.value
       else:

--- a/bindings/python/cconfigspace/context.py
+++ b/bindings/python/cconfigspace/context.py
@@ -73,9 +73,9 @@ class Context(Object):
 
   def validate_value(self, parameter, value):
     if isinstance(parameter, Parameter):
-      parameter = parameter_index(parameter)
+      parameter = self.parameter_index(parameter)
     elif isinstance(parameter, str):
-      parameter = parameter_index_by_name(parameter)
+      parameter = self.parameter_index_by_name(parameter)
     pv = Datum(value)
     v = DatumFix(pv)
     vo = Datum()

--- a/bindings/python/cconfigspace/map.py
+++ b/bindings/python/cconfigspace/map.py
@@ -28,6 +28,7 @@ class Map(Object):
   def __len__(self):
     v = ct.c_size_t()
     res = ccs_map_get_keys(self.handle, 0, None, ct.byref(v))
+    Error.check(res)
     return v.value
 
   def __getitem__(self, key):

--- a/bindings/python/cconfigspace/tree_space.py
+++ b/bindings/python/cconfigspace/tree_space.py
@@ -73,7 +73,7 @@ class TreeSpace(Object):
     res = ccs_tree_space_get_feature_space(self.handle, ct.byref(v))
     Error.check(res)
     if bool(v):
-      self._feature_space = Rng.from_handle(v)
+      self._feature_space = FeatureSpace.from_handle(v)
     else:
       self._feature_space = None
     return self._feature_space

--- a/bindings/ruby/lib/cconfigspace/distribution_space.rb
+++ b/bindings/ruby/lib/cconfigspace/distribution_space.rb
@@ -31,7 +31,7 @@ module CCS
         when Parameter
           configuration_space.parameter_index(h)
         when String, Symbol
-          configuration_space.parameter_index_by_name(parameter)
+          configuration_space.parameter_index_by_name(h)
         else
           h
         end

--- a/bindings/ruby/lib/cconfigspace/parameter.rb
+++ b/bindings/ruby/lib/cconfigspace/parameter.rb
@@ -87,6 +87,7 @@ module CCS
     def check_values(vals)
       count = vals.size
       return [] if count == 0
+      ss = []
       values = MemoryPointer::new(:ccs_datum_t, count)
       vals.each_with_index { |v, i| Datum::new(values[i]).set_value(v, string_store: ss) }
       ptr = MemoryPointer::new(:ccs_bool_t, count)


### PR DESCRIPTION
## Summary

Six bugs found during a comprehensive binding audit:

**Ruby:**
- `parameter.rb`: `check_values` used undefined variable `ss` — added `ss = []` initialization
- `distribution_space.rb`: `set_distribution` used wrong variable `parameter` instead of `h` in collect block

**Python:**
- `context.py`: `validate_value` called `parameter_index()` without `self.` prefix
- `configuration_space.py`: conditions with string keys referenced undefined `namedict` — use existing `ctx` dict instead
- `tree_space.py`: `feature_space` property used `Rng.from_handle` instead of `FeatureSpace.from_handle`
- `map.py`: `__len__` missing `Error.check()` on `ccs_map_get_keys` result

## Test plan
- [x] Ruby: 126 tests, 0 failures
- [x] Python: 120 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)