### PR TITLE
Fix method redefined warning in Ruby expression parser test

### DIFF
--- a/bindings/ruby/test/test_expression_parser.rb
+++ b/bindings/ruby/test/test_expression_parser.rb
@@ -59,10 +59,11 @@ class CConfigSpaceTestExpressionParser < Minitest::Test
     assert_equal( "none", res.to_s )
   end
 
+  def func(a, b)
+    a * b
+  end
+
   def _test_function(fmt)
-    def func(a, b)
-      a * b
-    end
     exp = "func(3, 4)"
     res = CCS.parse(exp, binding: binding)
     assert( res.kind_of? CCS::Expression::UserDefined )


### PR DESCRIPTION
## Summary

Move `func` method definition from inside `_test_function` to class level in `test_expression_parser.rb`. Defining it inside the method caused Ruby to redefine it on each call (binary and JSON formats), producing the warning:

```
test_expression_parser.rb:63: warning: method redefined; discarding old func
test_expression_parser.rb:63: warning: previous definition of func was here
```

## Test plan

- [x] Ruby: 132 runs, 0 failures, 0 warnings
- [x] `func` still accessible via `binding` for expression parser

🤖 Generated with [Claude Code](https://claude.com/claude-code)