### PR TITLE
Add JSON serialization tests for remaining C test files

### DIFF
--- a/tests/test_dynamic_tree_space.c
+++ b/tests/test_dynamic_tree_space.c
@@ -61,7 +61,7 @@ deserialize_vector_callback(
 }
 
 void
-test_dynamic_tree_space(void)
+test_dynamic_tree_space(ccs_serialize_format_t format)
 {
 	ccs_result_t             err;
 	ccs_tree_t               root, tree;
@@ -147,8 +147,7 @@ test_dynamic_tree_space(void)
 	size_t buff_size;
 
 	err = ccs_object_serialize(
-		tree_space, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
+		tree_space, format, CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
 		CCS_SERIALIZE_OPTION_END);
 	assert(err == CCS_RESULT_SUCCESS);
 
@@ -156,9 +155,8 @@ test_dynamic_tree_space(void)
 	assert(buff);
 
 	err = ccs_object_serialize(
-		tree_space, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_MEMORY, buff_size, buff,
-		CCS_SERIALIZE_OPTION_END);
+		tree_space, format, CCS_SERIALIZE_OPERATION_MEMORY, buff_size,
+		buff, CCS_SERIALIZE_OPTION_END);
 	assert(err == CCS_RESULT_SUCCESS);
 
 	err = ccs_tree_space_samples(
@@ -194,7 +192,7 @@ test_dynamic_tree_space(void)
 	assert(err == CCS_RESULT_SUCCESS);
 
 	err = ccs_object_deserialize(
-		(ccs_object_t *)&tree_space, CCS_SERIALIZE_FORMAT_BINARY,
+		(ccs_object_t *)&tree_space, format,
 		CCS_DESERIALIZE_OPERATION_MEMORY, buff_size, buff,
 		CCS_DESERIALIZE_OPTION_VECTOR_CALLBACK,
 		&deserialize_vector_callback, (void *)NULL,
@@ -289,7 +287,7 @@ deserialize_vector_callback_with_state(
 }
 
 void
-test_dynamic_tree_space_with_feature_space(void)
+test_dynamic_tree_space_with_feature_space(ccs_serialize_format_t format)
 {
 	ccs_result_t             err;
 	ccs_tree_t               root;
@@ -331,8 +329,7 @@ test_dynamic_tree_space_with_feature_space(void)
 
 	/* Serialize with user state callbacks */
 	err = ccs_object_serialize(
-		tree_space, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
+		tree_space, format, CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
 		CCS_SERIALIZE_OPTION_END);
 	assert(err == CCS_RESULT_SUCCESS);
 
@@ -340,14 +337,13 @@ test_dynamic_tree_space_with_feature_space(void)
 	assert(buff);
 
 	err = ccs_object_serialize(
-		tree_space, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_MEMORY, buff_size, buff,
-		CCS_SERIALIZE_OPTION_END);
+		tree_space, format, CCS_SERIALIZE_OPERATION_MEMORY, buff_size,
+		buff, CCS_SERIALIZE_OPTION_END);
 	assert(err == CCS_RESULT_SUCCESS);
 
 	/* Deserialize with vector callback */
 	err = ccs_object_deserialize(
-		(ccs_object_t *)&tree_space2, CCS_SERIALIZE_FORMAT_BINARY,
+		(ccs_object_t *)&tree_space2, format,
 		CCS_DESERIALIZE_OPERATION_MEMORY, buff_size, buff,
 		CCS_DESERIALIZE_OPTION_VECTOR_CALLBACK,
 		&deserialize_vector_callback_with_state, (void *)NULL,
@@ -376,8 +372,10 @@ int
 main(void)
 {
 	ccs_init();
-	test_dynamic_tree_space();
-	test_dynamic_tree_space_with_feature_space();
+	test_dynamic_tree_space(CCS_SERIALIZE_FORMAT_BINARY);
+	test_dynamic_tree_space(CCS_SERIALIZE_FORMAT_JSON);
+	test_dynamic_tree_space_with_feature_space(CCS_SERIALIZE_FORMAT_BINARY);
+	test_dynamic_tree_space_with_feature_space(CCS_SERIALIZE_FORMAT_JSON);
 	ccs_clear_thread_error();
 	ccs_fini();
 	return 0;

--- a/tests/test_random_features_tuner.c
+++ b/tests/test_random_features_tuner.c
@@ -5,7 +5,7 @@
 #include "test_utils.h"
 
 void
-test(void)
+test(ccs_serialize_format_t format)
 {
 	ccs_configuration_space_t cspace;
 	ccs_feature_space_t       fspace;
@@ -131,21 +131,19 @@ test(void)
 	err = ccs_create_map(&map);
 	assert(err == CCS_RESULT_SUCCESS);
 	err = ccs_object_serialize(
-		tuner, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
+		tuner, format, CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
 		CCS_SERIALIZE_OPTION_END);
 	assert(err == CCS_RESULT_SUCCESS);
 	buff = (char *)malloc(buff_size);
 	assert(buff);
 
 	err = ccs_object_serialize(
-		tuner, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_MEMORY, buff_size, buff,
+		tuner, format, CCS_SERIALIZE_OPERATION_MEMORY, buff_size, buff,
 		CCS_SERIALIZE_OPTION_END);
 	assert(err == CCS_RESULT_SUCCESS);
 
 	err = ccs_object_deserialize(
-		(ccs_object_t *)&tuner_copy, CCS_SERIALIZE_FORMAT_BINARY,
+		(ccs_object_t *)&tuner_copy, format,
 		CCS_DESERIALIZE_OPERATION_MEMORY, buff_size, buff,
 		CCS_DESERIALIZE_OPTION_HANDLE_MAP, map,
 		CCS_DESERIALIZE_OPTION_MAP_HANDLES, CCS_DESERIALIZE_OPTION_END);
@@ -184,7 +182,7 @@ test(void)
 }
 
 void
-test_evaluation_deserialize(void)
+test_evaluation_deserialize(ccs_serialize_format_t format)
 {
 	ccs_configuration_space_t cspace;
 	ccs_feature_space_t       fspace;
@@ -216,21 +214,19 @@ test_evaluation_deserialize(void)
 	err = ccs_create_map(&map);
 	assert(err == CCS_RESULT_SUCCESS);
 	err = ccs_object_serialize(
-		evaluation_ref, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
-		CCS_SERIALIZE_OPTION_END);
+		evaluation_ref, format, CCS_SERIALIZE_OPERATION_SIZE,
+		&buff_size, CCS_SERIALIZE_OPTION_END);
 	assert(err == CCS_RESULT_SUCCESS);
 	buff = (char *)malloc(buff_size);
 	assert(buff);
 
 	err = ccs_object_serialize(
-		evaluation_ref, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_MEMORY, buff_size, buff,
-		CCS_SERIALIZE_OPTION_END);
+		evaluation_ref, format, CCS_SERIALIZE_OPERATION_MEMORY,
+		buff_size, buff, CCS_SERIALIZE_OPTION_END);
 	assert(err == CCS_RESULT_SUCCESS);
 
 	err = ccs_object_deserialize(
-		(ccs_object_t *)&evaluation, CCS_SERIALIZE_FORMAT_BINARY,
+		(ccs_object_t *)&evaluation, format,
 		CCS_DESERIALIZE_OPERATION_MEMORY, buff_size, buff,
 		CCS_DESERIALIZE_OPTION_HANDLE_MAP, map,
 		CCS_DESERIALIZE_OPTION_END);
@@ -242,7 +238,7 @@ test_evaluation_deserialize(void)
 	assert(err == CCS_RESULT_SUCCESS);
 
 	err = ccs_object_deserialize(
-		(ccs_object_t *)&evaluation, CCS_SERIALIZE_FORMAT_BINARY,
+		(ccs_object_t *)&evaluation, format,
 		CCS_DESERIALIZE_OPERATION_MEMORY, buff_size, buff,
 		CCS_DESERIALIZE_OPTION_HANDLE_MAP, map,
 		CCS_DESERIALIZE_OPTION_END);
@@ -254,7 +250,7 @@ test_evaluation_deserialize(void)
 	assert(err == CCS_RESULT_SUCCESS);
 
 	err = ccs_object_deserialize(
-		(ccs_object_t *)&evaluation, CCS_SERIALIZE_FORMAT_BINARY,
+		(ccs_object_t *)&evaluation, format,
 		CCS_DESERIALIZE_OPERATION_MEMORY, buff_size, buff,
 		CCS_DESERIALIZE_OPTION_HANDLE_MAP, map,
 		CCS_DESERIALIZE_OPTION_END);
@@ -266,7 +262,7 @@ test_evaluation_deserialize(void)
 	assert(err == CCS_RESULT_SUCCESS);
 
 	err = ccs_object_deserialize(
-		(ccs_object_t *)&evaluation, CCS_SERIALIZE_FORMAT_BINARY,
+		(ccs_object_t *)&evaluation, format,
 		CCS_DESERIALIZE_OPERATION_MEMORY, buff_size, buff,
 		CCS_DESERIALIZE_OPTION_HANDLE_MAP, map,
 		CCS_DESERIALIZE_OPTION_END);
@@ -300,8 +296,11 @@ int
 main(void)
 {
 	ccs_init();
-	test();
-	test_evaluation_deserialize();
+	test(CCS_SERIALIZE_FORMAT_BINARY);
+	test(CCS_SERIALIZE_FORMAT_JSON);
+	test_evaluation_deserialize(CCS_SERIALIZE_FORMAT_BINARY);
+	ccs_clear_thread_error();
+	test_evaluation_deserialize(CCS_SERIALIZE_FORMAT_JSON);
 	ccs_clear_thread_error();
 	ccs_fini();
 	return 0;

--- a/tests/test_random_tree_tuner.c
+++ b/tests/test_random_tree_tuner.c
@@ -58,7 +58,7 @@ create_tree_tuning_problem(
 }
 
 void
-test(void)
+test(ccs_serialize_format_t format)
 {
 	ccs_tree_space_t      tree_space;
 	ccs_objective_space_t ospace;
@@ -129,21 +129,19 @@ test(void)
 	err = ccs_create_map(&map);
 	assert(err == CCS_RESULT_SUCCESS);
 	err = ccs_object_serialize(
-		tuner, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
+		tuner, format, CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
 		CCS_SERIALIZE_OPTION_END);
 	assert(err == CCS_RESULT_SUCCESS);
 	buff = (char *)malloc(buff_size);
 	assert(buff);
 
 	err = ccs_object_serialize(
-		tuner, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_MEMORY, buff_size, buff,
+		tuner, format, CCS_SERIALIZE_OPERATION_MEMORY, buff_size, buff,
 		CCS_SERIALIZE_OPTION_END);
 	assert(err == CCS_RESULT_SUCCESS);
 
 	err = ccs_object_deserialize(
-		(ccs_object_t *)&tuner_copy, CCS_SERIALIZE_FORMAT_BINARY,
+		(ccs_object_t *)&tuner_copy, format,
 		CCS_DESERIALIZE_OPERATION_MEMORY, buff_size, buff,
 		CCS_DESERIALIZE_OPTION_HANDLE_MAP, map,
 		CCS_DESERIALIZE_OPTION_MAP_HANDLES, CCS_DESERIALIZE_OPTION_END);
@@ -176,7 +174,7 @@ test(void)
 }
 
 void
-test_tree_evaluation_deserialize(void)
+test_tree_evaluation_deserialize(ccs_serialize_format_t format)
 {
 	ccs_tree_space_t         tree_space;
 	ccs_objective_space_t    ospace;
@@ -203,20 +201,18 @@ test_tree_evaluation_deserialize(void)
 	err = ccs_create_map(&map);
 	assert(err == CCS_RESULT_SUCCESS);
 	err = ccs_object_serialize(
-		evaluation_ref, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
-		CCS_SERIALIZE_OPTION_END);
+		evaluation_ref, format, CCS_SERIALIZE_OPERATION_SIZE,
+		&buff_size, CCS_SERIALIZE_OPTION_END);
 	assert(err == CCS_RESULT_SUCCESS);
 	buff = (char *)malloc(buff_size);
 	assert(buff);
 	err = ccs_object_serialize(
-		evaluation_ref, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_MEMORY, buff_size, buff,
-		CCS_SERIALIZE_OPTION_END);
+		evaluation_ref, format, CCS_SERIALIZE_OPERATION_MEMORY,
+		buff_size, buff, CCS_SERIALIZE_OPTION_END);
 	assert(err == CCS_RESULT_SUCCESS);
 
 	err = ccs_object_deserialize(
-		(ccs_object_t *)&evaluation, CCS_SERIALIZE_FORMAT_BINARY,
+		(ccs_object_t *)&evaluation, format,
 		CCS_DESERIALIZE_OPERATION_MEMORY, buff_size, buff,
 		CCS_DESERIALIZE_OPTION_HANDLE_MAP, map,
 		CCS_DESERIALIZE_OPTION_END);
@@ -228,7 +224,7 @@ test_tree_evaluation_deserialize(void)
 	assert(err == CCS_RESULT_SUCCESS);
 
 	err = ccs_object_deserialize(
-		(ccs_object_t *)&evaluation, CCS_SERIALIZE_FORMAT_BINARY,
+		(ccs_object_t *)&evaluation, format,
 		CCS_DESERIALIZE_OPERATION_MEMORY, buff_size, buff,
 		CCS_DESERIALIZE_OPTION_HANDLE_MAP, map,
 		CCS_DESERIALIZE_OPTION_END);
@@ -240,7 +236,7 @@ test_tree_evaluation_deserialize(void)
 	assert(err == CCS_RESULT_SUCCESS);
 
 	err = ccs_object_deserialize(
-		(ccs_object_t *)&evaluation, CCS_SERIALIZE_FORMAT_BINARY,
+		(ccs_object_t *)&evaluation, format,
 		CCS_DESERIALIZE_OPERATION_MEMORY, buff_size, buff,
 		CCS_DESERIALIZE_OPTION_HANDLE_MAP, map,
 		CCS_DESERIALIZE_OPTION_END);
@@ -270,8 +266,11 @@ int
 main(void)
 {
 	ccs_init();
-	test();
-	test_tree_evaluation_deserialize();
+	test(CCS_SERIALIZE_FORMAT_BINARY);
+	test(CCS_SERIALIZE_FORMAT_JSON);
+	test_tree_evaluation_deserialize(CCS_SERIALIZE_FORMAT_BINARY);
+	ccs_clear_thread_error();
+	test_tree_evaluation_deserialize(CCS_SERIALIZE_FORMAT_JSON);
 	ccs_clear_thread_error();
 	ccs_fini();
 	return 0;

--- a/tests/test_user_defined_features_tuner.c
+++ b/tests/test_user_defined_features_tuner.c
@@ -170,7 +170,7 @@ deserialize_vector_callback(
 }
 
 void
-test(void)
+test(ccs_serialize_format_t format)
 {
 	ccs_configuration_space_t cspace;
 	ccs_feature_space_t       fspace;
@@ -272,21 +272,19 @@ test(void)
 	err = ccs_create_map(&map);
 	assert(err == CCS_RESULT_SUCCESS);
 	err = ccs_object_serialize(
-		tuner, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
+		tuner, format, CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
 		CCS_SERIALIZE_OPTION_END);
 	assert(err == CCS_RESULT_SUCCESS);
 	buff = (char *)malloc(buff_size);
 	assert(buff);
 
 	err = ccs_object_serialize(
-		tuner, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_MEMORY, buff_size, buff,
+		tuner, format, CCS_SERIALIZE_OPERATION_MEMORY, buff_size, buff,
 		CCS_SERIALIZE_OPTION_END);
 	assert(err == CCS_RESULT_SUCCESS);
 
 	err = ccs_object_deserialize(
-		(ccs_object_t *)&tuner_copy, CCS_SERIALIZE_FORMAT_BINARY,
+		(ccs_object_t *)&tuner_copy, format,
 		CCS_DESERIALIZE_OPERATION_MEMORY, buff_size, buff,
 		CCS_DESERIALIZE_OPTION_HANDLE_MAP, map,
 		CCS_DESERIALIZE_OPTION_MAP_HANDLES,
@@ -331,7 +329,9 @@ int
 main(void)
 {
 	ccs_init();
-	test();
+	test(CCS_SERIALIZE_FORMAT_BINARY);
+	ccs_clear_thread_error();
+	test(CCS_SERIALIZE_FORMAT_JSON);
 	ccs_clear_thread_error();
 	ccs_fini();
 	return 0;

--- a/tests/test_user_defined_tree_tuner.c
+++ b/tests/test_user_defined_tree_tuner.c
@@ -216,7 +216,7 @@ deserialize_vector_callback(
 }
 
 void
-test(void)
+test(ccs_serialize_format_t format)
 {
 	ccs_tree_space_t      tree_space;
 	ccs_objective_space_t ospace;
@@ -283,21 +283,19 @@ test(void)
 	err = ccs_create_map(&map);
 	assert(err == CCS_RESULT_SUCCESS);
 	err = ccs_object_serialize(
-		tuner, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
+		tuner, format, CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
 		CCS_SERIALIZE_OPTION_END);
 	assert(err == CCS_RESULT_SUCCESS);
 	buff = (char *)malloc(buff_size);
 	assert(buff);
 
 	err = ccs_object_serialize(
-		tuner, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_MEMORY, buff_size, buff,
+		tuner, format, CCS_SERIALIZE_OPERATION_MEMORY, buff_size, buff,
 		CCS_SERIALIZE_OPTION_END);
 	assert(err == CCS_RESULT_SUCCESS);
 
 	err = ccs_object_deserialize(
-		(ccs_object_t *)&tuner_copy, CCS_SERIALIZE_FORMAT_BINARY,
+		(ccs_object_t *)&tuner_copy, format,
 		CCS_DESERIALIZE_OPERATION_MEMORY, buff_size, buff,
 		CCS_DESERIALIZE_OPTION_HANDLE_MAP, map,
 		CCS_DESERIALIZE_OPTION_MAP_HANDLES,
@@ -336,7 +334,9 @@ int
 main(void)
 {
 	ccs_init();
-	test();
+	test(CCS_SERIALIZE_FORMAT_BINARY);
+	ccs_clear_thread_error();
+	test(CCS_SERIALIZE_FORMAT_JSON);
 	ccs_clear_thread_error();
 	ccs_fini();
 	return 0;

--- a/tests/test_user_defined_tuner.c
+++ b/tests/test_user_defined_tuner.c
@@ -163,7 +163,7 @@ deserialize_vector_callback(
 }
 
 void
-test(void)
+test(ccs_serialize_format_t format)
 {
 	ccs_configuration_space_t cspace;
 	ccs_objective_space_t     ospace;
@@ -226,21 +226,19 @@ test(void)
 	err = ccs_create_map(&map);
 	assert(err == CCS_RESULT_SUCCESS);
 	err = ccs_object_serialize(
-		tuner, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
+		tuner, format, CCS_SERIALIZE_OPERATION_SIZE, &buff_size,
 		CCS_SERIALIZE_OPTION_END);
 	assert(err == CCS_RESULT_SUCCESS);
 	buff = (char *)malloc(buff_size);
 	assert(buff);
 
 	err = ccs_object_serialize(
-		tuner, CCS_SERIALIZE_FORMAT_BINARY,
-		CCS_SERIALIZE_OPERATION_MEMORY, buff_size, buff,
+		tuner, format, CCS_SERIALIZE_OPERATION_MEMORY, buff_size, buff,
 		CCS_SERIALIZE_OPTION_END);
 	assert(err == CCS_RESULT_SUCCESS);
 
 	err = ccs_object_deserialize(
-		(ccs_object_t *)&tuner_copy, CCS_SERIALIZE_FORMAT_BINARY,
+		(ccs_object_t *)&tuner_copy, format,
 		CCS_DESERIALIZE_OPERATION_MEMORY, buff_size, buff,
 		CCS_DESERIALIZE_OPTION_HANDLE_MAP, map,
 		CCS_DESERIALIZE_OPTION_MAP_HANDLES,
@@ -279,7 +277,9 @@ int
 main(void)
 {
 	ccs_init();
-	test();
+	test(CCS_SERIALIZE_FORMAT_BINARY);
+	ccs_clear_thread_error();
+	test(CCS_SERIALIZE_FORMAT_JSON);
 	ccs_clear_thread_error();
 	ccs_fini();
 	return 0;


### PR DESCRIPTION
## Summary

Parameterize serialize/deserialize tests in the 6 remaining C test files that only tested binary format:
- `test_user_defined_tuner.c`
- `test_dynamic_tree_space.c` (basic + feature_space variants)
- `test_random_features_tuner.c` (tuner + evaluation deserialize)
- `test_user_defined_features_tuner.c`
- `test_random_tree_tuner.c` (tuner + tree evaluation deserialize)
- `test_user_defined_tree_tuner.c`

Each test function now accepts a `ccs_serialize_format_t` parameter and is called with both `BINARY` and `JSON`. Error path tests (missing handle map entries) are also exercised with JSON.

All C tests now have JSON serialization coverage.

## Test plan

- [x] All 30 C tests pass
- [x] All 6 Ubuntu CI matrix configurations pass (gcc/g++/clang × thread-safe/no-thread-safe)
- [x] clang-format-17 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)