### PR TITLE
Add tests for previously uncovered binding code paths

### DIFF
--- a/bindings/python/test/test_configuration_space.py
+++ b/bindings/python/test/test_configuration_space.py
@@ -302,6 +302,41 @@ class TestConfigurationSpace(unittest.TestCase):
   def test_omp_parse_json(self):
     self._test_omp_parse('json')
 
+  def test_set_distribution_string_names(self):
+    h1 = ccs.NumericalParameter.Float()
+    h2 = ccs.NumericalParameter.Float()
+    cs = ccs.ConfigurationSpace(name = "space", parameters = [h1, h2])
+    ds = ccs.DistributionSpace(configuration_space = cs)
+    distributions = [ ccs.UniformDistribution.Float(lower = 0.1, upper = 0.3),
+                      ccs.UniformDistribution.Float(lower = 0.2, upper = 0.6) ]
+    d = ccs.MultivariateDistribution(distributions = distributions)
+    ds.set_distribution(d, [h1.name, h2.name])
+    (dist, indx) = ds.get_parameter_distribution(h1)
+    self.assertEqual( d.handle.value, dist.handle.value )
+    self.assertEqual( 0, indx )
+    (dist, indx) = ds.get_parameter_distribution(h2)
+    self.assertEqual( d.handle.value, dist.handle.value )
+    self.assertEqual( 1, indx )
+
+  def test_conditions_string_keys(self):
+    h1 = ccs.NumericalParameter.Float(lower = -1.0, upper = 1.0, default = 0.0)
+    h2 = ccs.NumericalParameter.Float(lower = -1.0, upper = 1.0)
+    e1 = ccs.Expression.Less(left = h1, right = 0.0)
+    cs = ccs.ConfigurationSpace(name = "space", parameters = [h1, h2], conditions = {h2.name: e1})
+    conditions = cs.conditions
+    self.assertIsNone( conditions[0] )
+    self.assertEqual( e1.handle.value, conditions[1].handle.value )
+
+  def test_validate_value(self):
+    h1 = ccs.NumericalParameter.Float(lower = -1.0, upper = 1.0, default = 0.0)
+    cs = ccs.ConfigurationSpace(name = "space", parameters = [h1])
+    v = cs.validate_value(0, 0.5)
+    self.assertEqual( 0.5, v )
+    v = cs.validate_value(h1, 0.5)
+    self.assertEqual( 0.5, v )
+    v = cs.validate_value(h1.name, 0.5)
+    self.assertEqual( 0.5, v )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/bindings/python/test/test_parameter.py
+++ b/bindings/python/test/test_parameter.py
@@ -324,5 +324,12 @@ class TestParameter(unittest.TestCase):
   def test_serialize_string_json(self):
     self._test_serialize_string('json')
 
+  def test_check_values(self):
+    values = ["foo", 2, 3.0]
+    h = ccs.CategoricalParameter(values = values)
+    results = h.check_values(["foo", 2, 1.5, 3.0])
+    self.assertEqual( [True, True, False, True], results )
+    self.assertEqual( [], h.check_values([]) )
+
 if __name__ == '__main__':
     unittest.main()

--- a/bindings/python/test/test_tree_space.py
+++ b/bindings/python/test/test_tree_space.py
@@ -82,6 +82,19 @@ class TestTreeSpace(unittest.TestCase):
   def test_dynamic_tree_space_json(self):
     self._test_dynamic_tree_space('json')
 
+  def test_static_tree_space_feature_space(self):
+    fe1 = ccs.CategoricalParameter(values = ["on", "off"])
+    fs = ccs.FeatureSpace(parameters = [fe1])
+    tree = generate_tree(4, 0)
+    ts = ccs.StaticTreeSpace(name = 'space', tree = tree, feature_space = fs)
+    self.assertIsInstance( ts.feature_space, ccs.FeatureSpace )
+    self.assertEqual( fs.handle.value, ts.feature_space.handle.value )
+
+  def test_static_tree_space_no_feature_space(self):
+    tree = generate_tree(4, 0)
+    ts = ccs.StaticTreeSpace(name = 'space', tree = tree)
+    self.assertIsNone( ts.feature_space )
+
   def test_tree_configuration(self):
     tree = generate_tree(4, 0)
     ts = ccs.StaticTreeSpace(name = 'space', tree = tree)

--- a/bindings/ruby/lib/cconfigspace/parameter.rb
+++ b/bindings/ruby/lib/cconfigspace/parameter.rb
@@ -92,7 +92,7 @@ module CCS
       vals.each_with_index { |v, i| Datum::new(values[i]).set_value(v, string_store: ss) }
       ptr = MemoryPointer::new(:ccs_bool_t, count)
       CCS.error_check CCS.ccs_parameter_check_values(@handle, count, values, ptr)
-      count.times.collect { |i| ptr[i].read_ccs_bool_t == CCS::FALSE ? false : true }
+      count.times.collect { |i| Pointer.new(:ccs_bool_t, ptr[i]).read_ccs_bool_t == CCS::FALSE ? false : true }
     end
 
     def sample(distribution: default_distribution, rng: CCS::DefaultRng)

