### PR TITLE
Fix undefined behavior and add sanitizer CI builds

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -63,6 +63,40 @@ jobs:
             build/**/*.log
             build/config.log
 
+  sanitizers:
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    name: Sanitizers ${{ matrix.sanitizer }}${{ matrix.threadsafe && ' ' || ' No Thread Safe' }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        sanitizer: [address, undefined]
+        threadsafe: [true, false]
+
+    steps:
+      - uses: actions/checkout@v4
+      - run: sudo apt update; sudo apt install -y clang ruby-dev libgsl-dev python3-dev
+      - run: gem install --user-install rake ffi ffi-value whittle xmlrpc
+      - run: pip3 install --user parglare
+      - run: ./autogen.sh
+      - run: mkdir -p build
+      - run: ../configure --enable-strict${{ matrix.threadsafe && ' --enable-thread-safe' || ' --disable-thread-safe' }} CC=clang CFLAGS="-gdwarf-4 -O2 -fsanitize=${{ matrix.sanitizer }} -fno-omit-frame-pointer" LDFLAGS="-fsanitize=${{ matrix.sanitizer }}"
+        working-directory: build
+      - run: make -j
+        working-directory: build
+      - run: make -j check
+        working-directory: build
+        env:
+          ASAN_OPTIONS: detect_leaks=1
+          UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: sanitizers-${{ matrix.sanitizer }}-${{ matrix.threadsafe && 'ts' || 'nots' }}
+          path: |
+            build/**/*.log
+            build/config.log
+
   distcheck:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -75,9 +75,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - run: sudo apt update; sudo apt install -y clang ruby-dev libgsl-dev python3-dev
-      - run: gem install --user-install rake ffi ffi-value whittle xmlrpc
-      - run: pip3 install --user parglare
+      - run: sudo apt update; sudo apt install -y clang libgsl-dev
       - run: ./autogen.sh
       - run: mkdir -p build
       - run: ../configure --enable-strict${{ matrix.threadsafe && ' --enable-thread-safe' || ' --disable-thread-safe' }} CC=clang CFLAGS="-gdwarf-4 -O2 -fsanitize=${{ matrix.sanitizer }} -fno-omit-frame-pointer" LDFLAGS="-fsanitize=${{ matrix.sanitizer }}"
@@ -85,7 +83,7 @@ jobs:
       - run: make -j
         working-directory: build
       - run: make -j check
-        working-directory: build
+        working-directory: build/tests
         env:
           ASAN_OPTIONS: detect_leaks=1
           UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -136,9 +136,10 @@ _ccs_configuration_serialize(
 }
 
 static ccs_result_t
-_ccs_configuration_hash(ccs_configuration_t configuration, ccs_hash_t *hash_ret)
+_ccs_configuration_hash(ccs_binding_t binding, ccs_hash_t *hash_ret)
 {
-	ccs_hash_t h, ht;
+	ccs_configuration_t configuration = (ccs_configuration_t)binding;
+	ccs_hash_t          h, ht;
 	if (configuration->data->features)
 		CCS_VALIDATE(_ccs_binding_hash(
 			(ccs_binding_t)configuration->data->features, &h));
@@ -152,10 +153,12 @@ _ccs_configuration_hash(ccs_configuration_t configuration, ccs_hash_t *hash_ret)
 
 static ccs_result_t
 _ccs_configuration_cmp(
-	ccs_configuration_t configuration,
-	ccs_configuration_t other,
-	int                *cmp_ret)
+	ccs_binding_t binding,
+	ccs_binding_t other_binding,
+	int          *cmp_ret)
 {
+	ccs_configuration_t configuration = (ccs_configuration_t)binding;
+	ccs_configuration_t other         = (ccs_configuration_t)other_binding;
 	if (configuration->data->features || other->data->features) {
 		if (!configuration->data->features || !other->data->features) {
 			*cmp_ret = configuration->data->features ? 1 : -1;

--- a/src/configuration_internal.h
+++ b/src/configuration_internal.h
@@ -8,13 +8,10 @@ typedef struct _ccs_configuration_data_s _ccs_configuration_data_t;
 struct _ccs_configuration_ops_s {
 	_ccs_object_ops_t obj_ops;
 
-	ccs_result_t (
-		*hash)(ccs_configuration_t configuration, ccs_hash_t *hash_ret);
+	ccs_result_t (*hash)(ccs_binding_t binding, ccs_hash_t *hash_ret);
 
-	ccs_result_t (*cmp)(
-		ccs_configuration_t configuration,
-		ccs_configuration_t other,
-		int                *cmp_ret);
+	ccs_result_t (
+		*cmp)(ccs_binding_t binding, ccs_binding_t other, int *cmp_ret);
 };
 typedef struct _ccs_configuration_ops_s _ccs_configuration_ops_t;
 

--- a/src/evaluation.c
+++ b/src/evaluation.c
@@ -145,9 +145,10 @@ _ccs_evaluation_serialize(
 }
 
 static ccs_result_t
-_ccs_evaluation_hash(ccs_evaluation_t evaluation, ccs_hash_t *hash_ret)
+_ccs_evaluation_hash(ccs_binding_t binding, ccs_hash_t *hash_ret)
 {
-	_ccs_evaluation_data_t *data = evaluation->data;
+	ccs_evaluation_t        evaluation = (ccs_evaluation_t)binding;
+	_ccs_evaluation_data_t *data       = evaluation->data;
 	ccs_hash_t              h, ht;
 	CCS_VALIDATE(_ccs_binding_hash((ccs_binding_t)evaluation, &h));
 	CCS_VALIDATE(_ccs_search_configuration_hash(data->configuration, &ht));
@@ -160,10 +161,12 @@ _ccs_evaluation_hash(ccs_evaluation_t evaluation, ccs_hash_t *hash_ret)
 
 static ccs_result_t
 _ccs_evaluation_cmp(
-	ccs_evaluation_t evaluation,
-	ccs_evaluation_t other,
-	int             *cmp_ret)
+	ccs_binding_t binding,
+	ccs_binding_t other_binding,
+	int          *cmp_ret)
 {
+	ccs_evaluation_t        evaluation = (ccs_evaluation_t)binding;
+	ccs_evaluation_t        other      = (ccs_evaluation_t)other_binding;
 	_ccs_evaluation_data_t *data       = evaluation->data;
 	_ccs_evaluation_data_t *other_data = other->data;
 	*cmp_ret = data->result < other_data->result ? -1 :

--- a/src/evaluation_internal.h
+++ b/src/evaluation_internal.h
@@ -9,12 +9,10 @@ typedef struct _ccs_evaluation_data_s _ccs_evaluation_data_t;
 struct _ccs_evaluation_ops_s {
 	_ccs_object_ops_t obj_ops;
 
-	ccs_result_t (*hash)(ccs_evaluation_t evaluation, ccs_hash_t *hash_ret);
+	ccs_result_t (*hash)(ccs_binding_t binding, ccs_hash_t *hash_ret);
 
-	ccs_result_t (*cmp)(
-		ccs_evaluation_t evaluation,
-		ccs_evaluation_t other,
-		int             *cmp_ret);
+	ccs_result_t (
+		*cmp)(ccs_binding_t binding, ccs_binding_t other, int *cmp_ret);
 
 	ccs_result_t (*compare)(
 		ccs_evaluation_t  evaluation,

--- a/src/features.c
+++ b/src/features.c
@@ -61,17 +61,16 @@ _ccs_features_serialize(
 }
 
 static ccs_result_t
-_ccs_features_hash(ccs_features_t features, ccs_hash_t *hash_ret)
+_ccs_features_hash(ccs_binding_t binding, ccs_hash_t *hash_ret)
 {
-	CCS_VALIDATE(_ccs_binding_hash((ccs_binding_t)features, hash_ret));
+	CCS_VALIDATE(_ccs_binding_hash(binding, hash_ret));
 	return CCS_RESULT_SUCCESS;
 }
 
 static ccs_result_t
-_ccs_features_cmp(ccs_features_t features, ccs_features_t other, int *cmp_ret)
+_ccs_features_cmp(ccs_binding_t binding, ccs_binding_t other, int *cmp_ret)
 {
-	CCS_VALIDATE(_ccs_binding_cmp(
-		(ccs_binding_t)features, (ccs_binding_t)other, cmp_ret));
+	CCS_VALIDATE(_ccs_binding_cmp(binding, other, cmp_ret));
 	return CCS_RESULT_SUCCESS;
 }
 

--- a/src/features_internal.h
+++ b/src/features_internal.h
@@ -8,12 +8,10 @@ typedef struct _ccs_features_data_s _ccs_features_data_t;
 struct _ccs_features_ops_s {
 	_ccs_object_ops_t obj_ops;
 
-	ccs_result_t (*hash)(ccs_features_t features, ccs_hash_t *hash_ret);
+	ccs_result_t (*hash)(ccs_binding_t binding, ccs_hash_t *hash_ret);
 
-	ccs_result_t (*cmp)(
-		ccs_features_t features,
-		ccs_features_t other,
-		int           *cmp_ret);
+	ccs_result_t (
+		*cmp)(ccs_binding_t binding, ccs_binding_t other, int *cmp_ret);
 };
 typedef struct _ccs_features_ops_s _ccs_features_ops_t;
 

--- a/src/search_configuration_internal.h
+++ b/src/search_configuration_internal.h
@@ -9,14 +9,10 @@ typedef struct _ccs_search_configuration_data_s _ccs_search_configuration_data_t
 struct _ccs_search_configuration_ops_s {
 	_ccs_object_ops_t obj_ops;
 
-	ccs_result_t (*hash)(
-		ccs_search_configuration_t configuration,
-		ccs_hash_t                *hash_ret);
+	ccs_result_t (*hash)(ccs_binding_t binding, ccs_hash_t *hash_ret);
 
-	ccs_result_t (*cmp)(
-		ccs_search_configuration_t configuration,
-		ccs_search_configuration_t other,
-		int                       *cmp_ret);
+	ccs_result_t (
+		*cmp)(ccs_binding_t binding, ccs_binding_t other, int *cmp_ret);
 };
 typedef struct _ccs_search_configuration_ops_s _ccs_search_configuration_ops_t;
 
@@ -36,7 +32,7 @@ _ccs_search_configuration_hash(
 {
 	_ccs_search_configuration_ops_t *ops =
 		(_ccs_search_configuration_ops_t *)configuration->obj.ops;
-	CCS_VALIDATE(ops->hash(configuration, hash_ret));
+	CCS_VALIDATE(ops->hash((ccs_binding_t)configuration, hash_ret));
 	return CCS_RESULT_SUCCESS;
 }
 
@@ -48,7 +44,8 @@ _ccs_search_configuration_cmp(
 {
 	_ccs_search_configuration_ops_t *ops =
 		(_ccs_search_configuration_ops_t *)configuration->obj.ops;
-	CCS_VALIDATE(ops->cmp(configuration, other, cmp_ret));
+	CCS_VALIDATE(ops->cmp(
+		(ccs_binding_t)configuration, (ccs_binding_t)other, cmp_ret));
 	return CCS_RESULT_SUCCESS;
 }
 

--- a/src/tree_configuration.c
+++ b/src/tree_configuration.c
@@ -155,15 +155,13 @@ _ccs_tree_configuration_serialize(
 }
 
 static ccs_result_t
-_ccs_tree_configuration_hash(
-	ccs_tree_configuration_t configuration,
-	ccs_hash_t              *hash_ret);
+_ccs_tree_configuration_hash(ccs_binding_t binding, ccs_hash_t *hash_ret);
 
 static ccs_result_t
 _ccs_tree_configuration_cmp(
-	ccs_tree_configuration_t configuration,
-	ccs_tree_configuration_t other_configuration,
-	int                     *cmp_ret);
+	ccs_binding_t binding,
+	ccs_binding_t other_binding,
+	int          *cmp_ret);
 
 static _ccs_tree_configuration_ops_t _tree_configuration_ops = {
 	{&_ccs_tree_configuration_del, &_ccs_tree_configuration_serialize_size,
@@ -226,8 +224,9 @@ ccs_create_tree_configuration(
 				tsdata->feature_space, &features),
 			errinit);
 	config->data->features = features;
-	memcpy(config->data->position, position,
-	       position_size * sizeof(size_t));
+	if (position_size)
+		memcpy(config->data->position, position,
+		       position_size * sizeof(size_t));
 	CCS_VALIDATE_ERR_GOTO(
 		err,
 		_ccs_tree_space_check_position(
@@ -328,10 +327,14 @@ ccs_tree_configuration_get_node(
 
 static ccs_result_t
 _ccs_tree_configuration_cmp(
-	ccs_tree_configuration_t configuration,
-	ccs_tree_configuration_t other_configuration,
-	int                     *cmp_ret)
+	ccs_binding_t binding,
+	ccs_binding_t other_binding,
+	int          *cmp_ret)
 {
+	ccs_tree_configuration_t configuration =
+		(ccs_tree_configuration_t)binding;
+	ccs_tree_configuration_t other_configuration =
+		(ccs_tree_configuration_t)other_binding;
 	if (configuration == other_configuration) {
 		*cmp_ret = 0;
 		return CCS_RESULT_SUCCESS;
@@ -367,16 +370,17 @@ ccs_tree_configuration_cmp(
 	CCS_CHECK_OBJ(other_configuration, CCS_OBJECT_TYPE_TREE_CONFIGURATION);
 	CCS_CHECK_PTR(cmp_ret);
 	CCS_VALIDATE(_ccs_tree_configuration_cmp(
-		configuration, other_configuration, cmp_ret));
+		(ccs_binding_t)configuration,
+		(ccs_binding_t)other_configuration, cmp_ret));
 	return CCS_RESULT_SUCCESS;
 }
 
 #include "datum_hash.h"
 static ccs_result_t
-_ccs_tree_configuration_hash(
-	ccs_tree_configuration_t configuration,
-	ccs_hash_t              *hash_ret)
+_ccs_tree_configuration_hash(ccs_binding_t binding, ccs_hash_t *hash_ret)
 {
+	ccs_tree_configuration_t configuration =
+		(ccs_tree_configuration_t)binding;
 	ccs_hash_t h, ht;
 	HASH_JEN(
 		&(configuration->data->tree_space),
@@ -400,6 +404,7 @@ ccs_tree_configuration_hash(
 {
 	CCS_CHECK_OBJ(configuration, CCS_OBJECT_TYPE_TREE_CONFIGURATION);
 	CCS_CHECK_PTR(hash_ret);
-	CCS_VALIDATE(_ccs_tree_configuration_hash(configuration, hash_ret));
+	CCS_VALIDATE(_ccs_tree_configuration_hash(
+		(ccs_binding_t)configuration, hash_ret));
 	return CCS_RESULT_SUCCESS;
 }

--- a/src/tree_configuration_internal.h
+++ b/src/tree_configuration_internal.h
@@ -7,14 +7,10 @@ typedef struct _ccs_tree_configuration_data_s _ccs_tree_configuration_data_t;
 struct _ccs_tree_configuration_ops_s {
 	_ccs_object_ops_t obj_ops;
 
-	ccs_result_t (*hash)(
-		ccs_tree_configuration_t configuration,
-		ccs_hash_t              *hash_ret);
+	ccs_result_t (*hash)(ccs_binding_t binding, ccs_hash_t *hash_ret);
 
-	ccs_result_t (*cmp)(
-		ccs_tree_configuration_t configuration,
-		ccs_tree_configuration_t other,
-		int                     *cmp_ret);
+	ccs_result_t (
+		*cmp)(ccs_binding_t binding, ccs_binding_t other, int *cmp_ret);
 };
 typedef struct _ccs_tree_configuration_ops_s _ccs_tree_configuration_ops_t;
 

--- a/tests/test_categorical_parameter.c
+++ b/tests/test_categorical_parameter.c
@@ -109,7 +109,7 @@ ccs_result_t
 deserialize_callback(
 	ccs_object_t object,
 	size_t       serialize_data_size,
-	void        *serialize_data,
+	const char  *serialize_data,
 	void        *callback_user_data)
 {
 	assert(callback_user_data == (void *)0xbeefdead);


### PR DESCRIPTION
## Summary

**UB fixes:**
- Fix function pointer type mismatches in the binding/search_configuration ops hierarchy. All hash/cmp function pointers now use `ccs_binding_t` as the common base type, and implementations cast to the concrete type internally. This eliminates UBSan errors from calling functions through incompatible pointer types.
- Fix null pointer passed to `memcpy` in `tree_configuration.c` when `position_size` is 0
- Fix `deserialize_callback` signature mismatch in `test_categorical_parameter.c` (`void*` vs `const char*`)

**CI: sanitizer builds (4 new jobs):**
- AddressSanitizer × thread-safe/no-thread-safe
- UndefinedBehaviorSanitizer × thread-safe/no-thread-safe
- All run on ubuntu-latest with clang, halt on error

## Test plan

- [x] All 30 C tests pass under UBSan with `halt_on_error=1` (zero UB errors)
- [x] All 30 C tests pass under ASan with `detect_leaks=1`
- [x] All 30 C tests pass with normal gcc --enable-strict build

🤖 Generated with [Claude Code](https://claude.com/claude-code)