### PR TITLE
Document serialize strategy choice in Python and Ruby bindings

### DIFF
--- a/bindings/python/cconfigspace/base.py
+++ b/bindings/python/cconfigspace/base.py
@@ -559,6 +559,8 @@ class Object:
       Error.check(res)
       return None
     elif fmt == SerializeFormat.BINARY:
+      # Binary uses SIZE+MEMORY to minimize copies: the caller
+      # provides the buffer so no extra allocation is needed.
       s = ct.c_size_t(0)
       res = ccs_object_serialize(self.handle, fmt, SerializeOperation.SIZE, ct.byref(s), *options)
       Error.check(res)
@@ -567,6 +569,8 @@ class Object:
       Error.check(res)
       return v.raw
     else:
+      # JSON uses BUFFER to avoid building the cJSON tree twice
+      # (once for SIZE, once for MEMORY).
       buf_ptr = ct.c_void_p()
       buf_sz = ct.c_size_t(0)
       res = ccs_object_serialize(self.handle, fmt, SerializeOperation.BUFFER, ct.byref(buf_ptr), ct.byref(buf_sz), *options)

--- a/bindings/ruby/lib/cconfigspace/base.rb
+++ b/bindings/ruby/lib/cconfigspace/base.rb
@@ -734,6 +734,8 @@ module CCS
         CCS.error_check CCS.ccs_object_serialize(@handle, format, :CCS_SERIALIZE_OPERATION_FILE_DESCRIPTOR, *varargs)
         return nil
       elsif format == :CCS_SERIALIZE_FORMAT_BINARY
+        # Binary uses SIZE+MEMORY to minimize copies: the caller
+        # provides the buffer so no extra allocation is needed.
         sz = MemoryPointer::new(:size_t)
         varargs = [:pointer, sz] + options
         CCS.error_check CCS.ccs_object_serialize(@handle, format, :CCS_SERIALIZE_OPERATION_SIZE, *varargs)
@@ -743,6 +745,8 @@ module CCS
         CCS.error_check CCS.ccs_object_serialize(@handle, format, :CCS_SERIALIZE_OPERATION_MEMORY, *varargs)
         return result
       else
+        # JSON uses BUFFER to avoid building the cJSON tree twice
+        # (once for SIZE, once for MEMORY).
         buf_ptr = MemoryPointer::new(:pointer)
         buf_sz = MemoryPointer::new(:size_t)
         varargs = [:pointer, buf_ptr, :pointer, buf_sz] + options


### PR DESCRIPTION
## Summary

Add comments explaining why binary and JSON use different serialization strategies in both Python and Ruby bindings:
- **Binary**: SIZE+MEMORY minimizes copies (caller provides the buffer)
- **JSON**: BUFFER avoids building the cJSON tree twice (once for SIZE, once for MEMORY)

## Test plan

- [x] All tests pass (30 C, 132 Ruby, 126 Python, 2 samples)

🤖 Generated with [Claude Code](https://claude.com/claude-code)