### PR TITLE
Document JSON serialization format in README and CONCEPTS

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -473,17 +473,27 @@ using `ccs_expression_eval()`.
 <a id="serialization"></a>
 ## Serialization
 
-CCS supports **binary serialization** (`CCS_SERIALIZE_FORMAT_BINARY`) for all
-object types. This lets you save and restore tuner state, configuration spaces,
-evaluations, and other objects.
+CCS supports serialization of all object types in two formats:
 
-Serialization targets:
+- **Binary** (`CCS_SERIALIZE_FORMAT_BINARY`) — compact and fast, suitable for
+  checkpointing and IPC
+- **JSON** (`CCS_SERIALIZE_FORMAT_JSON`) — human-readable, suitable for
+  inspection, interoperability, and version control of configuration spaces
 
-- **Memory buffer** (`CCS_SERIALIZE_OPERATION_MEMORY`)
+Both formats support the same set of operations:
+
+- **Memory buffer** (`CCS_SERIALIZE_OPERATION_MEMORY`) — serialize into a
+  caller-provided buffer
+- **Library-allocated buffer** (`CCS_SERIALIZE_OPERATION_BUFFER`) — the library
+  allocates the buffer; the caller must free it with `ccs_release_buffer()`
 - **File path** (`CCS_SERIALIZE_OPERATION_FILE`)
 - **File descriptor** (`CCS_SERIALIZE_OPERATION_FILE_DESCRIPTOR`)
 - **Size query** (`CCS_SERIALIZE_OPERATION_SIZE`) — compute the buffer size
-  needed
+  needed for `MEMORY`
+
+The JSON format handles non-finite IEEE 754 values (`Infinity`, `-Infinity`,
+`NaN`) by encoding them as strings while preserving the numeric type, so they
+survive round-trip serialization.
 
 Use `ccs_object_serialize()` to serialize and `ccs_object_deserialize()` to
 restore. For user-defined objects (tuners, expressions), custom serialization

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ auto-tuning needs. It was greatly inspired by
   optimization
 - **Tree spaces**: static and dynamic tree-structured search spaces
 - **Expressions**: expression trees for conditions and forbidden clauses
-- **Serialization**: binary serialization/deserialization of all objects
+- **Serialization**: binary and JSON serialization/deserialization of all objects
 - **Thread safety**: optional thread-safe mode (`--enable-thread-safe`,
   enabled by default)
 - **Bindings**: Ruby and Python bindings


### PR DESCRIPTION
## Summary

- Update README.md feature list: "binary serialization" → "binary and JSON serialization"
- Rewrite CONCEPTS.md serialization section to cover:
  - Both formats (binary and JSON) with their use cases
  - The BUFFER operation and `ccs_release_buffer()`
  - Non-finite float handling (Infinity/NaN encoded as strings)

## Test plan

Documentation-only change, no code modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)