--- a/bindings/ruby/test/test_configuration_space.rb
+++ b/bindings/ruby/test/test_configuration_space.rb
@@ -327,4 +327,41 @@ class CConfigSpaceTestConfigurationSpace < Minitest::Test
   def test_omp_parse_json
     _test_omp_parse(:json)
   end
+
+  def test_set_distribution_string_names
+    h1 = CCS::NumericalParameter::Float.new
+    h2 = CCS::NumericalParameter::Float.new
+    cs = CCS::ConfigurationSpace::new(name: "space", parameters: [h1, h2])
+    ds = CCS::DistributionSpace::new(configuration_space: cs)
+    distributions = [ CCS::UniformDistribution::Float.new(lower: 0.1, upper: 0.3), CCS::UniformDistribution::Float.new(lower: 0.2, upper: 0.6) ]
+    d = CCS::MultivariateDistribution::new(distributions: distributions)
+    ds.set_distribution(d, [h1.name, h2.name])
+    dist, indx = ds.get_parameter_distribution(h1)
+    assert_equal( d.handle, dist.handle )
+    assert_equal( 0, indx )
+    dist, indx = ds.get_parameter_distribution(h2)
+    assert_equal( d.handle, dist.handle )
+    assert_equal( 1, indx )
+  end
+
+  def test_conditions_string_keys
+    h1 = CCS::NumericalParameter::Float.new(lower: -1.0, upper: 1.0, default: 0.0)
+    h2 = CCS::NumericalParameter::Float.new(lower: -1.0, upper: 1.0)
+    e1 = CCS::Expression::Less.new(left: h1, right: 0.0)
+    cs = CCS::ConfigurationSpace::new(name: "space", parameters: [h1, h2], conditions: {h2.name => e1})
+    conditions = cs.conditions
+    assert_nil( conditions[0] )
+    assert_equal( e1.handle, conditions[1].handle )
+  end
+
+  def test_validate_value
+    h1 = CCS::NumericalParameter::Float.new(lower: -1.0, upper: 1.0, default: 0.0)
+    cs = CCS::ConfigurationSpace::new(name: "space", parameters: [h1])
+    v = cs.validate_value(0, 0.5)
+    assert_equal( 0.5, v )
+    v = cs.validate_value(h1, 0.5)
+    assert_equal( 0.5, v )
+    v = cs.validate_value(h1.name, 0.5)
+    assert_equal( 0.5, v )
+  end
 end

--- a/bindings/ruby/test/test_parameter.rb
+++ b/bindings/ruby/test/test_parameter.rb
@@ -313,4 +313,12 @@ class CConfigSpaceTestParameter < Minitest::Test
     string_check(href.dup)
   end
 
+  def test_check_values
+    values = ["foo", 2, 3.0]
+    h = CCS::CategoricalParameter::new(values: values)
+    results = h.check_values(["foo", 2, 1.5, 3.0])
+    assert_equal( [true, true, false, true], results )
+    assert_equal( [], h.check_values([]) )
+  end
+
 end

--- a/bindings/ruby/test/test_tree_space.rb
+++ b/bindings/ruby/test/test_tree_space.rb
@@ -83,6 +83,21 @@ class CConfigSpaceTestTreeSpace < Minitest::Test
     _test_dynamic_tree_space(:json)
   end
 
+  def test_static_tree_space_feature_space
+    fe1 = CCS::CategoricalParameter::new(values: ["on", "off"])
+    fs = CCS::FeatureSpace::new(parameters: [fe1])
+    tree = generate_tree(4, 0)
+    ts = CCS::StaticTreeSpace.new(name: 'space', tree: tree, feature_space: fs)
+    assert_instance_of( CCS::FeatureSpace, ts.feature_space )
+    assert_equal( fs.handle, ts.feature_space.handle )
+  end
+
+  def test_static_tree_space_no_feature_space
+    tree = generate_tree(4, 0)
+    ts = CCS::StaticTreeSpace.new(name: 'space', tree: tree)
+    assert_nil( ts.feature_space )
+  end
+
   def test_tree_configuration
     tree = generate_tree(4, 0)
     ts = CCS::StaticTreeSpace.new(name: 'space', tree: tree)


### PR DESCRIPTION
## Summary

Add tests covering the code paths where bugs were fixed in #114, plus a bonus fix:

- **parameter check_values**: Tests the multi-value check method. Also fixes a pre-existing bug in Ruby where `ptr[i]` returns a plain `FFI::Pointer` lacking the `read_ccs_bool_t` method — wrap with `Pointer.new(:ccs_bool_t, ptr[i])`.
- **configuration_space conditions with string keys**: Exercises the string-keyed conditions path that had the `namedict` / `parameter` vs `h` bugs.
- **configuration_space validate_value**: Exercises the `self.parameter_index` / `self.parameter_index_by_name` paths with Parameter objects and strings.
- **distribution_space set_distribution with string names**: Exercises the string name lookup path in `set_distribution`.
- **tree_space feature_space property**: Exercises the `FeatureSpace.from_handle` path (was `Rng.from_handle`), with and without feature space.

## Test plan
- [x] Ruby: 132 tests, 0 failures (was 126)
- [x] Python: 126 tests, 0 failures (was 120)

🤖 Generated with [Claude Code](https://claude.com/claude-code)