### PR TITLE
Expose missing C API functions in Ruby and Python bindings

### DIFF
--- a/bindings/python/cconfigspace/distribution.py
+++ b/bindings/python/cconfigspace/distribution.py
@@ -1,6 +1,6 @@
 import ctypes as ct
 from . import libcconfigspace
-from .base import Object, Error, Result, ccs_int, ccs_float, ccs_bool, ccs_rng, ccs_distribution, NumericType, Numeric, CEnumeration, _ccs_get_function, ccs_false, ccs_true
+from .base import Object, Error, Result, ccs_int, ccs_float, ccs_bool, ccs_rng, ccs_distribution, ccs_parameter, NumericType, Numeric, Datum, CEnumeration, _ccs_get_function, ccs_false, ccs_true
 from .interval import Interval
 
 class DistributionType(CEnumeration):
@@ -23,6 +23,8 @@ ccs_distribution_get_bounds = _ccs_get_function("ccs_distribution_get_bounds", [
 ccs_distribution_check_oversampling = _ccs_get_function("ccs_distribution_check_oversampling", [ccs_distribution, ct.POINTER(Interval), ct.POINTER(ccs_bool)])
 ccs_distribution_sample = _ccs_get_function("ccs_distribution_sample", [ccs_distribution, ccs_rng, ct.POINTER(Numeric)])
 ccs_distribution_samples = _ccs_get_function("ccs_distribution_samples", [ccs_distribution, ccs_rng, ct.c_size_t, ct.POINTER(Numeric)])
+ccs_distribution_parameters_sample = _ccs_get_function("ccs_distribution_parameters_sample", [ccs_distribution, ccs_rng, ct.POINTER(ccs_parameter), ct.POINTER(Datum)])
+ccs_distribution_parameters_samples = _ccs_get_function("ccs_distribution_parameters_samples", [ccs_distribution, ccs_rng, ct.POINTER(ccs_parameter), ct.c_size_t, ct.POINTER(Datum)])
 
 class Distribution(Object):
 
@@ -127,6 +129,28 @@ class Distribution(Object):
       res = ccs_distribution_samples(self.handle, rng.handle, count, v)
       Error.check(res)
       return [ [v[j][i].i if self.data_types[i] == NumericType.INT else v[j][i].f for i in range(dim) ] for j in range(count) ]
+
+  def parameters_sample(self, parameters, rng = None):
+    if rng is None:
+      from .rng import ccs_default_rng
+      rng = ccs_default_rng
+    dim = self.dimension
+    p_params = (ccs_parameter * dim)(*[p.handle.value for p in parameters])
+    values = (Datum * dim)()
+    res = ccs_distribution_parameters_sample(self.handle, rng.handle, p_params, values)
+    Error.check(res)
+    return [x.value for x in values]
+
+  def parameters_samples(self, parameters, count, rng = None):
+    if rng is None:
+      from .rng import ccs_default_rng
+      rng = ccs_default_rng
+    dim = self.dimension
+    p_params = (ccs_parameter * dim)(*[p.handle.value for p in parameters])
+    values = (Datum * (count * dim))()
+    res = ccs_distribution_parameters_samples(self.handle, rng.handle, p_params, count, values)
+    Error.check(res)
+    return [[values[j * dim + i].value for i in range(dim)] for j in range(count)]
 
 ccs_create_uniform_int_distribution = _ccs_get_function("ccs_create_uniform_int_distribution", [ccs_int, ccs_int, ScaleType, ccs_int, ct.POINTER(ccs_distribution)])
 ccs_create_uniform_float_distribution = _ccs_get_function("ccs_create_uniform_float_distribution", [ccs_float, ccs_float, ScaleType, ccs_float, ct.POINTER(ccs_distribution)])

--- a/bindings/python/cconfigspace/interval.py
+++ b/bindings/python/cconfigspace/interval.py
@@ -111,6 +111,12 @@ class Interval(ct.Structure):
     Error.check(res)
     return v
 
+  def union(self, other):
+    v = Interval()
+    res = ccs_interval_union(ct.byref(self), ct.byref(other), ct.byref(v))
+    Error.check(res)
+    return v
+
   def __eq__(self, other):
     v = ccs_bool(0)
     res = ccs_interval_equal(ct.byref(self), ct.byref(other), ct.byref(v))
@@ -141,6 +147,7 @@ class Interval(ct.Structure):
 
 ccs_interval_empty = _ccs_get_function("ccs_interval_empty", [ct.POINTER(Interval), ct.POINTER(ccs_bool)])
 ccs_interval_intersect = _ccs_get_function("ccs_interval_intersect", [ct.POINTER(Interval), ct.POINTER(Interval), ct.POINTER(Interval)])
+ccs_interval_union = _ccs_get_function("ccs_interval_union", [ct.POINTER(Interval), ct.POINTER(Interval), ct.POINTER(Interval)])
 ccs_interval_equal = _ccs_get_function("ccs_interval_equal", [ct.POINTER(Interval), ct.POINTER(Interval), ct.POINTER(ccs_bool)])
 ccs_interval_include = _ccs_get_function("ccs_interval_include", [ct.POINTER(Interval), ccs_int], ccs_bool)
 

--- a/bindings/python/cconfigspace/map.py
+++ b/bindings/python/cconfigspace/map.py
@@ -10,6 +10,7 @@ ccs_map_del = _ccs_get_function("ccs_map_del", [ccs_map, DatumFix])
 ccs_map_get_keys = _ccs_get_function("ccs_map_get_keys", [ccs_map, ct.c_size_t, ct.POINTER(Datum), ct.POINTER(ct.c_size_t)])
 ccs_map_get_values = _ccs_get_function("ccs_map_get_values", [ccs_map, ct.c_size_t, ct.POINTER(Datum), ct.POINTER(ct.c_size_t)])
 ccs_map_get_pairs = _ccs_get_function("ccs_map_get_pairs", [ccs_map, ct.c_size_t, ct.POINTER(Datum), ct.POINTER(Datum), ct.POINTER(ct.c_size_t)])
+ccs_map_clear = _ccs_get_function("ccs_map_clear", [ccs_map])
 
 class Map(Object):
   def __init__(self, handle = None, retain = False, auto_release = True):
@@ -51,6 +52,10 @@ class Map(Object):
     pk = Datum(key)
     k = DatumFix(pk)
     res = ccs_map_del(self.handle, k)
+    Error.check(res)
+
+  def clear(self):
+    res = ccs_map_clear(self.handle)
     Error.check(res)
 
   def has_key(self, key):

--- a/bindings/python/cconfigspace/parameter.py
+++ b/bindings/python/cconfigspace/parameter.py
@@ -1,6 +1,6 @@
 import ctypes as ct
 from . import libcconfigspace
-from .base import Object, Error, Result, CEnumeration, _ccs_get_function, ccs_parameter, Datum, DatumFix, ccs_distribution, ccs_rng, ccs_float, ccs_int, DataType, ccs_bool, NumericType, Numeric, _ccs_get_id, ccs_false
+from .base import Object, Error, Result, CEnumeration, _ccs_get_function, ccs_parameter, Datum, DatumFix, ccs_distribution, ccs_rng, ccs_float, ccs_int, DataType, ccs_bool, NumericType, Numeric, _ccs_get_id, ccs_false, ccs_true
 from .interval import Interval
 from .rng import ccs_default_rng
 from .distribution import Distribution
@@ -162,7 +162,7 @@ class Parameter(Object):
       else:
         v[i].f = values[i]
     results = (Datum * sz)()
-    res = ccs_parameter_convert_samples(self.handle, 1 if oversampling else 0, sz, v, results)
+    res = ccs_parameter_convert_samples(self.handle, ccs_true if oversampling else ccs_false, sz, v, results)
     Error.check(res)
     return [x.value for x in results]
 

--- a/bindings/python/cconfigspace/parameter.py
+++ b/bindings/python/cconfigspace/parameter.py
@@ -1,6 +1,7 @@
 import ctypes as ct
 from . import libcconfigspace
-from .base import Object, Error, Result, CEnumeration, _ccs_get_function, ccs_parameter, Datum, DatumFix, ccs_distribution, ccs_rng, ccs_float, ccs_int, DataType, ccs_bool, NumericType, Numeric, _ccs_get_id
+from .base import Object, Error, Result, CEnumeration, _ccs_get_function, ccs_parameter, Datum, DatumFix, ccs_distribution, ccs_rng, ccs_float, ccs_int, DataType, ccs_bool, NumericType, Numeric, _ccs_get_id, ccs_false
+from .interval import Interval
 from .rng import ccs_default_rng
 from .distribution import Distribution
 
@@ -21,6 +22,10 @@ ccs_parameter_get_name = _ccs_get_function("ccs_parameter_get_name", [ccs_parame
 ccs_parameter_get_default_distribution = _ccs_get_function("ccs_parameter_get_default_distribution", [ccs_parameter, ct.POINTER(ccs_distribution)])
 ccs_parameter_check_value = _ccs_get_function("ccs_parameter_check_value", [ccs_parameter, DatumFix, ct.POINTER(ccs_bool)])
 ccs_parameter_check_values = _ccs_get_function("ccs_parameter_check_values", [ccs_parameter, ct.c_size_t, ct.POINTER(Datum), ct.POINTER(ccs_bool)])
+ccs_parameter_validate_value = _ccs_get_function("ccs_parameter_validate_value", [ccs_parameter, DatumFix, ct.POINTER(Datum), ct.POINTER(ccs_bool)])
+ccs_parameter_validate_values = _ccs_get_function("ccs_parameter_validate_values", [ccs_parameter, ct.c_size_t, ct.POINTER(Datum), ct.POINTER(Datum), ct.POINTER(ccs_bool)])
+ccs_parameter_sampling_interval = _ccs_get_function("ccs_parameter_sampling_interval", [ccs_parameter, ct.POINTER(Interval)])
+ccs_parameter_convert_samples = _ccs_get_function("ccs_parameter_convert_samples", [ccs_parameter, ccs_bool, ct.c_size_t, ct.POINTER(Numeric), ct.POINTER(Datum)])
 ccs_parameter_sample = _ccs_get_function("ccs_parameter_sample", [ccs_parameter, ccs_distribution, ccs_rng, ct.POINTER(Datum)])
 ccs_parameter_samples = _ccs_get_function("ccs_parameter_samples", [ccs_parameter, ccs_distribution, ccs_rng, ct.c_size_t, ct.POINTER(Datum)])
 
@@ -119,6 +124,47 @@ class Parameter(Object):
     res = ccs_parameter_check_values(self.handle, sz, v, b)
     Error.check(res)
     return [False if x == 0 else True for x in b]
+
+  def validate_value(self, value):
+    pv = Datum(value)
+    v = DatumFix(pv)
+    vo = Datum()
+    b = ccs_bool()
+    res = ccs_parameter_validate_value(self.handle, v, ct.byref(vo), ct.byref(b))
+    Error.check(res)
+    return (vo.value, False if b.value == ccs_false else True)
+
+  def validate_values(self, values):
+    sz = len(values)
+    v = (Datum * sz)()
+    ss = []
+    for i in range(sz):
+      v[i].set_value(values[i], string_store = ss)
+    vo = (Datum * sz)()
+    b = (ccs_bool * sz)()
+    res = ccs_parameter_validate_values(self.handle, sz, v, vo, b)
+    Error.check(res)
+    return [(vo[i].value, False if b[i] == ccs_false else True) for i in range(sz)]
+
+  @property
+  def sampling_interval(self):
+    v = Interval()
+    res = ccs_parameter_sampling_interval(self.handle, ct.byref(v))
+    Error.check(res)
+    return v
+
+  def convert_samples(self, values, oversampling = False):
+    sz = len(values)
+    v = (Numeric * sz)()
+    for i in range(sz):
+      if isinstance(values[i], int):
+        v[i].i = values[i]
+      else:
+        v[i].f = values[i]
+    results = (Datum * sz)()
+    res = ccs_parameter_convert_samples(self.handle, 1 if oversampling else 0, sz, v, results)
+    Error.check(res)
+    return [x.value for x in results]
 
   def sample(self, distribution = None, rng = None):
     if distribution is None:

--- a/bindings/python/test/test_configuration_space.py
+++ b/bindings/python/test/test_configuration_space.py
@@ -337,6 +337,14 @@ class TestConfigurationSpace(unittest.TestCase):
     v = cs.validate_value(h1.name, 0.5)
     self.assertEqual( 0.5, v )
 
+  def test_map_clear(self):
+    m = ccs.Map()
+    m["foo"] = "bar"
+    m["baz"] = 42
+    self.assertEqual( 2, len(m) )
+    m.clear()
+    self.assertEqual( 0, len(m) )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/bindings/python/test/test_distribution.py
+++ b/bindings/python/test/test_distribution.py
@@ -326,5 +326,22 @@ class TestDistribution(unittest.TestCase):
   def test_serialize_multivariate_json(self):
     self._test_serialize_multivariate('json')
 
+  def test_parameters_sample(self):
+    h = ccs.NumericalParameter.Float(lower = -1.0, upper = 1.0)
+    d = ccs.UniformDistribution.Float(lower = -1.0, upper = 1.0)
+    vals = d.parameters_sample([h])
+    self.assertEqual( 1, len(vals) )
+    self.assertIsInstance( vals[0], float )
+
+  def test_parameters_samples(self):
+    h = ccs.NumericalParameter.Float(lower = -1.0, upper = 1.0)
+    d = ccs.UniformDistribution.Float(lower = -1.0, upper = 1.0)
+    vals = d.parameters_samples([h], 10)
+    self.assertEqual( 10, len(vals) )
+    for v in vals:
+      self.assertEqual( 1, len(v) )
+      self.assertIsInstance( v[0], float )
+    self.assertEqual( [], d.parameters_samples([h], 0) )
+
 if __name__ == '__main__':
     unittest.main()

--- a/bindings/python/test/test_interval.py
+++ b/bindings/python/test/test_interval.py
@@ -48,5 +48,12 @@ class TestInterval(unittest.TestCase):
     self.assertTrue( i.contains(0) )
     self.assertFalse( i.contains(6) )
 
+  def test_union(self):
+    i1 = ccs.Interval(t = ccs.NumericType.FLOAT, lower = -1.0, upper = 0.5)
+    i2 = ccs.Interval(t = ccs.NumericType.FLOAT, lower = 0.0, upper = 2.0)
+    i3 = i1.union(i2)
+    i4 = ccs.Interval(t = ccs.NumericType.FLOAT, lower = -1.0, upper = 2.0)
+    self.assertEqual( i4, i3 )
+
 if __name__ == '__main__':
     unittest.main()

--- a/bindings/python/test/test_parameter.py
+++ b/bindings/python/test/test_parameter.py
@@ -331,5 +331,36 @@ class TestParameter(unittest.TestCase):
     self.assertEqual( [True, True, False, True], results )
     self.assertEqual( [], h.check_values([]) )
 
+  def test_validate_value(self):
+    h = ccs.NumericalParameter.Float(lower = -1.0, upper = 1.0)
+    val, valid = h.validate_value(0.5)
+    self.assertEqual( 0.5, val )
+    self.assertTrue( valid )
+    val, valid = h.validate_value(5.0)
+    self.assertFalse( valid )
+
+  def test_validate_values(self):
+    values = ["foo", 2, 3.0]
+    h = ccs.CategoricalParameter(values = values)
+    results = h.validate_values(["foo", 1.5, 3.0])
+    self.assertTrue( results[0][1] )
+    self.assertEqual( "foo", results[0][0] )
+    self.assertFalse( results[1][1] )
+    self.assertTrue( results[2][1] )
+
+  def test_sampling_interval(self):
+    h = ccs.NumericalParameter.Float(lower = -1.0, upper = 1.0)
+    interval = h.sampling_interval
+    self.assertIsInstance( interval, ccs.Interval )
+    self.assertTrue( interval.include(0.0) )
+    self.assertFalse( interval.include(5.0) )
+
+  def test_convert_samples(self):
+    h = ccs.NumericalParameter.Float(lower = -1.0, upper = 1.0)
+    results = h.convert_samples([0.0, 0.5])
+    self.assertEqual( 2, len(results) )
+    for v in results:
+      self.assertIsInstance( v, float )
+
 if __name__ == '__main__':
     unittest.main()

--- a/bindings/ruby/lib/cconfigspace/distribution.rb
+++ b/bindings/ruby/lib/cconfigspace/distribution.rb
@@ -30,6 +30,8 @@ module CCS
   attach_function :ccs_distribution_check_oversampling, [:ccs_distribution_t, Interval.by_ref, :pointer], :ccs_result_t
   attach_function :ccs_distribution_sample, [:ccs_distribution_t, :ccs_rng_t, :pointer], :ccs_result_t
   attach_function :ccs_distribution_samples, [:ccs_distribution_t, :ccs_rng_t, :size_t, :pointer], :ccs_result_t
+  attach_function :ccs_distribution_parameters_sample, [:ccs_distribution_t, :ccs_rng_t, :pointer, :pointer], :ccs_result_t
+  attach_function :ccs_distribution_parameters_samples, [:ccs_distribution_t, :ccs_rng_t, :pointer, :size_t, :pointer], :ccs_result_t
 
   class Distribution < Object
     add_property :type, :ccs_distribution_type_t, :ccs_distribution_get_type, memoize: true
@@ -120,6 +122,27 @@ module CCS
           }
         }
       end
+    end
+
+    def parameters_sample(parameters, rng: CCS::DefaultRng)
+      dim = dimension
+      p_params = MemoryPointer::new(:ccs_parameter_t, dim)
+      p_params.write_array_of_pointer(parameters.collect(&:handle))
+      values = MemoryPointer::new(:ccs_datum_t, dim)
+      CCS.error_check CCS.ccs_distribution_parameters_sample(@handle, rng, p_params, values)
+      dim.times.collect { |i| Datum::new(values[i]).value }
+    end
+
+    def parameters_samples(parameters, count, rng: CCS::DefaultRng)
+      return [] if count == 0
+      dim = dimension
+      p_params = MemoryPointer::new(:ccs_parameter_t, dim)
+      p_params.write_array_of_pointer(parameters.collect(&:handle))
+      values = MemoryPointer::new(:ccs_datum_t, count * dim)
+      CCS.error_check CCS.ccs_distribution_parameters_samples(@handle, rng, p_params, count, values)
+      count.times.collect { |j|
+        dim.times.collect { |i| Datum::new(values[j * dim + i]).value }
+      }
     end
 
   end

--- a/bindings/ruby/lib/cconfigspace/interval.rb
+++ b/bindings/ruby/lib/cconfigspace/interval.rb
@@ -101,9 +101,15 @@ module CCS
     end
 
     def intersect(other)
-      intersection = Interval::new(type: :CCS_NUMERIC_TYPE_FLOAT)
-      CCS.error_check CCS.ccs_interval_intersect(self, other, intersection)
-      return intersection
+      result = Interval::new(type: self[:type])
+      CCS.error_check CCS.ccs_interval_intersect(self, other, result)
+      return result
+    end
+
+    def union(other)
+      result = Interval::new(type: self[:type])
+      CCS.error_check CCS.ccs_interval_union(self, other, result)
+      return result
     end
 
     def ==(other)
@@ -137,6 +143,7 @@ module CCS
 
   attach_function :ccs_interval_empty, [Interval.by_ref, :pointer], :ccs_result_t
   attach_function :ccs_interval_intersect, [Interval.by_ref, Interval.by_ref, Interval.by_ref], :ccs_result_t
+  attach_function :ccs_interval_union, [Interval.by_ref, Interval.by_ref, Interval.by_ref], :ccs_result_t
   attach_function :ccs_interval_equal, [Interval.by_ref, Interval.by_ref, :pointer], :ccs_result_t
   attach_function :ccs_interval_include, [Interval.by_ref, :ccs_numeric_t], :ccs_bool_t
 

--- a/bindings/ruby/lib/cconfigspace/interval.rb
+++ b/bindings/ruby/lib/cconfigspace/interval.rb
@@ -6,25 +6,18 @@ module CCS
            :lower_included, :ccs_bool_t,
            :upper_included, :ccs_bool_t
 
-    def initialize(*args, type:, lower: nil, upper: nil, lower_included: true, upper_included: false)
+    def initialize(*args, type: :CCS_NUMERIC_TYPE_FLOAT, lower: 0.0, upper: 1.0, lower_included: true, upper_included: false)
       unless [:CCS_NUMERIC_TYPE_FLOAT, :CCS_NUMERIC_TYPE_INT].include?(type)
         raise CCSError, :CCS_RESULT_ERROR_INVALID_TYPE
       end
       super(*args)
       self[:type] = type
-      if lower
-        if type == :CCS_NUMERIC_TYPE_FLOAT
-          self[:lower][:f] = lower
-        else
-          self[:lower][:i] = lower
-        end
-      end
-      if upper
-        if type == :CCS_NUMERIC_TYPE_FLOAT
-          self[:upper][:f] = upper
-        else
-          self[:upper][:i] = upper
-        end
+      if type == :CCS_NUMERIC_TYPE_FLOAT
+        self[:lower][:f] = lower
+        self[:upper][:f] = upper
+      else
+        self[:lower][:i] = lower
+        self[:upper][:i] = upper
       end
       self[:lower_included] = lower_included ? CCS::TRUE : CCS::FALSE
       self[:upper_included] = upper_included ? CCS::TRUE : CCS::FALSE

--- a/bindings/ruby/lib/cconfigspace/map.rb
+++ b/bindings/ruby/lib/cconfigspace/map.rb
@@ -7,6 +7,7 @@ module CCS
   attach_function :ccs_map_get_keys, [:ccs_map_t, :size_t, :pointer, :pointer], :ccs_result_t
   attach_function :ccs_map_get_values, [:ccs_map_t, :size_t, :pointer, :pointer], :ccs_result_t
   attach_function :ccs_map_get_pairs, [:ccs_map_t, :size_t, :pointer, :pointer, :pointer], :ccs_result_t
+  attach_function :ccs_map_clear, [:ccs_map_t], :ccs_result_t
 
   class Map < Object
     add_array_property :keys, :ccs_datum_t, :ccs_map_get_keys
@@ -40,6 +41,11 @@ module CCS
       v = Datum.from_value(value)
       CCS.error_check CCS.ccs_map_set(@handle, k, v)
       value
+    end
+
+    def clear
+      CCS.error_check CCS.ccs_map_clear(@handle)
+      self
     end
 
     def include?(key)

--- a/bindings/ruby/lib/cconfigspace/parameter.rb
+++ b/bindings/ruby/lib/cconfigspace/parameter.rb
@@ -121,7 +121,7 @@ module CCS
     end
 
     def sampling_interval
-      interval = Interval::new(type: :CCS_NUMERIC_TYPE_FLOAT)
+      interval = Interval::new
       CCS.error_check CCS.ccs_parameter_sampling_interval(@handle, interval)
       interval
     end

--- a/bindings/ruby/lib/cconfigspace/parameter.rb
+++ b/bindings/ruby/lib/cconfigspace/parameter.rb
@@ -29,6 +29,8 @@ module CCS
   attach_function :ccs_parameter_check_values, [:ccs_parameter_t, :size_t, :pointer, :pointer], :ccs_result_t
   attach_function :ccs_parameter_validate_value, [:ccs_parameter_t, :ccs_datum_t, :pointer, :pointer], :ccs_result_t
   attach_function :ccs_parameter_validate_values, [:ccs_parameter_t, :size_t, :pointer, :pointer, :pointer], :ccs_result_t
+  attach_function :ccs_parameter_sampling_interval, [:ccs_parameter_t, Interval.by_ref], :ccs_result_t
+  attach_function :ccs_parameter_convert_samples, [:ccs_parameter_t, :ccs_bool_t, :size_t, :pointer, :pointer], :ccs_result_t
   attach_function :ccs_parameter_sample, [:ccs_parameter_t, :ccs_distribution_t, :ccs_rng_t, :pointer], :ccs_result_t
   attach_function :ccs_parameter_samples, [:ccs_parameter_t, :ccs_distribution_t, :ccs_rng_t, :size_t, :pointer], :ccs_result_t
 
@@ -93,6 +95,53 @@ module CCS
       ptr = MemoryPointer::new(:ccs_bool_t, count)
       CCS.error_check CCS.ccs_parameter_check_values(@handle, count, values, ptr)
       count.times.collect { |i| Pointer.new(:ccs_bool_t, ptr[i]).read_ccs_bool_t == CCS::FALSE ? false : true }
+    end
+
+    def validate_value(v)
+      value_ret = MemoryPointer::new(:ccs_datum_t)
+      result_ret = MemoryPointer::new(:ccs_bool_t)
+      CCS.error_check CCS.ccs_parameter_validate_value(@handle, Datum::from_value(v), value_ret, result_ret)
+      valid = result_ret.read_ccs_bool_t == CCS::FALSE ? false : true
+      [Datum::new(value_ret).value, valid]
+    end
+
+    def validate_values(vals)
+      count = vals.size
+      return [] if count == 0
+      ss = []
+      values = MemoryPointer::new(:ccs_datum_t, count)
+      vals.each_with_index { |v, i| Datum::new(values[i]).set_value(v, string_store: ss) }
+      values_ret = MemoryPointer::new(:ccs_datum_t, count)
+      results = MemoryPointer::new(:ccs_bool_t, count)
+      CCS.error_check CCS.ccs_parameter_validate_values(@handle, count, values, values_ret, results)
+      count.times.collect { |i|
+        valid = Pointer.new(:ccs_bool_t, results[i]).read_ccs_bool_t == CCS::FALSE ? false : true
+        [Datum::new(values_ret[i]).value, valid]
+      }
+    end
+
+    def sampling_interval
+      interval = Interval::new(type: :CCS_NUMERIC_TYPE_FLOAT)
+      CCS.error_check CCS.ccs_parameter_sampling_interval(@handle, interval)
+      interval
+    end
+
+    def convert_samples(vals, oversampling: false)
+      count = vals.size
+      return [] if count == 0
+      values = MemoryPointer::new(:ccs_numeric_t, count)
+      vals.each_with_index { |v, i|
+        n = Numeric::new(values[i])
+        case v
+        when Integer
+          n[:i] = v
+        when Float
+          n[:f] = v
+        end
+      }
+      results = MemoryPointer::new(:ccs_datum_t, count)
+      CCS.error_check CCS.ccs_parameter_convert_samples(@handle, oversampling ? CCS::TRUE : CCS::FALSE, count, values, results)
+      count.times.collect { |i| Datum::new(results[i]).value }
     end
 
     def sample(distribution: default_distribution, rng: CCS::DefaultRng)

--- a/bindings/ruby/test/test_configuration_space.rb
+++ b/bindings/ruby/test/test_configuration_space.rb
@@ -364,4 +364,13 @@ class CConfigSpaceTestConfigurationSpace < Minitest::Test
     v = cs.validate_value(h1.name, 0.5)
     assert_equal( 0.5, v )
   end
+
+  def test_map_clear
+    m = CCS::Map::new
+    m["foo"] = "bar"
+    m["baz"] = 42
+    assert_equal( 2, m.size )
+    m.clear
+    assert_equal( 0, m.size )
+  end
 end

--- a/bindings/ruby/test/test_distribution.rb
+++ b/bindings/ruby/test/test_distribution.rb
@@ -316,4 +316,24 @@ class CConfigSpaceTestDistribution < Minitest::Test
     assert( d2.data_types == [:CCS_NUMERIC_TYPE_FLOAT, :CCS_NUMERIC_TYPE_INT] )
     assert( d2.weights == [0.5, 0.5] )
   end
+
+  def test_parameters_sample
+    h = CCS::NumericalParameter::Float.new(lower: -1.0, upper: 1.0)
+    d = CCS::UniformDistribution::Float.new(lower: -1.0, upper: 1.0)
+    vals = d.parameters_sample([h])
+    assert_equal( 1, vals.length )
+    assert_kind_of( Float, vals[0] )
+  end
+
+  def test_parameters_samples
+    h = CCS::NumericalParameter::Float.new(lower: -1.0, upper: 1.0)
+    d = CCS::UniformDistribution::Float.new(lower: -1.0, upper: 1.0)
+    vals = d.parameters_samples([h], 10)
+    assert_equal( 10, vals.length )
+    vals.each { |v|
+      assert_equal( 1, v.length )
+      assert_kind_of( Float, v[0] )
+    }
+    assert_equal( [], d.parameters_samples([h], 0) )
+  end
 end

--- a/bindings/ruby/test/test_interval.rb
+++ b/bindings/ruby/test/test_interval.rb
@@ -47,4 +47,12 @@ class CConfigSpaceTestInterval < Minitest::Test
     refute( i.include?(6) )
   end
 
+  def test_union
+    i1 = CCS::Interval::new(type: :CCS_NUMERIC_TYPE_FLOAT, lower: -1.0, upper: 0.5)
+    i2 = CCS::Interval::new(type: :CCS_NUMERIC_TYPE_FLOAT, lower: 0.0, upper: 2.0)
+    i3 = i1.union(i2)
+    i4 = CCS::Interval::new(type: :CCS_NUMERIC_TYPE_FLOAT, lower: -1.0, upper: 2.0)
+    assert_equal(i4, i3)
+  end
+
 end

--- a/bindings/ruby/test/test_parameter.rb
+++ b/bindings/ruby/test/test_parameter.rb
@@ -321,4 +321,38 @@ class CConfigSpaceTestParameter < Minitest::Test
     assert_equal( [], h.check_values([]) )
   end
 
+  def test_validate_value
+    h = CCS::NumericalParameter::Float.new(lower: -1.0, upper: 1.0)
+    val, valid = h.validate_value(0.5)
+    assert_equal( 0.5, val )
+    assert( valid )
+    val, valid = h.validate_value(5.0)
+    refute( valid )
+  end
+
+  def test_validate_values
+    values = ["foo", 2, 3.0]
+    h = CCS::CategoricalParameter::new(values: values)
+    results = h.validate_values(["foo", 1.5, 3.0])
+    assert_equal( true, results[0][1] )
+    assert_equal( "foo", results[0][0] )
+    assert_equal( false, results[1][1] )
+    assert_equal( true, results[2][1] )
+  end
+
+  def test_sampling_interval
+    h = CCS::NumericalParameter::Float.new(lower: -1.0, upper: 1.0)
+    interval = h.sampling_interval
+    assert_instance_of( CCS::Interval, interval )
+    assert( interval.include?(0.0) )
+    refute( interval.include?(5.0) )
+  end
+
+  def test_convert_samples
+    h = CCS::NumericalParameter::Float.new(lower: -1.0, upper: 1.0)
+    results = h.convert_samples([0.0, 0.5])
+    assert_equal( 2, results.length )
+    results.each { |v| assert_kind_of( Float, v ) }
+  end
+
 end


### PR DESCRIPTION
## Summary

Add wrappers and tests for C API functions that were missing from both bindings:

| Function | Ruby | Python |
|----------|------|--------|
| `ccs_map_clear` | `Map#clear` | `Map.clear()` |
| `ccs_interval_union` | `Interval#union` | `Interval.union()` |
| `ccs_parameter_validate_value` | `Parameter#validate_value` | `Parameter.validate_value()` |
| `ccs_parameter_validate_values` | `Parameter#validate_values` | `Parameter.validate_values()` |
| `ccs_parameter_sampling_interval` | `Parameter#sampling_interval` | `Parameter.sampling_interval` |
| `ccs_parameter_convert_samples` | `Parameter#convert_samples` | `Parameter.convert_samples()` |
| `ccs_distribution_parameters_sample` | `Distribution#parameters_sample` | `Distribution.parameters_sample()` |
| `ccs_distribution_parameters_samples` | `Distribution#parameters_samples` | `Distribution.parameters_samples()` |

## Test plan
- [x] Ruby: 140 tests, 0 failures (was 132)
- [x] Python: 134 tests, 0 failures (was 126)

🤖 Generated with [Claude Code](https://claude.com/claude-code)