### PR TITLE
Fix typos and include CONCEPTS.md in distribution tarball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -26,10 +26,11 @@ EXTRA_DIST = \
 	autogen.sh \
 	cconfigspace.pc.subst \
 	README.md \
+	CONCEPTS.md \
 	build-aux/git-version-gen \
 	build-aux/version-subst
 
 dist-hook: .version
-	@echo Creating ditribution .tarball-version; echo v$(CURVER) > $(distdir)/.tarball-version
+	@echo Creating distribution .tarball-version; echo v$(CURVER) > $(distdir)/.tarball-version
 
 @DYNAMIC_VERSION_RULES@

--- a/configure.ac
+++ b/configure.ac
@@ -43,7 +43,7 @@ AC_ARG_ENABLE([strict], AS_HELP_STRING([--enable-strict], [Enable -Werror]),
 AM_CONDITIONAL([STRICT], [test "x$enable_strict" = xyes])
 
 AC_ARG_ENABLE([thread-safe],
-              AS_HELP_STRING([--enable-thread-safe], [Build with thread saffety enabled]),
+              AS_HELP_STRING([--enable-thread-safe], [Build with thread safety enabled]),
               [], [enable_thread_safe=yes])
 AM_CONDITIONAL([THREAD_SAFE], [test "x$enable_thread_safe" = xyes])
 


### PR DESCRIPTION
## Summary

- Fix typo in `configure.ac`: "thread saffety" → "thread safety"
- Fix typo in `Makefile.am`: "ditribution" → "distribution"
- Add `CONCEPTS.md` to `EXTRA_DIST` so it is included in release tarballs

## Test plan

- [x] All 30 C tests pass
- [x] `make dist` includes CONCEPTS.md in tarball

🤖 Generated with [Claude Code](https://claude.com/claude-code)